### PR TITLE
Quest history page & additional fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "admin-test": "cd services/admin && yarn test",
     "api": "cd services/api && yarn start",
     "api-test": "cd services/api && yarn test",
+    "api-watch-test": "cd services/api && yarn watch-test",
     "app": "cd services/app && yarn start",
     "app-deploy": "cd services/app && ./beta.sh",
     "app-local": "API_HOST='http://localhost:8081' npm run app & npm run api",
     "app-test": "cd services/app && yarn test",
+    "app-watch-test": "cd services/app && yarn watch-test",
     "cards": "cd services/cards && yarn start",
     "cards-deploy": "cd services/cards && ./beta.sh",
     "cards-test": "cd services/cards && yarn test",
@@ -154,6 +156,7 @@
     "@types/expect": "^1.20.2",
     "@types/express": "^4.0.36",
     "@types/express-session": "^1.15.0",
+    "@types/fetch-mock": "^6.0.3",
     "@types/jasmine": "^2.5.45",
     "@types/joi": "^13.0.0",
     "@types/jquery": "^3.0.0",
@@ -192,6 +195,7 @@
     "cordova-plugin-vibration": "^3.0.0",
     "cordova-plugin-whitelist": "^1.3.3",
     "cordova-plugin-x-socialsharing": "^5.4.0",
+    "fetch-mock": "^6.5.0",
     "tslint-loader": "^3.6.0"
   },
   "optionalDependencies": {

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.0",
   "scripts": {
     "test": "jest --runInBand --config jestconfig.json",
+    "watch-test": "jest --watchAll --runInBand --config jestconfig.json",
     "build": "webpack --config webpack.dist.config.js --progress",
     "start": "npm run build && node dist/server.js"
   },

--- a/services/api/src/Handlers.test.ts
+++ b/services/api/src/Handlers.test.ts
@@ -253,7 +253,10 @@ describe('handlers', () => {
     it('gets quest played by user', (done: DoneFn) => {
       const res = mockRes();
       res.locals.id = ae.questEnd.userID;
-      testingDBWithState([ae.questEnd])
+      testingDBWithState([
+        ae.questEnd,
+        q.basic,
+      ])
         .then((db) => userQuests(db, mockReq({}), res))
         .then(() => {
           expect(res.status.calledWith(200)).toEqual(true);

--- a/services/api/src/Handlers.ts
+++ b/services/api/src/Handlers.ts
@@ -303,7 +303,7 @@ export function feedback(db: Database, mail: MailService, req: express.Request, 
 export function userQuests(db: Database, req: express.Request, res: express.Response) {
   return getUserQuests(db, res.locals.id)
   .then((userQuests: UserQuestsType) => {
-    for (let k of Object.keys(userQuests)) {
+    for (const k of Object.keys(userQuests)) {
       proxifyQuestURL(userQuests[k].details);
     }
     return res.status(200).end(JSON.stringify(userQuests));

--- a/services/api/src/models/TestData.ts
+++ b/services/api/src/models/TestData.ts
@@ -167,7 +167,7 @@ export const events = {
 export function testingDBWithState(state: SchemaBase[]): Promise<Database> {
   const db = new Database(new Sequelize({
     dialect: 'sqlite',
-    logging: false,
+    logging: true,
     storage: ':memory:',
   }));
 

--- a/services/api/src/models/TestData.ts
+++ b/services/api/src/models/TestData.ts
@@ -167,7 +167,7 @@ export const events = {
 export function testingDBWithState(state: SchemaBase[]): Promise<Database> {
   const db = new Database(new Sequelize({
     dialect: 'sqlite',
-    logging: true,
+    logging: false,
     storage: ':memory:',
   }));
 

--- a/services/api/src/models/Users.test.ts
+++ b/services/api/src/models/Users.test.ts
@@ -1,9 +1,9 @@
 import {AnalyticsEvent} from 'shared/schema/AnalyticsEvents';
 import {Database} from './Database';
 import {analyticsEvents as ae,
+  quests as q,
   testingDBWithState,
-  users as u,
-  quests as q
+  users as u
 } from './TestData';
 import {
   getUser,

--- a/services/api/src/models/Users.test.ts
+++ b/services/api/src/models/Users.test.ts
@@ -2,7 +2,8 @@ import {AnalyticsEvent} from 'shared/schema/AnalyticsEvents';
 import {Database} from './Database';
 import {analyticsEvents as ae,
   testingDBWithState,
-  users as u
+  users as u,
+  quests as q
 } from './TestData';
 import {
   getUser,
@@ -73,9 +74,10 @@ describe('users', () => {
       .catch(done.fail);
     });
 
-    it('returns valid results for players with quest history', (done: DoneFn) => {
+    fit('returns valid results for players with quest history', (done: DoneFn) => {
       testingDBWithState([
         u.basic,
+        q.basic,
         new AnalyticsEvent({...ae.questEnd, userID: u.basic.id}),
       ])
       .then((tdb) => {
@@ -85,6 +87,7 @@ describe('users', () => {
         expect(Object.keys(quests).length).toEqual(1);
         const result = quests[ae.questEnd.questID];
         expect(result.lastPlayed).toEqual(ae.questEnd.created);
+        expect(result.details.title).toEqual(q.basic.title);
         done();
       }).catch(done.fail);
     });

--- a/services/api/src/models/Users.test.ts
+++ b/services/api/src/models/Users.test.ts
@@ -74,7 +74,7 @@ describe('users', () => {
       .catch(done.fail);
     });
 
-    fit('returns valid results for players with quest history', (done: DoneFn) => {
+    it('returns valid results for players with quest history', (done: DoneFn) => {
       testingDBWithState([
         u.basic,
         q.basic,

--- a/services/api/src/models/Users.ts
+++ b/services/api/src/models/Users.ts
@@ -1,8 +1,8 @@
 import * as Bluebird from 'bluebird';
 import Sequelize from 'sequelize';
 import {PUBLIC_PARTITION} from 'shared/schema/Constants';
-import {User} from 'shared/schema/Users';
 import {Quest} from 'shared/schema/Quests';
+import {User} from 'shared/schema/Users';
 import Config from '../config';
 import {Database, QuestInstance} from './Database';
 
@@ -61,7 +61,7 @@ export function getUserQuests(db: Database, id: string): Bluebird<UserQuestsType
       };
     });
 
-    const metas: Bluebird<void>[] = [];
+    const metas: Array<Bluebird<void>> = [];
     for (const k of Object.keys(userQuests)) {
       metas.push(db.quests.findOne({
         where: {partition: PUBLIC_PARTITION, id: k},

--- a/services/api/webpack.dist.config.js
+++ b/services/api/webpack.dist.config.js
@@ -33,7 +33,7 @@ const options = {
   },
   module: {
     rules: [
-      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader' },
+      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader', options: {fix: true} },
       { test: /\.json$/, loader: 'json-loader' },
       { test: /\.ts(x?)$/, loaders: ['awesome-typescript-loader'], exclude: [/\/node_modules\/.*/, /\/dist\/.*/] },
     ]

--- a/services/app/package.json
+++ b/services/app/package.json
@@ -5,6 +5,7 @@
   "homepage": "http://app.expeditiongame.com",
   "scripts": {
     "test": "karma start --single-run --browsers NoSandboxChromeHeadless",
+    "watch-test": "karma start --browsers NoSandboxChromeHeadless",
     "start": "webpack-dev-server --progress",
     "build": "webpack --config ./webpack.dist.config.js --progress",
     "build-all": "npm run build && cordova build android && cordova build ios"

--- a/services/app/src/actions/ActionTypes.tsx
+++ b/services/app/src/actions/ActionTypes.tsx
@@ -14,6 +14,7 @@ import {
   SavedQuestMeta,
   SearchSettings,
   SettingsType,
+  UserQuestInstance,
   UserQuestsType,
   UserState,
 } from '../reducers/StateTypes';
@@ -129,6 +130,11 @@ export interface UserLogoutAction extends Redux.Action {
 export interface UserQuestsAction extends Redux.Action {
   type: 'USER_QUESTS';
   quests: UserQuestsType;
+}
+
+export interface UserQuestInstanceSelect extends Redux.Action {
+  type: 'USER_QUEST_INSTANCE_SELECT';
+  selected: UserQuestInstance;
 }
 
 export interface UserQuestsDeltaAction extends Redux.Action {

--- a/services/app/src/actions/Card.test.tsx
+++ b/services/app/src/actions/Card.test.tsx
@@ -1,11 +1,11 @@
 import * as fetchMock from 'fetch-mock';
-import {toCard, toPrevious} from './Card';
-import {setNavigator} from '../Globals';
-import {Action} from '../Testing';
 import {AUTH_SETTINGS} from '../Constants';
+import {setNavigator} from '../Globals';
 import {initialQuestState} from '../reducers/Quest';
 import {initialSettings} from '../reducers/Settings';
 import {loggedOutUser} from '../reducers/User';
+import {Action} from '../Testing';
+import {toCard, toPrevious} from './Card';
 
 describe('Card action', () => {
   describe('toCard', () => {

--- a/services/app/src/actions/Card.test.tsx
+++ b/services/app/src/actions/Card.test.tsx
@@ -1,9 +1,4 @@
-import * as fetchMock from 'fetch-mock';
-import {AUTH_SETTINGS} from '../Constants';
 import {setNavigator} from '../Globals';
-import {initialQuestState} from '../reducers/Quest';
-import {initialSettings} from '../reducers/Settings';
-import {loggedOutUser} from '../reducers/User';
 import {Action} from '../Testing';
 import {toCard, toPrevious} from './Card';
 
@@ -11,10 +6,6 @@ describe('Card action', () => {
   describe('toCard', () => {
     const navigator = {vibrate: () => { /* mock */ }};
     setNavigator(navigator);
-
-    afterEach(() => {
-      fetchMock.restore();
-    });
 
     it('causes vibration if vibration enabled', () => {
       spyOn(navigator, 'vibrate');
@@ -30,17 +21,6 @@ describe('Card action', () => {
 
     it('dispatches a NAVIGATE action', () => {
       Action(toCard).expect({name: 'QUEST_CARD'}).toDispatch(jasmine.objectContaining({type: 'NAVIGATE'}));
-    });
-
-    it('Logs the end of the quest to analytics', () => {
-      const matcher = AUTH_SETTINGS.URL_BASE + '/analytics/quest/end';
-      fetchMock.post(matcher, {});
-      Action(toCard, {
-        user: loggedOutUser,
-        settings: initialSettings,
-        quest: {details: initialQuestState},
-      }).execute({name: 'QUEST_END'});
-      expect(fetchMock.called(matcher)).toEqual(true);
     });
   });
 

--- a/services/app/src/actions/Card.tsx
+++ b/services/app/src/actions/Card.tsx
@@ -3,8 +3,8 @@ import {VIBRATION_LONG_MS, VIBRATION_SHORT_MS} from '../Constants';
 import {getNavigator} from '../Globals';
 import {AppStateWithHistory, CardName, CardPhase} from '../reducers/StateTypes';
 import {getStore} from '../Store';
-import {logQuestPlay} from './Web';
 import {NavigateAction, remoteify} from './ActionTypes';
+import {logQuestPlay} from './Web';
 
 interface ToCardArgs {
   keySuffix?: string;

--- a/services/app/src/actions/Card.tsx
+++ b/services/app/src/actions/Card.tsx
@@ -4,7 +4,6 @@ import {getNavigator} from '../Globals';
 import {AppStateWithHistory, CardName, CardPhase} from '../reducers/StateTypes';
 import {getStore} from '../Store';
 import {NavigateAction, remoteify} from './ActionTypes';
-import {logQuestPlay} from './Web';
 
 interface ToCardArgs {
   keySuffix?: string;
@@ -39,12 +38,6 @@ export const toCard = remoteify(function toCard(a: ToCardArgs, dispatch: Redux.D
   }
   if (a.keySuffix) {
     keylist.push(a.keySuffix);
-  }
-
-  // Log the end of the quest if we reach it.
-  if (a.name === 'QUEST_END') {
-    console.log('Dispatching logQuestPlay');
-    dispatch(logQuestPlay({phase: 'end'}));
   }
 
   dispatch({type: 'NAVIGATE', to: {...a, ts: Date.now(), key: keylist.join('|'), questId}, dontUpdateUrl: state.settings && state.settings.simulator} as NavigateAction);

--- a/services/app/src/actions/Card.tsx
+++ b/services/app/src/actions/Card.tsx
@@ -3,6 +3,7 @@ import {VIBRATION_LONG_MS, VIBRATION_SHORT_MS} from '../Constants';
 import {getNavigator} from '../Globals';
 import {AppStateWithHistory, CardName, CardPhase} from '../reducers/StateTypes';
 import {getStore} from '../Store';
+import {logQuestPlay} from './Web';
 import {NavigateAction, remoteify} from './ActionTypes';
 
 interface ToCardArgs {
@@ -38,6 +39,12 @@ export const toCard = remoteify(function toCard(a: ToCardArgs, dispatch: Redux.D
   }
   if (a.keySuffix) {
     keylist.push(a.keySuffix);
+  }
+
+  // Log the end of the quest if we reach it.
+  if (a.name === 'QUEST_END') {
+    console.log('Dispatching logQuestPlay');
+    dispatch(logQuestPlay({phase: 'end'}));
   }
 
   dispatch({type: 'NAVIGATE', to: {...a, ts: Date.now(), key: keylist.join('|'), questId}, dontUpdateUrl: state.settings && state.settings.simulator} as NavigateAction);

--- a/services/app/src/actions/Quest.test.tsx
+++ b/services/app/src/actions/Quest.test.tsx
@@ -1,6 +1,11 @@
+import * as fetchMock from 'fetch-mock';
 import {defaultContext} from '../components/views/quest/cardtemplates/Template';
+import {AUTH_SETTINGS} from '../Constants';
 import {initialQuestState} from '../reducers/Quest';
-import {initQuest} from './Quest';
+import {initialSettings} from '../reducers/Settings';
+import {loggedOutUser} from '../reducers/User';
+import {Action} from '../Testing';
+import {endQuest, initQuest} from './Quest';
 
 const cheerio = require('cheerio') as CheerioAPI;
 
@@ -27,5 +32,22 @@ describe('Quest actions', () => {
     it('dispatches roleplay on roleplay node');
 
     it('dispatches combat on combat node');
+  });
+
+  describe('endQuest', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    it('Logs the end of the quest to analytics', () => {
+      const matcher = AUTH_SETTINGS.URL_BASE + '/analytics/quest/end';
+      fetchMock.post(matcher, {});
+      Action(endQuest, {
+        user: loggedOutUser,
+        settings: initialSettings,
+        quest: {details: initialQuestState},
+      }).execute({});
+      expect(fetchMock.called(matcher)).toEqual(true);
+    });
   });
 });

--- a/services/app/src/actions/Quest.tsx
+++ b/services/app/src/actions/Quest.tsx
@@ -2,12 +2,14 @@ import Redux from 'redux';
 import {initCardTemplate} from '../components/views/quest/cardtemplates/Template';
 import {ParserNode, TemplateContext} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {QuestDetails} from '../reducers/QuestTypes';
-import {AppStateWithHistory, SettingsType} from '../reducers/StateTypes';
+import {AppStateWithHistory, SettingsType, UserQuestInstance, UserQuestsType} from '../reducers/StateTypes';
 import {
   QuestDetailsAction,
   QuestExitAction,
   QuestNodeAction,
-  remoteify
+  remoteify,
+  UserQuestInstanceSelect,
+  UserQuestsDeltaAction,
 } from './ActionTypes';
 import {toCard} from './Card';
 
@@ -73,5 +75,17 @@ export function loadNode(node: ParserNode, details?: QuestDetails) {
       }
       dispatch(initCardTemplate(node));
     }
+  };
+}
+
+export function userQuestsDelta(delta: Partial<UserQuestsType>) {
+  return (dispatch: Redux.Dispatch<any>): any => {
+    dispatch({type: 'USER_QUESTS_DELTA', delta} as UserQuestsDeltaAction);
+  };
+}
+
+export function selectPlayedQuest(selected: UserQuestInstance) {
+  return (dispatch: Redux.Dispatch<any>): any => {
+    dispatch({type: 'USER_QUEST_INSTANCE_SELECT', selected} as UserQuestInstanceSelect);
   };
 }

--- a/services/app/src/actions/Quest.tsx
+++ b/services/app/src/actions/Quest.tsx
@@ -2,16 +2,15 @@ import Redux from 'redux';
 import {initCardTemplate} from '../components/views/quest/cardtemplates/Template';
 import {ParserNode, TemplateContext} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {QuestDetails} from '../reducers/QuestTypes';
-import {AppStateWithHistory, SettingsType, UserQuestInstance, UserQuestsType} from '../reducers/StateTypes';
+import {AppStateWithHistory, SettingsType} from '../reducers/StateTypes';
 import {
   QuestDetailsAction,
   QuestExitAction,
   QuestNodeAction,
   remoteify,
-  UserQuestInstanceSelect,
-  UserQuestsDeltaAction,
 } from './ActionTypes';
 import {toCard} from './Card';
+import {logQuestPlay} from './Web';
 
 export function initQuest(details: QuestDetails, questNode: Cheerio, ctx: TemplateContext): QuestNodeAction {
   const firstNode = questNode.children().eq(0);
@@ -21,6 +20,12 @@ export function initQuest(details: QuestDetails, questNode: Cheerio, ctx: Templa
 
 export const exitQuest = remoteify(function exitQuest(): QuestExitAction {
   return {type: 'QUEST_EXIT'};
+});
+
+interface EndQuestArgs {}
+export const endQuest = remoteify(function endQuest(a: EndQuestArgs, dispatch: Redux.Dispatch<any>) {
+  dispatch(toCard({name: 'QUEST_END'}));
+  dispatch(logQuestPlay({phase: 'end'}));
 });
 
 interface ChoiceArgs {
@@ -65,7 +70,7 @@ export function loadNode(node: ParserNode, details?: QuestDetails) {
     if (tag === 'trigger') {
       const triggerName = node.elem.text().trim();
       if (triggerName === 'end') {
-        dispatch(toCard({name: 'QUEST_END'}));
+        dispatch(endQuest({}));
       } else {
         throw new Error('invalid trigger ' + triggerName);
       }
@@ -75,17 +80,5 @@ export function loadNode(node: ParserNode, details?: QuestDetails) {
       }
       dispatch(initCardTemplate(node));
     }
-  };
-}
-
-export function userQuestsDelta(delta: Partial<UserQuestsType>) {
-  return (dispatch: Redux.Dispatch<any>): any => {
-    dispatch({type: 'USER_QUESTS_DELTA', delta} as UserQuestsDeltaAction);
-  };
-}
-
-export function selectPlayedQuest(selected: UserQuestInstance) {
-  return (dispatch: Redux.Dispatch<any>): any => {
-    dispatch({type: 'USER_QUEST_INSTANCE_SELECT', selected} as UserQuestInstanceSelect);
   };
 }

--- a/services/app/src/actions/QuestHistory.test.tsx
+++ b/services/app/src/actions/QuestHistory.test.tsx
@@ -1,0 +1,3 @@
+describe('QuestHistory', () => {
+  // Entirely glue code
+});

--- a/services/app/src/actions/QuestHistory.tsx
+++ b/services/app/src/actions/QuestHistory.tsx
@@ -1,0 +1,18 @@
+import Redux from 'redux';
+import {UserQuestInstance, UserQuestsType} from '../reducers/StateTypes';
+import {
+  UserQuestInstanceSelect,
+  UserQuestsDeltaAction,
+} from './ActionTypes';
+
+export function userQuestsDelta(delta: Partial<UserQuestsType>) {
+  return (dispatch: Redux.Dispatch<any>): any => {
+    dispatch({type: 'USER_QUESTS_DELTA', delta} as UserQuestsDeltaAction);
+  };
+}
+
+export function selectPlayedQuest(selected: UserQuestInstance) {
+  return (dispatch: Redux.Dispatch<any>): any => {
+    dispatch({type: 'USER_QUEST_INSTANCE_SELECT', selected} as UserQuestInstanceSelect);
+  };
+}

--- a/services/app/src/actions/User.tsx
+++ b/services/app/src/actions/User.tsx
@@ -2,9 +2,8 @@ import * as Raven from 'raven-js';
 import Redux from 'redux';
 import {AUTH_SETTINGS} from '../Constants';
 import {CordovaLoginPlugin, getGA, getGapi, getWindow} from '../Globals';
-import {AppState, UserQuestInstance, UserQuestsType, UserState} from '../reducers/StateTypes';
+import {AppState, UserState} from '../reducers/StateTypes';
 import {loggedOutUser} from '../reducers/User';
-import {UserQuestInstanceSelect, UserQuestsDeltaAction} from './ActionTypes';
 import {fetchUserQuests, handleFetchErrors} from './Web';
 
 interface LoadGapiResponse {gapi: any; async: boolean; }

--- a/services/app/src/actions/User.tsx
+++ b/services/app/src/actions/User.tsx
@@ -2,9 +2,9 @@ import * as Raven from 'raven-js';
 import Redux from 'redux';
 import {AUTH_SETTINGS} from '../Constants';
 import {CordovaLoginPlugin, getGA, getGapi, getWindow} from '../Globals';
-import {AppState, UserQuestsType, UserState} from '../reducers/StateTypes';
+import {AppState, UserQuestInstance, UserQuestsType, UserState} from '../reducers/StateTypes';
 import {loggedOutUser} from '../reducers/User';
-import {UserQuestsDeltaAction} from './ActionTypes';
+import {UserQuestInstanceSelect, UserQuestsDeltaAction} from './ActionTypes';
 import {fetchUserQuests, handleFetchErrors} from './Web';
 
 interface LoadGapiResponse {gapi: any; async: boolean; }
@@ -71,7 +71,6 @@ function registerUserAndIdToken(user: {name: string, image: string, email: strin
       image: user.image,
       loggedIn: true,
       name: user.name,
-      quests: {}, // Requested separately; cleared for now since it's a new user
     };
   }).catch((error: Error) => {
     console.log('Request failed', error);
@@ -205,11 +204,5 @@ export function silentLogin(): (dispatch: Redux.Dispatch<any>, getState: () => A
     .then((p) => silentLoginCordova(p))
     .catch(() => silentLoginWeb())
     .then(updateState(dispatch));
-  };
-}
-
-export function userQuestsDelta(delta: Partial<UserQuestsType>) {
-  return (dispatch: Redux.Dispatch<any>): any => {
-    dispatch({type: 'USER_QUESTS_DELTA', delta} as UserQuestsDeltaAction);
   };
 }

--- a/services/app/src/actions/Web.test.tsx
+++ b/services/app/src/actions/Web.test.tsx
@@ -1,11 +1,11 @@
 import * as fetchMock from 'fetch-mock';
-import {loadQuestXML} from './Web';
-import {Action} from '../Testing';
+import {defaultContext} from '../components/views/quest/cardtemplates/Template';
 import {AUTH_SETTINGS} from '../Constants';
 import {initialQuestState} from '../reducers/Quest';
 import {initialSettings} from '../reducers/Settings';
 import {loggedOutUser} from '../reducers/User';
-import {defaultContext} from '../components/views/quest/cardtemplates/Template';
+import {Action} from '../Testing';
+import {loadQuestXML} from './Web';
 
 const cheerio = require('cheerio') as CheerioAPI;
 const emptyQuest = cheerio.load('<quest><roleplay></roleplay></quest>')('quest');

--- a/services/app/src/actions/Web.test.tsx
+++ b/services/app/src/actions/Web.test.tsx
@@ -1,3 +1,15 @@
+import * as fetchMock from 'fetch-mock';
+import {loadQuestXML} from './Web';
+import {Action} from '../Testing';
+import {AUTH_SETTINGS} from '../Constants';
+import {initialQuestState} from '../reducers/Quest';
+import {initialSettings} from '../reducers/Settings';
+import {loggedOutUser} from '../reducers/User';
+import {defaultContext} from '../components/views/quest/cardtemplates/Template';
+
+const cheerio = require('cheerio') as CheerioAPI;
+const emptyQuest = cheerio.load('<quest><roleplay></roleplay></quest>')('quest');
+
 describe('Web action', () => {
   describe('fetchQuestXML', () => {
     it('shows snackbar on request error'); // $10
@@ -5,7 +17,23 @@ describe('Web action', () => {
   });
 
   describe('loadQuestXML', () => {
-    // Tested via fetchQuestXML
+    afterEach(() => {
+      fetchMock.restore();
+    });
+    it('logs quest play', () => {
+      const matcher = AUTH_SETTINGS.URL_BASE + '/analytics/quest/start';
+      fetchMock.post(matcher, {});
+      Action(loadQuestXML as any, {
+        user: loggedOutUser,
+        settings: initialSettings,
+        quest: {details: initialQuestState},
+      }).execute({
+        details: initialQuestState,
+        questNode: emptyQuest,
+        ctx: defaultContext(),
+      });
+      expect(fetchMock.called(matcher)).toEqual(true);
+    });
   });
 
   describe('search', () => {

--- a/services/app/src/actions/Web.tsx
+++ b/services/app/src/actions/Web.tsx
@@ -11,7 +11,8 @@ import {QuestDetails} from '../reducers/QuestTypes';
 import {AppState, FeedbackType, QuestState, SettingsType, UserQuestsType, UserState} from '../reducers/StateTypes';
 import {remoteify, UserQuestsAction} from './ActionTypes';
 import {toCard} from './Card';
-import {initQuest, userQuestsDelta} from './Quest';
+import {initQuest} from './Quest';
+import {userQuestsDelta} from './QuestHistory';
 import {openSnackbar} from './Snackbar';
 import {ensureLogin} from './User';
 

--- a/services/app/src/components/Compositor.tsx
+++ b/services/app/src/components/Compositor.tsx
@@ -9,8 +9,8 @@ import {
   MultiplayerPhase,
   MultiplayerState,
   QuestState,
-  SavedQuestsPhase,
   SearchPhase,
+  SelectionListPhase,
   SettingsType,
   SnackbarState,
   TransitionClassType
@@ -26,6 +26,7 @@ import PartySizeSelectContainer from './views/PartySizeSelectContainer';
 import {renderCardTemplate} from './views/quest/cardtemplates/Template';
 import QuestEndContainer from './views/quest/QuestEndContainer';
 import QuestSetupContainer from './views/quest/QuestSetupContainer';
+import QuestHistoryContainer from './views/QuestHistoryContainer';
 import SavedQuestsContainer from './views/SavedQuestsContainer';
 import SearchContainer from './views/SearchContainer';
 import SettingsContainer from './views/SettingsContainer';
@@ -69,7 +70,10 @@ export default class Compositor extends React.Component<CompositorProps, {}> {
         card = <FeaturedQuestsContainer />;
         break;
       case 'SAVED_QUESTS':
-        card = <SavedQuestsContainer  phase={this.props.card.phase as SavedQuestsPhase} />;
+        card = <SavedQuestsContainer  phase={this.props.card.phase as SelectionListPhase} />;
+        break;
+      case 'QUEST_HISTORY':
+        card = <QuestHistoryContainer  phase={this.props.card.phase as SelectionListPhase} />;
         break;
       case 'QUEST_SETUP':
         card = <QuestSetupContainer />;

--- a/services/app/src/components/views/FeaturedQuests.tsx
+++ b/services/app/src/components/views/FeaturedQuests.tsx
@@ -14,6 +14,7 @@ export interface FeaturedQuestsStateProps {
 export interface FeaturedQuestsDispatchProps {
   onTools: () => any;
   onSavedQuests: () => any;
+  onQuestHistory: () => any;
   onSearchSelect: (user: UserState, settings: SettingsType) => any;
   onQuestSelect: (quest: QuestDetails) => any;
 }
@@ -50,6 +51,13 @@ const FeaturedQuests = (props: FeaturedQuestsProps): JSX.Element => {
         <Button onClick={() => props.onSavedQuests()} id="saved">
         <div className="questButtonWithIcon">
           <div className="title"><img className="inline_icon" src="images/compass_small.svg"/>Saved Quests - Beta</div>
+        </div>
+      </Button>
+      }
+      {!props.settings.simulator && props.settings.experimental &&
+        <Button onClick={() => props.onQuestHistory()} id="history">
+        <div className="questButtonWithIcon">
+          <div className="title"><img className="inline_icon" src="images/compass_small.svg"/>Quest History - Beta</div>
         </div>
       </Button>
       }

--- a/services/app/src/components/views/FeaturedQuestsContainer.tsx
+++ b/services/app/src/components/views/FeaturedQuestsContainer.tsx
@@ -25,6 +25,9 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Featu
     onSavedQuests(): void {
       dispatch(toCard({name: 'SAVED_QUESTS', phase: 'LIST'}));
     },
+    onQuestHistory(): void {
+      dispatch(toCard({name: 'QUEST_HISTORY', phase: 'LIST'}));
+    },
     onSearchSelect(user: UserState, settings: SettingsType): void {
       if (user && user.loggedIn) {
         dispatch(search({

--- a/services/app/src/components/views/QuestHistory.test.tsx
+++ b/services/app/src/components/views/QuestHistory.test.tsx
@@ -1,0 +1,3 @@
+describe('QuestHistory', () => {
+  // Pretty basic; no tests needed for now.
+});

--- a/services/app/src/components/views/QuestHistory.tsx
+++ b/services/app/src/components/views/QuestHistory.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import {QuestDetails} from '../../reducers/QuestTypes';
+import {SelectionListPhase, UserQuestInstance, UserQuestsType} from '../../reducers/StateTypes';
+import Button from '../base/Button';
+import Card from '../base/Card';
+
+const Moment = require('moment');
+
+export interface QuestHistoryStateProps {
+  phase: SelectionListPhase;
+  played: UserQuestsType;
+  selected: UserQuestInstance|null;
+}
+
+export interface QuestHistoryDispatchProps {
+  onSelect: (selected: UserQuestInstance) => void;
+  onPlay: (details: QuestDetails) => void;
+  onReturn: () => any;
+}
+
+export interface QuestHistoryProps extends QuestHistoryStateProps, QuestHistoryDispatchProps {}
+
+function renderDetails(props: QuestHistoryProps): JSX.Element {
+  const selected = props.selected;
+  if (!selected) {
+    return <Card title="Quest Details">Loading...</Card>;
+  }
+  const quest = selected.details;
+  const expansions = (quest.expansionhorror) ? <span><img className="inline_icon" src="images/horror_small.svg"/>The Horror</span> : 'None';
+  return (
+    <Card title="Quest Details">
+      <div className="searchDetails">
+        <h2>{quest.title}</h2>
+        <div>{quest.summary}</div>
+        <div className="author">by {quest.author}</div>
+        <div className="summary">Last played {Moment(selected.lastPlayed).fromNow()}</div>
+      </div>
+      <Button className="bigbutton" onClick={(e) => props.onPlay(quest)} id="play">Play</Button>
+      <Button onClick={(e) => props.onReturn()} id="back">Back</Button>
+      <div className="searchDetailsExtended">
+        <h3>Details</h3>
+        <div><strong>Expansions required: </strong>{expansions}</div>
+        <div><strong>Content rating:</strong> {quest.contentrating}</div>
+        <div><strong>Players:</strong> {quest.minplayers}-{quest.maxplayers}</div>
+        <div><strong>Genre:</strong> {quest.genre}</div>
+        <div><strong>Last updated: </strong> {Moment(quest.published).format('MMMM D, YYYY')}</div>
+      </div>
+    </Card>
+  );
+}
+
+function renderList(props: QuestHistoryProps): JSX.Element {
+  if (Object.keys(props.played).length === 0) {
+    return (
+      <Card title="Quest History">
+        <p>You haven't played any quests yet.</p>
+      </Card>
+    );
+  }
+
+  const items: JSX.Element[] = Object.keys(props.played)
+    .map((k: string, index: number): JSX.Element => {
+      const i = props.played[k];
+      console.log(i);
+      return (
+        <Button onClick={() => props.onSelect(i)} key={index} id={'quest' + index.toString()}>
+          <div className="questButton">
+            <div className="title">{i.details.title}</div>
+            <div className="summary">{Moment(i.lastPlayed).fromNow()}</div>
+          </div>
+        </Button>
+      );
+    });
+
+  return (
+    <Card title="Saved Quests">
+      {items}
+    </Card>
+  );
+}
+
+const QuestHistory = (props: QuestHistoryProps): JSX.Element => {
+  switch (props.phase) {
+    case 'LIST':
+      return renderList(props);
+    case 'DETAILS':
+      return renderDetails(props);
+    default:
+      throw new Error('Unknown saved quest phase ' + props.phase);
+  }
+};
+
+export default QuestHistory;

--- a/services/app/src/components/views/QuestHistoryContainer.test.tsx
+++ b/services/app/src/components/views/QuestHistoryContainer.test.tsx
@@ -1,0 +1,3 @@
+describe('QuestHistoryContainer', () => {
+  // Pretty basic; no tests needed for now.
+});

--- a/services/app/src/components/views/QuestHistoryContainer.tsx
+++ b/services/app/src/components/views/QuestHistoryContainer.tsx
@@ -1,7 +1,7 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
 import {toCard, toPrevious} from '../../actions/Card';
-import {selectPlayedQuest} from '../../actions/Quest';
+import {selectPlayedQuest} from '../../actions/QuestHistory';
 import {fetchQuestXML} from '../../actions/Web';
 import {QuestDetails} from '../../reducers/QuestTypes';
 import {AppState, UserQuestInstance} from '../../reducers/StateTypes';

--- a/services/app/src/components/views/QuestHistoryContainer.tsx
+++ b/services/app/src/components/views/QuestHistoryContainer.tsx
@@ -1,7 +1,6 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
 import {toCard, toPrevious} from '../../actions/Card';
-import {setDialog} from '../../actions/Dialog';
 import {selectPlayedQuest} from '../../actions/Quest';
 import {fetchQuestXML} from '../../actions/Web';
 import {QuestDetails} from '../../reducers/QuestTypes';

--- a/services/app/src/components/views/QuestHistoryContainer.tsx
+++ b/services/app/src/components/views/QuestHistoryContainer.tsx
@@ -1,0 +1,42 @@
+import {connect} from 'react-redux';
+import Redux from 'redux';
+import {toCard, toPrevious} from '../../actions/Card';
+import {setDialog} from '../../actions/Dialog';
+import {selectPlayedQuest} from '../../actions/Quest';
+import {fetchQuestXML} from '../../actions/Web';
+import {QuestDetails} from '../../reducers/QuestTypes';
+import {AppState, UserQuestInstance} from '../../reducers/StateTypes';
+import QuestHistory, {QuestHistoryDispatchProps, QuestHistoryStateProps} from './QuestHistory';
+
+const mapStateToProps = (state: AppState, ownProps: QuestHistoryStateProps): QuestHistoryStateProps => {
+  return {
+    phase: ownProps.phase,
+    played: state.questHistory.list,
+    selected: state.questHistory.selected,
+  };
+};
+
+export const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): QuestHistoryDispatchProps => {
+  return {
+    onPlay(details: QuestDetails): void {
+      // We must dispatch VIEW_QUEST so the quest details are
+      // propagated appropriately for analytics.
+      dispatch({type: 'VIEW_QUEST', quest: details});
+      dispatch(fetchQuestXML(details));
+    },
+    onSelect(selected: UserQuestInstance): void {
+      dispatch(selectPlayedQuest(selected));
+      dispatch(toCard({name: 'QUEST_HISTORY', phase: 'DETAILS'}));
+    },
+    onReturn(): void {
+      dispatch(toPrevious({}));
+    },
+  };
+};
+
+const QuestHistoryContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(QuestHistory);
+
+export default QuestHistoryContainer;

--- a/services/app/src/components/views/SavedQuests.tsx
+++ b/services/app/src/components/views/SavedQuests.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import {SavedQuestMeta, SavedQuestsPhase} from '../../reducers/StateTypes';
+import {SavedQuestMeta, SelectionListPhase} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
 
 const Moment = require('moment');
 
 export interface SavedQuestsStateProps {
-  phase: SavedQuestsPhase;
+  phase: SelectionListPhase;
   saved: SavedQuestMeta[];
   selected: SavedQuestMeta|null;
 }

--- a/services/app/src/components/views/Search.tsx
+++ b/services/app/src/components/views/Search.tsx
@@ -10,7 +10,7 @@ import Truncate from 'react-truncate';
 import {CONTENT_RATING_DESC, GenreType, LANGUAGES} from 'shared/schema/Constants';
 import {PLAYTIME_MINUTES_BUCKETS} from '../../Constants';
 import {QuestDetails} from '../../reducers/QuestTypes';
-import {SearchPhase, SearchSettings, SearchState, SettingsType, UserState} from '../../reducers/StateTypes';
+import {SearchPhase, SearchSettings, SearchState, SettingsType, UserQuestHistory, UserState} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
 import Checkbox from '../base/Checkbox';
@@ -24,6 +24,7 @@ export interface SearchStateProps extends SearchState {
   search: SearchSettings;
   settings: SettingsType;
   user: UserState;
+  questHistory: UserQuestHistory;
 }
 
 export interface SearchDispatchProps {
@@ -316,7 +317,7 @@ export function renderResult(props: SearchResultProps): JSX.Element {
 
 function renderResults(props: SearchProps, hideHeader?: boolean): JSX.Element {
   const results: JSX.Element[] = (props.results || []).map((quest: QuestDetails, index: number) => {
-    return renderResult({index, quest, search: props.search, onQuest: props.onQuest, lastPlayed: (props.user.quests[quest.id] || {}).lastPlayed});
+    return renderResult({index, quest, search: props.search, onQuest: props.onQuest, lastPlayed: (props.questHistory.list[quest.id] || {}).lastPlayed});
   });
 
   return (
@@ -465,7 +466,7 @@ const Search = (props: SearchProps): JSX.Element => {
     case 'DETAILS':
       return renderDetails({
         isDirectLinked: props.isDirectLinked,
-        lastPlayed: (props.user.quests[(props.selected || {id: '-1'}).id] || {}).lastPlayed,
+        lastPlayed: (props.questHistory.list[(props.selected || {id: '-1'}).id] || {}).lastPlayed,
         onPlay: props.onPlay,
         onReturn: props.onReturn,
         quest: props.selected,

--- a/services/app/src/components/views/SearchContainer.tsx
+++ b/services/app/src/components/views/SearchContainer.tsx
@@ -17,6 +17,7 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: SearchStateProps)
     phase: ownProps.phase,
     settings: state.settings,
     user: state.user,
+    questHistory: state.questHistory,
   };
 };
 

--- a/services/app/src/components/views/quest/QuestEnd.tsx
+++ b/services/app/src/components/views/quest/QuestEnd.tsx
@@ -2,7 +2,6 @@ import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import TextField from '@material-ui/core/TextField';
 import * as React from 'react';
-import {logQuestPlay} from '../../../actions/Web';
 import {CheckoutState, QuestState, SettingsType, UserState} from '../../../reducers/StateTypes';
 import Button from '../../base/Button';
 import Card from '../../base/Card';

--- a/services/app/src/components/views/quest/QuestEnd.tsx
+++ b/services/app/src/components/views/quest/QuestEnd.tsx
@@ -32,7 +32,6 @@ export default class QuestEnd extends React.Component<QuestEndProps, {}> {
   constructor(props: QuestEndProps) {
     super(props);
     this.state = {anonymous: false, text: '', rating: null};
-    logQuestPlay({phase: 'end'});
   }
 
   public render() {

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
@@ -4,7 +4,7 @@ import {QuestNodeAction, remoteify} from '../../../../../actions/ActionTypes';
 import {audioSet} from '../../../../../actions/Audio';
 import {toCard} from '../../../../../actions/Card';
 import {setMultiplayerStatus} from '../../../../../actions/Multiplayer';
-import {loadNode} from '../../../../../actions/Quest';
+import {endQuest, loadNode} from '../../../../../actions/Quest';
 import {COMBAT_DIFFICULTY, MUSIC_INTENSITY_MAX, PLAYER_TIME_MULT} from '../../../../../Constants';
 import {PLAYER_DAMAGE_MULT} from '../../../../../Constants';
 import {ENCOUNTERS} from '../../../../../Encounters';
@@ -509,7 +509,7 @@ export const midCombatChoice = remoteify(function midCombatChoice(a: MidCombatCh
         // it's handled like a normal combat RP choice change (below).
       } else if (next.isEnd()) {
         // Treat quest end as normal
-        dispatch(toCard({name: 'QUEST_END'}));
+        dispatch(endQuest({}));
         return remoteArgs;
       } else {
         // If the trigger exits via the win/lose handlers, go to the appropriate

--- a/services/app/src/reducers/CombinedReducers.tsx
+++ b/services/app/src/reducers/CombinedReducers.tsx
@@ -9,6 +9,7 @@ import {dialog} from './Dialog';
 import {inflight} from './InFlight';
 import {multiplayer} from './Multiplayer';
 import {quest} from './Quest';
+import {questhistory} from './QuestHistory';
 import {saved} from './Saved';
 import {search} from './Search';
 import {settings} from './Settings';
@@ -27,6 +28,7 @@ function combinedReduce(state: AppStateWithHistory, action: Redux.Action): AppSt
     dialog: dialog(state.dialog, action),
     multiplayer: multiplayer(state.multiplayer, action),
     quest: quest(state.quest, action),
+    questHistory: questhistory(state.questHistory, action),
     saved: saved(state.saved, action),
     search: search(state.search, action),
     settings: settings(state.settings, action),

--- a/services/app/src/reducers/QuestHistory.tsx
+++ b/services/app/src/reducers/QuestHistory.tsx
@@ -1,0 +1,23 @@
+import merge from 'deepmerge';
+import Redux from 'redux';
+import {UserQuestInstanceSelect, UserQuestsAction, UserQuestsDeltaAction} from '../actions/ActionTypes';
+import {UserQuestHistory} from './StateTypes';
+
+const initialHistoryState: UserQuestHistory = {
+  list: {},
+  selected: null,
+};
+
+export function questhistory(state: UserQuestHistory = initialHistoryState, action: Redux.Action): UserQuestHistory {
+  switch (action.type) {
+    case 'USER_QUEST_INSTANCE_SELECT':
+      return {...state, selected: (action as UserQuestInstanceSelect).selected || null};
+    case 'USER_QUESTS':
+      return {...state, list: (action as UserQuestsAction).quests};
+    case 'USER_QUESTS_DELTA':
+      const delta = (action as UserQuestsDeltaAction).delta;
+      return merge(state, {list: delta}) as UserQuestHistory;
+    default:
+      return state;
+  }
+}

--- a/services/app/src/reducers/StateTypes.tsx
+++ b/services/app/src/reducers/StateTypes.tsx
@@ -98,12 +98,12 @@ export interface SavedQuestMeta {
   ts: number;
 }
 
-export type SavedQuestsPhase = 'LIST' | 'DETAILS';
+export type SelectionListPhase = 'LIST' | 'DETAILS';
 
 export type MultiplayerPhase = 'CONNECT'|'LOBBY';
 export type CheckoutPhase = 'ENTRY' | 'DONE';
-export type CardName = 'SAVED_QUESTS' | 'CHECKOUT' | 'PLAYER_COUNT_SETTING' | 'QUEST_SETUP' | 'QUEST_END' | 'QUEST_CARD' | 'FEATURED_QUESTS' | 'SPLASH_CARD' | 'SEARCH_CARD' | 'SETTINGS' | 'ADVANCED' | 'REMOTE_PLAY';
-export type CardPhase = TemplatePhase | SearchPhase | MultiplayerPhase | CheckoutPhase | SavedQuestsPhase;
+export type CardName = 'QUEST_HISTORY' | 'SAVED_QUESTS' | 'CHECKOUT' | 'PLAYER_COUNT_SETTING' | 'QUEST_SETUP' | 'QUEST_END' | 'QUEST_CARD' | 'FEATURED_QUESTS' | 'SPLASH_CARD' | 'SEARCH_CARD' | 'SETTINGS' | 'ADVANCED' | 'REMOTE_PLAY';
+export type CardPhase = TemplatePhase | SearchPhase | MultiplayerPhase | CheckoutPhase | SelectionListPhase;
 export interface CardState {
   questId: string;
   name: CardName;
@@ -133,10 +133,13 @@ export interface SearchState {
   searching: boolean;
 }
 
+export interface UserQuestInstance {
+  details: QuestDetails;
+  lastPlayed: Date;
+}
+
 export interface UserQuestsType {
-  [questId: string]: {
-    lastPlayed: Date;
-  };
+  [questId: string]: UserQuestInstance;
 }
 
 export interface UserState {
@@ -145,7 +148,11 @@ export interface UserState {
   name: string;
   image: string;
   email: string;
-  quests: UserQuestsType;
+}
+
+export interface UserQuestHistory {
+  list: UserQuestsType;
+  selected: UserQuestInstance|null;
 }
 
 export type FeedbackType = 'feedback'|'rating'|'report_error'|'report_quest';
@@ -185,6 +192,7 @@ export interface AppStateBase {
   search: SearchState;
   snackbar: SnackbarState;
   user: UserState;
+  questHistory: UserQuestHistory;
   commitID: number;
 }
 

--- a/services/app/src/reducers/User.test.tsx
+++ b/services/app/src/reducers/User.test.tsx
@@ -6,7 +6,6 @@ export const testLoggedInUser: UserState = {
   image: 'http://app.expeditiongame.com/logo.png',
   loggedIn: true,
   name: 'Bob Fisher',
-  quests: {},
 };
 
 describe('User reducer', () => {

--- a/services/app/src/reducers/User.tsx
+++ b/services/app/src/reducers/User.tsx
@@ -1,5 +1,5 @@
 import Redux from 'redux';
-import {UserLoginAction, UserQuestsAction, UserQuestsDeltaAction} from '../actions/ActionTypes';
+import {UserLoginAction} from '../actions/ActionTypes';
 import {UserState} from './StateTypes';
 
 export const loggedOutUser: UserState = {

--- a/services/app/src/reducers/User.tsx
+++ b/services/app/src/reducers/User.tsx
@@ -1,4 +1,3 @@
-import merge from 'deepmerge';
 import Redux from 'redux';
 import {UserLoginAction, UserQuestsAction, UserQuestsDeltaAction} from '../actions/ActionTypes';
 import {UserState} from './StateTypes';
@@ -9,18 +8,12 @@ export const loggedOutUser: UserState = {
   image: '',
   loggedIn: false,
   name: '',
-  quests: {},
 };
 
 export function user(state: UserState = loggedOutUser, action: Redux.Action): UserState {
   switch (action.type) {
     case 'USER_LOGIN':
       return (action as UserLoginAction).user;
-    case 'USER_QUESTS':
-      return {...state, quests: (action as UserQuestsAction).quests};
-    case 'USER_QUESTS_DELTA':
-      const delta = (action as UserQuestsDeltaAction).delta;
-      return merge(state, {quests: delta}) as UserState;
     default:
       return state;
   }

--- a/services/app/webpack.config.js
+++ b/services/app/webpack.config.js
@@ -37,7 +37,7 @@ const options = {
   },
   module: {
     rules: [
-      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader' },
+      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader', options: {fix: true}},
       { test: /\.(ttf|eot|svg|png|gif|jpe?g|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader: 'file-loader',
         options: { name: '[name].[ext]' }, // disable filename hashing for infrequently changed static assets to enable preloading
       },

--- a/services/cards/webpack.config.js
+++ b/services/cards/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
   },
   module: {
     rules: [
-      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader' },
+      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader', options: {fix: true} },
       { test: /\.(ttf|eot|svg|png|gif|jpg|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader : 'file-loader' },
       { test: /\.scss$/, loader: 'style-loader!css-loader!sass-loader' },
       { test: /\.json$/, loader: 'json-loader' },

--- a/services/quests/webpack.config.js
+++ b/services/quests/webpack.config.js
@@ -47,7 +47,7 @@ const options = {
   },
   module: {
     rules: [
-      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader' },
+      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader', options: {fix: true} },
       { test: /\.(ttf|eot|svg|png|gif|jpe?g|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader : 'file-loader' },
       { test: /\.scss$/, loader: 'style-loader!css-loader!sass-loader' },
       { test: /\.json$/, loader: 'json-loader' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,6 +162,10 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/fetch-mock@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-6.0.3.tgz#54ba90776293e728089bf53ba53e3c69f1c80655"
+
 "@types/form-data@*":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.2.1.tgz#ee2b3b8eaa11c0938289953606b745b738c54b1e"
@@ -1560,7 +1564,7 @@ babel-polyfill@6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-polyfill@^6.23.0:
+babel-polyfill@^6.23.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:
@@ -4649,6 +4653,14 @@ fbjs@^0.8.1, fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
+fetch-mock@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-6.5.0.tgz#3841b90d5a315e213be61c07f1125be8c52f4f9c"
+  dependencies:
+    babel-polyfill "^6.26.0"
+    glob-to-regexp "^0.4.0"
+    path-to-regexp "^2.2.1"
+
 figures@^1.4.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -5154,6 +5166,10 @@ glob-stream@^5.3.2:
     through2 "^0.6.0"
     to-absolute-glob "^0.1.1"
     unique-stream "^2.0.2"
+
+glob-to-regexp@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz#49bd677b1671022bd10921c3788f23cdebf9c7e6"
 
 glob2base@^0.0.12:
   version "0.0.12"
@@ -9086,6 +9102,10 @@ path-to-regexp@^1.2.1, path-to-regexp@^1.7.0:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
     isarray "0.0.1"
+
+path-to-regexp@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
 
 path-type@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
https://github.com/ExpeditionRPG/expedition/issues/242

Adds a "Quest history" beta feature - the API server now queries for quest details using the analytics events for quest completion, returning it to the app which then has a flow similar to SavedQuests for interaction.

Additional fixes:
- Add `yarn app-watch-test` and `yarn api-watch-test` for continuous testing
- Analytics events weren't being saved on quest begin and end (it wasn't dispatching the thunk). Fixed this and added tests
- Moved the quest history out of the `user` reducer, since it's not really a property of the user and we may extend it later on.