### PR TITLE
Consolidated quest preview code, plus small fixes

### DIFF
--- a/services/app/src/Format.test.tsx
+++ b/services/app/src/Format.test.tsx
@@ -1,0 +1,10 @@
+import {formatPlayPeriod} from './Format';
+
+describe('formatPlayPeriod', () => {
+  it('formats time ranges to minutes and hours', () => {
+    expect(formatPlayPeriod(30, 60)).toEqual('30-60 min');
+    expect(formatPlayPeriod(30, 120)).toEqual('30-120 min');
+    expect(formatPlayPeriod(60, 120)).toEqual('1-2 hrs');
+    expect(formatPlayPeriod(999, 999)).toEqual('2+ hrs');
+  });
+});

--- a/services/app/src/Format.tsx
+++ b/services/app/src/Format.tsx
@@ -1,0 +1,17 @@
+// General-use string formatting of quest details and other data.
+
+export function formatPlayPeriod(minMinutes: number, maxMinutes: number): string {
+  if (maxMinutes >= 999) {
+    if (minMinutes >= 999) {
+      return '2+ hrs';
+    } else if (minMinutes >= 60) {
+      return Math.round(minMinutes / 60) + '+ hrs';
+    } else {
+      return Math.round(minMinutes) + '+ min';
+    }
+  } else if (minMinutes >= 60 && maxMinutes >= 60) {
+    return Math.round(minMinutes / 60) + '-' + Math.round(maxMinutes / 60) + ' hrs';
+  } else {
+    return minMinutes + '-' + maxMinutes + ' min';
+  }
+}

--- a/services/app/src/Style.scss
+++ b/services/app/src/Style.scss
@@ -635,6 +635,7 @@ span.line {
       line-height: size(inputsquare);
       order: 2;
       padding-left: size(small);
+      margin-top: size(small);
     }
     .hint {
       color: #757575;

--- a/services/app/src/actions/ActionTypes.tsx
+++ b/services/app/src/actions/ActionTypes.tsx
@@ -113,9 +113,11 @@ export interface SearchResponseAction extends Redux.Action {
   search: SearchSettings;
 }
 
-export interface ViewQuestAction extends Redux.Action {
-  type: 'VIEW_QUEST';
+export interface PreviewQuestAction extends Redux.Action {
+  type: 'PREVIEW_QUEST';
   quest: QuestDetails;
+  savedTS: number|null;
+  lastPlayed: Date|null;
 }
 
 export interface UserLoginAction extends Redux.Action {
@@ -166,11 +168,6 @@ export interface SavedQuestDeletedAction {
 export interface SavedQuestListAction {
   type: 'SAVED_QUEST_LIST';
   savedQuests: SavedQuestMeta[];
-}
-
-export interface SavedQuestSelectedAction {
-  type: 'SAVED_QUEST_SELECTED';
-  selected: SavedQuestMeta;
 }
 
 export interface MultiplayerSessionAction extends Redux.Action {

--- a/services/app/src/actions/Quest.tsx
+++ b/services/app/src/actions/Quest.tsx
@@ -2,7 +2,7 @@ import Redux from 'redux';
 import {initCardTemplate} from '../components/views/quest/cardtemplates/Template';
 import {ParserNode, TemplateContext} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {QuestDetails} from '../reducers/QuestTypes';
-import {AppStateWithHistory, SavedQuestMeta, SettingsType} from '../reducers/StateTypes';
+import {AppStateWithHistory, SettingsType} from '../reducers/StateTypes';
 import {
   PreviewQuestAction,
   QuestDetailsAction,

--- a/services/app/src/actions/Quest.tsx
+++ b/services/app/src/actions/Quest.tsx
@@ -2,8 +2,9 @@ import Redux from 'redux';
 import {initCardTemplate} from '../components/views/quest/cardtemplates/Template';
 import {ParserNode, TemplateContext} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {QuestDetails} from '../reducers/QuestTypes';
-import {AppStateWithHistory, SettingsType} from '../reducers/StateTypes';
+import {AppStateWithHistory, SavedQuestMeta, SettingsType} from '../reducers/StateTypes';
 import {
+  PreviewQuestAction,
   QuestDetailsAction,
   QuestExitAction,
   QuestNodeAction,
@@ -82,3 +83,15 @@ export function loadNode(node: ParserNode, details?: QuestDetails) {
     }
   };
 }
+
+interface PreviewQuestArgs {
+  quest: QuestDetails;
+  saveTS?: number;
+  lastPlayed?: Date;
+}
+export const previewQuest = remoteify(function previewQuest(a: PreviewQuestArgs, dispatch: Redux.Dispatch<any>) {
+  // dispatch(selectPlayedQuest(selected));
+  dispatch({type: 'PREVIEW_QUEST', quest: a.quest, savedTS: a.saveTS, lastPlayed: a.lastPlayed} as PreviewQuestAction);
+  dispatch(toCard({name: 'QUEST_PREVIEW'}));
+  return a;
+});

--- a/services/app/src/actions/SavedQuests.tsx
+++ b/services/app/src/actions/SavedQuests.tsx
@@ -5,7 +5,7 @@ import {getStorageJson, setStorageKeyValue} from '../LocalStorage';
 import {logEvent} from '../Logging';
 import {QuestDetails} from '../reducers/QuestTypes';
 import {SavedQuestMeta} from '../reducers/StateTypes';
-import {QuestNodeAction, SavedQuestDeletedAction, SavedQuestListAction, SavedQuestSelectedAction, SavedQuestStoredAction} from './ActionTypes';
+import {QuestNodeAction, SavedQuestDeletedAction, SavedQuestListAction, SavedQuestStoredAction} from './ActionTypes';
 import {initQuest} from './Quest';
 
 declare interface SavedQuest {xml: string; path: number[]; }
@@ -23,10 +23,6 @@ export function savedQuestKey(id: string, ts: number) {
 export function listSavedQuests(): SavedQuestListAction {
   const savedQuests = getSavedQuestMeta();
   return {type: 'SAVED_QUEST_LIST', savedQuests};
-}
-
-export function selectSavedQuest(selected: SavedQuestMeta): SavedQuestSelectedAction {
-  return {type: 'SAVED_QUEST_SELECTED', selected};
 }
 
 export function deleteSavedQuest(id: string, ts: number) {

--- a/services/app/src/actions/Search.tsx
+++ b/services/app/src/actions/Search.tsx
@@ -6,12 +6,7 @@ import {CardPhase, ExpansionsType, SearchSettings, SettingsType} from '../reduce
 import {SearchResponseAction} from './ActionTypes';
 import {remoteify} from './ActionTypes';
 import {toCard} from './Card';
-
-export const viewQuest = remoteify(function viewQuest(a: {quest: QuestDetails}, dispatch: Redux.Dispatch<any>) {
-  dispatch({type: 'VIEW_QUEST', quest: a.quest});
-  dispatch(toCard({name: 'SEARCH_CARD', phase: 'DETAILS'}));
-  return a;
-});
+import {previewQuest} from './Quest';
 
 // TODO: Make search options propagate to other clients
 export const search = remoteify(function search(a: {search: SearchSettings, settings: SettingsType}, dispatch: Redux.Dispatch<any>) {
@@ -45,7 +40,7 @@ export const searchAndPlay = remoteify(function searchAndPlay(id: string, dispat
   } as SearchSettings;
   const featuredQuest = FEATURED_QUESTS.filter((q: QuestDetails) => q.id === id);
   if (featuredQuest.length === 1) {
-    dispatch(viewQuest({quest: featuredQuest[0]}));
+    dispatch(previewQuest({quest: featuredQuest[0]}));
   } else {
     dispatch(getSearchResults(params, (quests: QuestDetails[], response: any) => {
       dispatch({
@@ -61,7 +56,7 @@ export const searchAndPlay = remoteify(function searchAndPlay(id: string, dispat
         alert('Quest not found, returning to home screen.');
         dispatch(toCard({name: 'SPLASH_CARD'}));
       } else {
-        dispatch(viewQuest({quest: quests[0]}));
+        dispatch(previewQuest({quest: quests[0]}));
       }
     }));
   }

--- a/services/app/src/components/Compositor.tsx
+++ b/services/app/src/components/Compositor.tsx
@@ -10,7 +10,6 @@ import {
   MultiplayerState,
   QuestState,
   SearchPhase,
-  SelectionListPhase,
   SettingsType,
   SnackbarState,
   TransitionClassType
@@ -27,6 +26,7 @@ import {renderCardTemplate} from './views/quest/cardtemplates/Template';
 import QuestEndContainer from './views/quest/QuestEndContainer';
 import QuestSetupContainer from './views/quest/QuestSetupContainer';
 import QuestHistoryContainer from './views/QuestHistoryContainer';
+import QuestPreviewContainer from './views/QuestPreviewContainer';
 import SavedQuestsContainer from './views/SavedQuestsContainer';
 import SearchContainer from './views/SearchContainer';
 import SettingsContainer from './views/SettingsContainer';
@@ -70,10 +70,13 @@ export default class Compositor extends React.Component<CompositorProps, {}> {
         card = <FeaturedQuestsContainer />;
         break;
       case 'SAVED_QUESTS':
-        card = <SavedQuestsContainer  phase={this.props.card.phase as SelectionListPhase} />;
+        card = <SavedQuestsContainer />;
         break;
       case 'QUEST_HISTORY':
-        card = <QuestHistoryContainer  phase={this.props.card.phase as SelectionListPhase} />;
+        card = <QuestHistoryContainer />;
+        break;
+      case 'QUEST_PREVIEW':
+        card = <QuestPreviewContainer />;
         break;
       case 'QUEST_SETUP':
         card = <QuestSetupContainer />;

--- a/services/app/src/components/base/Dialogs.tsx
+++ b/services/app/src/components/base/Dialogs.tsx
@@ -276,11 +276,12 @@ interface DeleteSavedQuestDialogProps extends React.Props<any> {
   onClose: () => void;
   onDeleteSavedQuest: (savedQuest: SavedQuestMeta) => void;
   open: boolean;
-  savedQuest: SavedQuestMeta;
+  savedQuest: SavedQuestMeta|null;
 }
 
 export class DeleteSavedQuestDialog extends React.Component<DeleteSavedQuestDialogProps, {}> {
-  public render(): JSX.Element {
+  public render() {
+    const savedQuest = this.props.savedQuest;
     return (
       <Dialog
         open={Boolean(this.props.open)}
@@ -289,7 +290,12 @@ export class DeleteSavedQuestDialog extends React.Component<DeleteSavedQuestDial
         <DialogContent className="dialog"></DialogContent>
         <DialogActions>
           <Button onClick={() => this.props.onClose()}>Cancel</Button>
-          <Button className="primary" onClick={() => this.props.onDeleteSavedQuest(this.props.savedQuest)}>Delete</Button>
+          <Button className="primary" onClick={() => {
+            if (savedQuest === null) {
+              throw new Error('missing saved quest information');
+            }
+            this.props.onDeleteSavedQuest(savedQuest);
+          }}>Delete</Button>
         </DialogActions>
       </Dialog>
     );
@@ -300,7 +306,7 @@ export interface DialogsStateProps {
   dialog: DialogState;
   multiplayerStats: MultiplayerCounters;
   quest: QuestState;
-  selectedSave: SavedQuestMeta;
+  selectedSave: SavedQuestMeta|null;
   settings: SettingsType;
   user: UserState;
 }

--- a/services/app/src/components/base/DialogsContainer.tsx
+++ b/services/app/src/components/base/DialogsContainer.tsx
@@ -27,7 +27,7 @@ const mapStateToProps = (state: AppState, ownProps: any): DialogsStateProps => {
     dialog: state.dialog,
     multiplayerStats,
     quest: state.quest || {details: {}} as any,
-    selectedSave: state.saved.selected || {} as SavedQuestMeta,
+    selectedSave: (state.quest.savedTS) ? {details: state.quest.details, ts: state.quest.savedTS} : null,
     settings: state.settings,
     user: state.user,
   };
@@ -40,7 +40,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Dialo
     },
     onDeleteSavedQuest: (savedQuest: SavedQuestMeta) => {
       dispatch(deleteSavedQuest(savedQuest.details.id, savedQuest.ts));
-      dispatch(toPrevious({name: 'SAVED_QUESTS', phase: 'LIST', before: false}));
+      dispatch(toPrevious({name: 'SAVED_QUESTS', before: false}));
       dispatch(openSnackbar('Save deleted.'));
     },
     onExitMultiplayer: () => {

--- a/services/app/src/components/base/StarRating.tsx
+++ b/services/app/src/components/base/StarRating.tsx
@@ -37,17 +37,28 @@ export default class StarRating extends React.Component<StarRatingProps, {}> {
       }
 
       // TODO: Flatten this structure so ripples are circular
-      return <div key={i} className={classes.join(' ')}>
-        <IconButton
-          disabled={this.props.readOnly}
-          onClick={() => {
-            if (!this.props.readOnly && this.props.onChange) {
-              this.props.onChange(i);
-            }
-          }}>
-          {star}
-        </IconButton>
-      </div>;
+      // We use a non-button element here due to redux errors on nesting buttons
+      // when the stars are just used in a display-only fashion.
+      if (this.props.readOnly) {
+        return (
+          <div key={i} className={classes.join(' ')}>
+            {star}
+          </div>
+        );
+      } else {
+        return (
+          <div key={i} className={classes.join(' ')}>
+            <IconButton
+              onClick={() => {
+                if (this.props.onChange) {
+                  this.props.onChange(i);
+                }
+              }}>
+              {star}
+            </IconButton>
+          </div>
+        );
+      }
     });
     return <span className="starContainer">
       <div className="stars" style={this.props.style}>

--- a/services/app/src/components/views/FeaturedQuests.tsx
+++ b/services/app/src/components/views/FeaturedQuests.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {openWindow} from '../../Globals';
 import {QuestDetails} from '../../reducers/QuestTypes';
-import {SettingsType, UserState} from '../../reducers/StateTypes';
+import {CardName, SettingsType, UserState} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
 
@@ -12,9 +12,7 @@ export interface FeaturedQuestsStateProps {
 }
 
 export interface FeaturedQuestsDispatchProps {
-  onTools: () => any;
-  onSavedQuests: () => any;
-  onQuestHistory: () => any;
+  toCard: (name: CardName) => any;
   onSearchSelect: (user: UserState, settings: SettingsType) => any;
   onQuestSelect: (quest: QuestDetails) => any;
 }
@@ -48,20 +46,20 @@ const FeaturedQuests = (props: FeaturedQuestsProps): JSX.Element => {
       </Button>
       }
       {!props.settings.simulator && props.settings.experimental &&
-        <Button onClick={() => props.onSavedQuests()} id="saved">
+        <Button onClick={() => props.toCard('SAVED_QUESTS')} id="saved">
         <div className="questButtonWithIcon">
           <div className="title"><img className="inline_icon" src="images/compass_small.svg"/>Saved Quests - Beta</div>
         </div>
       </Button>
       }
       {!props.settings.simulator && props.settings.experimental &&
-        <Button onClick={() => props.onQuestHistory()} id="history">
+        <Button onClick={() => props.toCard('QUEST_HISTORY')} id="history">
         <div className="questButtonWithIcon">
           <div className="title"><img className="inline_icon" src="images/compass_small.svg"/>Quest History - Beta</div>
         </div>
       </Button>
       }
-      <Button onClick={() => props.onTools()} id="tools">
+      <Button onClick={() => props.toCard('ADVANCED')} id="tools">
         <div className="questButtonWithIcon">
           <div className="title"><img className="inline_icon" src="images/roll_small.svg"/>Tools</div>
         </div>

--- a/services/app/src/components/views/FeaturedQuestsContainer.tsx
+++ b/services/app/src/components/views/FeaturedQuestsContainer.tsx
@@ -2,11 +2,12 @@ import {connect} from 'react-redux';
 import Redux from 'redux';
 
 import {toCard} from '../../actions/Card';
-import {search, viewQuest} from '../../actions/Search';
+import {previewQuest} from '../../actions/Quest';
+import {search} from '../../actions/Search';
 import {FEATURED_QUESTS} from '../../Constants';
 import {QuestDetails} from '../../reducers/QuestTypes';
 import {initialSearch} from '../../reducers/Search';
-import {AppState, SettingsType, UserState} from '../../reducers/StateTypes';
+import {AppState, CardName, SettingsType, UserState} from '../../reducers/StateTypes';
 import FeaturedQuests, {FeaturedQuestsDispatchProps, FeaturedQuestsStateProps} from './FeaturedQuests';
 
 const mapStateToProps = (state: AppState, ownProps: FeaturedQuestsStateProps): FeaturedQuestsStateProps => {
@@ -19,14 +20,8 @@ const mapStateToProps = (state: AppState, ownProps: FeaturedQuestsStateProps): F
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): FeaturedQuestsDispatchProps => {
   return {
-    onTools(): void {
-      dispatch(toCard({name: 'ADVANCED'}));
-    },
-    onSavedQuests(): void {
-      dispatch(toCard({name: 'SAVED_QUESTS', phase: 'LIST'}));
-    },
-    onQuestHistory(): void {
-      dispatch(toCard({name: 'QUEST_HISTORY', phase: 'LIST'}));
+    toCard(name: CardName): void {
+      dispatch(toCard({name}));
     },
     onSearchSelect(user: UserState, settings: SettingsType): void {
       if (user && user.loggedIn) {
@@ -39,7 +34,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Featu
       }
     },
     onQuestSelect(quest: QuestDetails): void {
-      dispatch(viewQuest({quest}));
+      dispatch(previewQuest({quest}));
     },
   };
 };

--- a/services/app/src/components/views/QuestHistory.tsx
+++ b/services/app/src/components/views/QuestHistory.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import {UserQuestInstance, UserQuestsType} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';

--- a/services/app/src/components/views/QuestHistory.tsx
+++ b/services/app/src/components/views/QuestHistory.tsx
@@ -1,55 +1,23 @@
 import * as React from 'react';
 import {QuestDetails} from '../../reducers/QuestTypes';
-import {SelectionListPhase, UserQuestInstance, UserQuestsType} from '../../reducers/StateTypes';
+import {UserQuestInstance, UserQuestsType} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
 
 const Moment = require('moment');
 
 export interface QuestHistoryStateProps {
-  phase: SelectionListPhase;
   played: UserQuestsType;
-  selected: UserQuestInstance|null;
 }
 
 export interface QuestHistoryDispatchProps {
   onSelect: (selected: UserQuestInstance) => void;
-  onPlay: (details: QuestDetails) => void;
   onReturn: () => any;
 }
 
 export interface QuestHistoryProps extends QuestHistoryStateProps, QuestHistoryDispatchProps {}
 
-function renderDetails(props: QuestHistoryProps): JSX.Element {
-  const selected = props.selected;
-  if (!selected) {
-    return <Card title="Quest Details">Loading...</Card>;
-  }
-  const quest = selected.details;
-  const expansions = (quest.expansionhorror) ? <span><img className="inline_icon" src="images/horror_small.svg"/>The Horror</span> : 'None';
-  return (
-    <Card title="Quest Details">
-      <div className="searchDetails">
-        <h2>{quest.title}</h2>
-        <div>{quest.summary}</div>
-        <div className="author">by {quest.author}</div>
-        <div className="summary">Last played {Moment(selected.lastPlayed).fromNow()}</div>
-      </div>
-      <Button className="bigbutton" onClick={(e) => props.onPlay(quest)} id="play">Play</Button>
-      <Button onClick={(e) => props.onReturn()} id="back">Back</Button>
-      <div className="searchDetailsExtended">
-        <h3>Details</h3>
-        <div><strong>Expansions required: </strong>{expansions}</div>
-        <div><strong>Content rating:</strong> {quest.contentrating}</div>
-        <div><strong>Players:</strong> {quest.minplayers}-{quest.maxplayers}</div>
-        <div><strong>Genre:</strong> {quest.genre}</div>
-        <div><strong>Last updated: </strong> {Moment(quest.published).format('MMMM D, YYYY')}</div>
-      </div>
-    </Card>
-  );
-}
-
-function renderList(props: QuestHistoryProps): JSX.Element {
+const QuestHistory = (props: QuestHistoryProps): JSX.Element => {
   if (Object.keys(props.played).length === 0) {
     return (
       <Card title="Quest History">
@@ -73,21 +41,10 @@ function renderList(props: QuestHistoryProps): JSX.Element {
     });
 
   return (
-    <Card title="Saved Quests">
+    <Card title="Quest History">
       {items}
     </Card>
   );
-}
-
-const QuestHistory = (props: QuestHistoryProps): JSX.Element => {
-  switch (props.phase) {
-    case 'LIST':
-      return renderList(props);
-    case 'DETAILS':
-      return renderDetails(props);
-    default:
-      throw new Error('Unknown saved quest phase ' + props.phase);
-  }
 };
 
 export default QuestHistory;

--- a/services/app/src/components/views/QuestHistoryContainer.tsx
+++ b/services/app/src/components/views/QuestHistoryContainer.tsx
@@ -1,10 +1,7 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
-import {toCard, toPrevious} from '../../actions/Card';
+import {toPrevious} from '../../actions/Card';
 import {previewQuest} from '../../actions/Quest';
-import {selectPlayedQuest} from '../../actions/QuestHistory';
-import {fetchQuestXML} from '../../actions/Web';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import {AppState, UserQuestInstance} from '../../reducers/StateTypes';
 import QuestHistory, {QuestHistoryDispatchProps, QuestHistoryStateProps} from './QuestHistory';
 

--- a/services/app/src/components/views/QuestHistoryContainer.tsx
+++ b/services/app/src/components/views/QuestHistoryContainer.tsx
@@ -1,6 +1,7 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
 import {toCard, toPrevious} from '../../actions/Card';
+import {previewQuest} from '../../actions/Quest';
 import {selectPlayedQuest} from '../../actions/QuestHistory';
 import {fetchQuestXML} from '../../actions/Web';
 import {QuestDetails} from '../../reducers/QuestTypes';
@@ -9,23 +10,14 @@ import QuestHistory, {QuestHistoryDispatchProps, QuestHistoryStateProps} from '.
 
 const mapStateToProps = (state: AppState, ownProps: QuestHistoryStateProps): QuestHistoryStateProps => {
   return {
-    phase: ownProps.phase,
     played: state.questHistory.list,
-    selected: state.questHistory.selected,
   };
 };
 
 export const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): QuestHistoryDispatchProps => {
   return {
-    onPlay(details: QuestDetails): void {
-      // We must dispatch VIEW_QUEST so the quest details are
-      // propagated appropriately for analytics.
-      dispatch({type: 'VIEW_QUEST', quest: details});
-      dispatch(fetchQuestXML(details));
-    },
     onSelect(selected: UserQuestInstance): void {
-      dispatch(selectPlayedQuest(selected));
-      dispatch(toCard({name: 'QUEST_HISTORY', phase: 'DETAILS'}));
+      dispatch(previewQuest({quest: selected.details, lastPlayed: selected.lastPlayed}));
     },
     onReturn(): void {
       dispatch(toPrevious({}));

--- a/services/app/src/components/views/QuestPreview.test.tsx
+++ b/services/app/src/components/views/QuestPreview.test.tsx
@@ -1,0 +1,67 @@
+import {configure, render} from 'enzyme';
+import * as Adapter from 'enzyme-adapter-react-16';
+import {LanguageType} from 'shared/schema/Constants';
+import {FEATURED_QUESTS} from '../../Constants';
+import {QuestDetails} from '../../reducers/QuestTypes';
+import {SearchSettings} from '../../reducers/StateTypes';
+import QuestPreview, {QuestPreviewProps} from './QuestPreview';
+configure({ adapter: new Adapter() });
+
+describe('Details', () => {
+  function setup(questTitle: string, overrides?: Partial<QuestPreviewProps>, questOverrides?: Partial<QuestDetails>) {
+    const props: QuestPreviewProps = {
+      isDirectLinked: false,
+      lastPlayed: null,
+      quest: {...FEATURED_QUESTS.filter((el) => el.title === questTitle)[0], ...questOverrides},
+      onPlay: jasmine.createSpy('onPlay'),
+      onPlaySaved: jasmine.createSpy('onPlaySaved'),
+      onDeleteConfirm: jasmine.createSpy('onDeleteConfirm'),
+      onReturn: jasmine.createSpy('onReturn'),
+      savedTS: null,
+      ...overrides,
+    };
+    const wrapper = render(QuestPreview(props), undefined /*renderOptions*/);
+    return {props, wrapper};
+  }
+
+  it('renders selected quest details', () => {
+    const quest = FEATURED_QUESTS.filter((el) => el.title === 'Learning to Adventure')[0];
+    const {wrapper} = setup(quest.title);
+    expect(wrapper.html()).toContain(quest.title);
+    expect(wrapper.html()).toContain(quest.genre);
+    expect(wrapper.html()).toContain(quest.summary);
+    expect(wrapper.html()).toContain(quest.author);
+    expect(wrapper.html()).toContain(quest.official);
+    expect(wrapper.html()).not.toContain(quest.expansionhorror);
+    expect(wrapper.html()).not.toContain(quest.requirespenpaper);
+    expect(wrapper.html()).not.toContain(quest.awarded);
+  });
+
+  it('shows last played information if it has been played before', () => {
+    const quest = FEATURED_QUESTS.filter((el) => el.title === 'Learning to Adventure')[0];
+    const {wrapper} = setup(quest.title, {lastPlayed: new Date()});
+    expect(wrapper.text().toLowerCase()).toContain('last played');
+  });
+
+  it('does not show last played infomation if it does not exist', () => {
+    const quest = FEATURED_QUESTS.filter((el) => el.title === 'Learning to Adventure')[0];
+    const {wrapper} = setup(quest.title, {lastPlayed: null});
+    expect(wrapper.text().toLowerCase()).not.toContain('last played');
+  });
+
+  it('does not show book icon if it does not exist', () => {
+    const quest = FEATURED_QUESTS.filter((el) => el.title === 'Learning to Adventure')[0];
+    const {wrapper} = setup(quest.title, {}, {requirespenpaper: false});
+    expect(wrapper.html()).not.toContain('book');
+  });
+
+  it('shows a book icon if it exists', () => {
+    const quest = FEATURED_QUESTS.filter((el) => el.title === 'Learning to Adventure')[0];
+    const {wrapper} = setup(quest.title, {}, {requirespenpaper: true});
+    expect(wrapper.html()).toContain('book');
+  });
+
+  it('prompts for user count and multitouch if playing direct linked');
+  it('goes directly to playing quest if not direct linked');
+  it('allows users to go back');
+});

--- a/services/app/src/components/views/QuestPreview.test.tsx
+++ b/services/app/src/components/views/QuestPreview.test.tsx
@@ -1,9 +1,7 @@
 import {configure, render} from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
-import {LanguageType} from 'shared/schema/Constants';
 import {FEATURED_QUESTS} from '../../Constants';
 import {QuestDetails} from '../../reducers/QuestTypes';
-import {SearchSettings} from '../../reducers/StateTypes';
 import QuestPreview, {QuestPreviewProps} from './QuestPreview';
 configure({ adapter: new Adapter() });
 

--- a/services/app/src/components/views/QuestPreview.tsx
+++ b/services/app/src/components/views/QuestPreview.tsx
@@ -1,0 +1,110 @@
+import DoneIcon from '@material-ui/icons/Done';
+import StarsIcon from '@material-ui/icons/Stars';
+import * as React from 'react';
+import {formatPlayPeriod} from '../../Format';
+import {QuestDetails} from '../../reducers/QuestTypes';
+import {SavedQuestMeta, SearchPhase, SearchSettings, SearchState, SettingsType, UserQuestHistory, UserState} from '../../reducers/StateTypes';
+import Button from '../base/Button';
+import Card from '../base/Card';
+import Checkbox from '../base/Checkbox';
+import StarRating from '../base/StarRating';
+
+const Moment = require('moment');
+
+export interface QuestPreviewStateProps {
+  isDirectLinked: boolean;
+  quest: QuestDetails | null;
+  lastPlayed: Date | null;
+  savedTS: number | null;
+}
+
+export interface QuestPreviewDispatchProps {
+  onPlay: (quest: QuestDetails, isDirectLinked: boolean) => void;
+  onPlaySaved: (id: string, ts: number) => void;
+  onDeleteConfirm: () => void;
+  onReturn: () => void;
+}
+
+export interface QuestPreviewProps extends QuestPreviewStateProps, QuestPreviewDispatchProps {}
+
+function renderRequirements(quest: QuestDetails): JSX.Element[] {
+  const requires = [];
+  if (quest.expansionhorror) {
+    requires.push(<span key="horror"><img className="inline_icon" src="images/horror_small.svg"/>The Horror</span>);
+  }
+  if (quest.requirespenpaper) {
+    requires.push(<span key="penpaper"><img className="inline_icon" src="images/book_small.svg"/> Pen and Paper</span>);
+  }
+
+  if (requires.length === 0) {
+    return [<span key={0}>None</span>];
+  }
+
+  const delimited = [];
+  for (let i = 0; i < requires.length; i++) {
+    delimited.push(requires[i]);
+    if (i < requires.length - 1) {
+      delimited.push(<span key={i}>,&nbsp;</span>);
+    }
+  }
+  return delimited;
+}
+
+const QuestPreview = (props: QuestPreviewProps): JSX.Element => {
+  const quest = props.quest;
+  if (!quest) {
+    return <Card title="Quest Details">Loading...</Card>;
+  }
+
+  let actions: JSX.Element;
+  const savedTS = props.savedTS;
+  if (savedTS !== null) {
+    actions = <span>
+      <Button className="bigbutton" onClick={(e) => props.onPlaySaved(quest.id, savedTS)} id="play">Resume</Button>
+      <Button onClick={(e) => props.onDeleteConfirm()} id="play">Delete save</Button>
+      <Button onClick={(e) => props.onReturn()} id="back">Back</Button>
+    </span>;
+  } else {
+    actions = <span>
+      <Button className="bigbutton" onClick={(e) => props.onPlay(quest, props.isDirectLinked)} id="play">Play</Button>
+      <Button id="searchDetailsBackButton" onClick={(e) => props.onReturn()} >Pick a different quest</Button>
+    </span>;
+  }
+
+  const ratingAvg = quest.ratingavg || 0;
+  return (
+    <Card title="Quest Details">
+      <div className="searchDetails">
+        <h2>{quest.title}</h2>
+        <div>{quest.summary}</div>
+        <div className="author">by {quest.author}</div>
+        {savedTS !== null && <div className="summary">Saved {Moment(savedTS).fromNow()}</div>}
+        {(quest.ratingcount && quest.ratingcount >= 1) ? <StarRating readOnly={true} value={+ratingAvg} quantity={quest.ratingcount}/> : ''}
+        <div className="indicators">
+          {props.lastPlayed && <div className="inline_icon"><DoneIcon className="inline_icon" /> Last played {Moment(props.lastPlayed).fromNow()}</div>}
+          {quest.official && <div className="inline_icon"><img className="inline_icon" src="images/compass_small.svg"/> Official Quest!</div>}
+          {quest.awarded && <div className="inline_icon"><StarsIcon className="inline_icon" /> {quest.awarded}</div>}
+        </div>
+      </div>
+      {actions}
+      <div className="searchDetailsExtended">
+        <h3>Details</h3>
+        <table className="searchDetailsTable">
+          <tbody>
+            <tr><th>Requires</th><td>{renderRequirements(quest)}</td></tr>
+            <tr><th>Content rating</th><td>{quest.contentrating}</td></tr>
+            {quest.mintimeminutes !== undefined && quest.maxtimeminutes !== undefined &&
+              <tr><th>Play time</th><td>{formatPlayPeriod(quest.mintimeminutes, quest.maxtimeminutes)}</td></tr>
+            }
+            <tr><th>Players</th><td>{quest.minplayers}-{quest.maxplayers}</td></tr>
+            <tr><th>Genre</th><td>{quest.genre}</td></tr>
+            <tr><th>Language</th><td>{quest.language}</td></tr>
+            <tr><th>Last updated</th><td>{Moment(quest.published).format('MMMM D, YYYY h:mm a')}</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+};
+
+export default QuestPreview;

--- a/services/app/src/components/views/QuestPreview.tsx
+++ b/services/app/src/components/views/QuestPreview.tsx
@@ -3,10 +3,8 @@ import StarsIcon from '@material-ui/icons/Stars';
 import * as React from 'react';
 import {formatPlayPeriod} from '../../Format';
 import {QuestDetails} from '../../reducers/QuestTypes';
-import {SavedQuestMeta, SearchPhase, SearchSettings, SearchState, SettingsType, UserQuestHistory, UserState} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
-import Checkbox from '../base/Checkbox';
 import StarRating from '../base/StarRating';
 
 const Moment = require('moment');

--- a/services/app/src/components/views/QuestPreviewContainer.tsx
+++ b/services/app/src/components/views/QuestPreviewContainer.tsx
@@ -1,0 +1,47 @@
+import {connect} from 'react-redux';
+import Redux from 'redux';
+import {toCard, toPrevious} from '../../actions/Card';
+import {setDialog} from '../../actions/Dialog';
+import {loadSavedQuest} from '../../actions/SavedQuests';
+import {fetchQuestXML} from '../../actions/Web';
+import {QuestDetails} from '../../reducers/QuestTypes';
+import {AppStateWithHistory} from '../../reducers/StateTypes';
+import QuestPreview, {QuestPreviewDispatchProps, QuestPreviewStateProps} from './QuestPreview';
+
+const mapStateToProps = (state: AppStateWithHistory, ownProps: QuestPreviewStateProps): QuestPreviewStateProps => {
+  return {
+    isDirectLinked: state._history.length <= 1,
+    quest: state.quest.details,
+    lastPlayed: (state.questHistory.list[(state.quest.details || {id: '-1'}).id] || {}).lastPlayed,
+    savedTS: state.quest.savedTS,
+  };
+};
+
+const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): QuestPreviewDispatchProps => {
+  return {
+    onPlay: (quest: QuestDetails, isDirectLinked: boolean) => {
+      if (isDirectLinked) {
+        dispatch(setDialog('SET_PLAYER_COUNT'));
+      } else {
+        dispatch(fetchQuestXML(quest));
+      }
+    },
+    onPlaySaved(id: string, ts: number): void {
+      dispatch(loadSavedQuest(id, ts));
+      dispatch(toCard({name: 'QUEST_CARD'}));
+    },
+    onDeleteConfirm(): void {
+      dispatch(setDialog('DELETE_SAVED_QUEST'));
+    },
+    onReturn: () => {
+      dispatch(toPrevious({}));
+    },
+  };
+};
+
+const QuestPreviewContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(QuestPreview);
+
+export default QuestPreviewContainer;

--- a/services/app/src/components/views/SavedQuests.test.tsx
+++ b/services/app/src/components/views/SavedQuests.test.tsx
@@ -13,39 +13,8 @@ function setup(props: Partial<SavedQuestsProps>) {
 describe('SavedQuests', () => {
   it('promps the user when there are no saved quests', () => {
     const {wrapper} = setup({
-      phase: 'LIST',
       saved: [],
-      selected: null,
     });
     expect(wrapper.text()).toContain('You have no saved quests.');
-  });
-  it('shows selected saved quest', () => {
-    const {wrapper} = setup({
-      phase: 'DETAILS',
-      saved: [],
-      selected: {
-        details: {
-          author: 'Test Testerson',
-          contentrating: 'Teen',
-          genre: 'Horror',
-          id: 'test',
-          maxplayers: 5,
-          minplayers: 1,
-          published: Date.now(),
-          summary: 'Test Summary',
-          title: 'Test Quest',
-        } as any as QuestDetails,
-        ts: 12345,
-      },
-    });
-    expect(wrapper.html()).toContain('<h2>Test Quest</h2>');
-  });
-  it('shows loading state when no quest selected', () => {
-    const {wrapper} = setup({
-      phase: 'DETAILS',
-      saved: [],
-      selected: null,
-    });
-    expect(wrapper.text()).toContain('Loading...');
   });
 });

--- a/services/app/src/components/views/SavedQuests.test.tsx
+++ b/services/app/src/components/views/SavedQuests.test.tsx
@@ -1,7 +1,6 @@
 import {configure, render} from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
 import * as React from 'react';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import SavedQuests, {SavedQuestsProps} from './SavedQuests';
 configure({ adapter: new Adapter() });
 

--- a/services/app/src/components/views/SavedQuests.tsx
+++ b/services/app/src/components/views/SavedQuests.tsx
@@ -1,56 +1,21 @@
 import * as React from 'react';
-import {SavedQuestMeta, SelectionListPhase} from '../../reducers/StateTypes';
+import {SavedQuestMeta} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
 
 const Moment = require('moment');
 
 export interface SavedQuestsStateProps {
-  phase: SelectionListPhase;
   saved: SavedQuestMeta[];
-  selected: SavedQuestMeta|null;
 }
 
 export interface SavedQuestsDispatchProps {
   onSelect: (selected: SavedQuestMeta) => void;
-  onPlay: (id: string, ts: number) => void;
-  onDelete: (selected: SavedQuestMeta) => void;
-  onReturn: () => any;
 }
 
 export interface SavedQuestsProps extends SavedQuestsStateProps, SavedQuestsDispatchProps {}
 
-function renderDetails(props: SavedQuestsProps): JSX.Element {
-  const selected = props.selected;
-  if (!selected) {
-    return <Card title="Saved Quest Details">Loading...</Card>;
-  }
-  const quest = selected.details;
-  const expansions = (quest.expansionhorror) ? <span><img className="inline_icon" src="images/horror_small.svg"/>The Horror</span> : 'None';
-  return (
-    <Card title="Saved Quest Details">
-      <div className="searchDetails">
-        <h2>{quest.title}</h2>
-        <div>{quest.summary}</div>
-        <div className="author">by {quest.author}</div>
-        <div className="summary">Saved {Moment(selected.ts).fromNow()}</div>
-      </div>
-      <Button className="bigbutton" onClick={(e) => props.onPlay(selected.details.id, selected.ts)} id="play">Resume</Button>
-      <Button onClick={(e) => props.onDelete(selected)} id="play">Delete save</Button>
-      <Button onClick={(e) => props.onReturn()} id="back">Back</Button>
-      <div className="searchDetailsExtended">
-        <h3>Details</h3>
-        <div><strong>Expansions required: </strong>{expansions}</div>
-        <div><strong>Content rating:</strong> {quest.contentrating}</div>
-        <div><strong>Players:</strong> {quest.minplayers}-{quest.maxplayers}</div>
-        <div><strong>Genre:</strong> {quest.genre}</div>
-        <div><strong>Last updated: </strong> {Moment(quest.published).format('MMMM D, YYYY')}</div>
-      </div>
-    </Card>
-  );
-}
-
-function renderList(props: SavedQuestsProps): JSX.Element {
+const SavedQuests = (props: SavedQuestsProps): JSX.Element => {
   if (props.saved.length === 0) {
     return (
       <Card title="Saved Quests">
@@ -80,17 +45,6 @@ function renderList(props: SavedQuestsProps): JSX.Element {
       {items}
     </Card>
   );
-}
-
-const SavedQuests = (props: SavedQuestsProps): JSX.Element => {
-  switch (props.phase) {
-    case 'LIST':
-      return renderList(props);
-    case 'DETAILS':
-      return renderDetails(props);
-    default:
-      throw new Error('Unknown saved quest phase ' + props.phase);
-  }
 };
 
 export default SavedQuests;

--- a/services/app/src/components/views/SavedQuestsContainer.tsx
+++ b/services/app/src/components/views/SavedQuestsContainer.tsx
@@ -1,7 +1,5 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
-import {toCard, toPrevious} from '../../actions/Card';
-import {setDialog} from '../../actions/Dialog';
 import {previewQuest} from '../../actions/Quest';
 import {AppState, SavedQuestMeta} from '../../reducers/StateTypes';
 import SavedQuests, {SavedQuestsDispatchProps, SavedQuestsStateProps} from './SavedQuests';

--- a/services/app/src/components/views/SavedQuestsContainer.tsx
+++ b/services/app/src/components/views/SavedQuestsContainer.tsx
@@ -2,33 +2,20 @@ import {connect} from 'react-redux';
 import Redux from 'redux';
 import {toCard, toPrevious} from '../../actions/Card';
 import {setDialog} from '../../actions/Dialog';
-import {loadSavedQuest, selectSavedQuest} from '../../actions/SavedQuests';
+import {previewQuest} from '../../actions/Quest';
 import {AppState, SavedQuestMeta} from '../../reducers/StateTypes';
 import SavedQuests, {SavedQuestsDispatchProps, SavedQuestsStateProps} from './SavedQuests';
 
 const mapStateToProps = (state: AppState, ownProps: SavedQuestsStateProps): SavedQuestsStateProps => {
   return {
-    phase: ownProps.phase,
     saved: state.saved.list,
-    selected: state.saved.selected,
   };
 };
 
 export const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): SavedQuestsDispatchProps => {
   return {
-    onPlay(id: string, ts: number): void {
-      dispatch(loadSavedQuest(id, ts));
-      dispatch(toCard({name: 'QUEST_CARD'}));
-    },
-    onDelete(selected: SavedQuestMeta): void {
-      dispatch(setDialog('DELETE_SAVED_QUEST'));
-    },
-    onSelect(selected: SavedQuestMeta): void {
-      dispatch(selectSavedQuest(selected));
-      dispatch(toCard({name: 'SAVED_QUESTS', phase: 'DETAILS'}));
-    },
-    onReturn(): void {
-      dispatch(toPrevious({}));
+    onSelect(saved: SavedQuestMeta): void {
+      dispatch(previewQuest({quest: saved.details, saveTS: saved.ts}));
     },
   };
 };

--- a/services/app/src/components/views/Search.test.tsx
+++ b/services/app/src/components/views/Search.test.tsx
@@ -5,10 +5,7 @@ import {FEATURED_QUESTS} from '../../Constants';
 import {QuestDetails} from '../../reducers/QuestTypes';
 import {SearchSettings} from '../../reducers/StateTypes';
 import {
-  formatPlayPeriod,
-  renderDetails,
   renderResult,
-  SearchDetailsProps,
   SearchResultProps,
   smartTruncateSummary,
 } from './Search';
@@ -26,13 +23,6 @@ const TEST_SEARCH: SearchSettings = {
 };
 
 describe('Search', () => {
-  it('formats time ranges to minutes and hours', () => {
-    expect(formatPlayPeriod(30, 60)).toEqual('30-60 min');
-    expect(formatPlayPeriod(30, 120)).toEqual('30-120 min');
-    expect(formatPlayPeriod(60, 120)).toEqual('1-2 hrs');
-    expect(formatPlayPeriod(999, 999)).toEqual('2+ hrs');
-  });
-
   describe('Settings', () => {
     /*
     function setup() {
@@ -124,62 +114,6 @@ describe('Search', () => {
   describe('Results', () => {
     it('gracefully handles no search results');
     it('renders some search results');
-  });
-
-  describe('Details', () => {
-    function setup(questTitle: string, overrides?: Partial<SearchDetailsProps>, questOverrides?: Partial<QuestDetails>) {
-      const props: SearchDetailsProps = {
-        isDirectLinked: false,
-        lastPlayed: null,
-        quest: {...FEATURED_QUESTS.filter((el) => el.title === questTitle)[0], ...questOverrides},
-        onPlay: jasmine.createSpy('onPlay'),
-        onReturn: jasmine.createSpy('onReturn'),
-        ...overrides,
-      };
-      const wrapper = render(renderDetails(props), undefined /*renderOptions*/);
-      return {props, wrapper};
-    }
-
-    it('renders selected quest details', () => {
-      const quest = FEATURED_QUESTS.filter((el) => el.title === 'Learning to Adventure')[0];
-      const {wrapper} = setup(quest.title);
-      expect(wrapper.html()).toContain(quest.title);
-      expect(wrapper.html()).toContain(quest.genre);
-      expect(wrapper.html()).toContain(quest.summary);
-      expect(wrapper.html()).toContain(quest.author);
-      expect(wrapper.html()).toContain(quest.official);
-      expect(wrapper.html()).not.toContain(quest.expansionhorror);
-      expect(wrapper.html()).not.toContain(quest.requirespenpaper);
-      expect(wrapper.html()).not.toContain(quest.awarded);
-    });
-
-    it('shows last played information if it has been played before', () => {
-      const quest = FEATURED_QUESTS.filter((el) => el.title === 'Learning to Adventure')[0];
-      const {wrapper} = setup(quest.title, {lastPlayed: new Date()});
-      expect(wrapper.text().toLowerCase()).toContain('last played');
-    });
-
-    it('does not show last played infomation if it does not exist', () => {
-      const quest = FEATURED_QUESTS.filter((el) => el.title === 'Learning to Adventure')[0];
-      const {wrapper} = setup(quest.title, {lastPlayed: null});
-      expect(wrapper.text().toLowerCase()).not.toContain('last played');
-    });
-
-    it('does not show book icon if it does not exist', () => {
-      const quest = FEATURED_QUESTS.filter((el) => el.title === 'Learning to Adventure')[0];
-      const {wrapper} = setup(quest.title, {}, {requirespenpaper: false});
-      expect(wrapper.html()).not.toContain('book');
-    });
-
-    it('shows a book icon if it exists', () => {
-      const quest = FEATURED_QUESTS.filter((el) => el.title === 'Learning to Adventure')[0];
-      const {wrapper} = setup(quest.title, {}, {requirespenpaper: true});
-      expect(wrapper.html()).toContain('book');
-    });
-
-    it('prompts for user count and multitouch if playing direct linked');
-    it('goes directly to playing quest if not direct linked');
-    it('allows users to go back');
   });
 
   describe('smartTruncateSummary', () => {

--- a/services/app/src/components/views/SearchContainer.tsx
+++ b/services/app/src/components/views/SearchContainer.tsx
@@ -2,7 +2,8 @@ import {connect} from 'react-redux';
 import Redux from 'redux';
 import {toCard, toPrevious} from '../../actions/Card';
 import {setDialog} from '../../actions/Dialog';
-import {search, viewQuest} from '../../actions/Search';
+import {previewQuest} from '../../actions/Quest';
+import {search} from '../../actions/Search';
 import {ensureLogin} from '../../actions/User';
 import {fetchQuestXML, subscribe} from '../../actions/Web';
 import {QuestDetails} from '../../reducers/QuestTypes';
@@ -43,7 +44,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Searc
       }
     },
     onQuest: (quest: QuestDetails) => {
-      dispatch(viewQuest({quest}));
+      dispatch(previewQuest({quest}));
     },
     onReturn: () => {
       dispatch(toPrevious({}));

--- a/services/app/src/reducers/CombinedReducers.tsx
+++ b/services/app/src/reducers/CombinedReducers.tsx
@@ -109,6 +109,7 @@ export default function combinedReducerWithHistory(state: AppStateWithHistory, a
         commitID: state.commitID,
         multiplayer: state.multiplayer,
         saved: state.saved,
+        questHistory: state.questHistory,
         settings: state.settings,
         user: state.user,
       } as AppStateWithHistory;
@@ -126,6 +127,7 @@ export default function combinedReducerWithHistory(state: AppStateWithHistory, a
         _return: undefined,
         multiplayer: undefined,
         saved: undefined,
+        questHistory: undefined,
         settings: undefined,
       } as AppStateBase);
     }

--- a/services/app/src/reducers/Quest.tsx
+++ b/services/app/src/reducers/Quest.tsx
@@ -1,6 +1,6 @@
 import Redux from 'redux';
 import * as seedrandom from 'seedrandom';
-import {QuestDetailsAction, QuestNodeAction, ViewQuestAction} from '../actions/ActionTypes';
+import {PreviewQuestAction, QuestDetailsAction, QuestNodeAction} from '../actions/ActionTypes';
 import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {QuestState} from './StateTypes';
 
@@ -31,6 +31,8 @@ export const initialQuestState: QuestState = {
     templates: {},
     views: {},
   }),
+  lastPlayed: null,
+  savedTS: null,
   seed: autoseed(),
 };
 
@@ -46,8 +48,15 @@ export function quest(state: QuestState = initialQuestState, action: Redux.Actio
         node: (action as QuestNodeAction).node,
         seed: autoseed(),
       };
-    case 'VIEW_QUEST':
-      return {...state, details: (action as ViewQuestAction).quest, seed: autoseed()};
+    case 'PREVIEW_QUEST':
+      const pqa = action as PreviewQuestAction;
+      return {
+        ...state,
+        details: pqa.quest,
+        lastPlayed: pqa.lastPlayed || null,
+        savedTS: pqa.savedTS || null,
+        seed: autoseed(),
+      };
     default:
       return state;
   }

--- a/services/app/src/reducers/QuestHistory.tsx
+++ b/services/app/src/reducers/QuestHistory.tsx
@@ -5,13 +5,10 @@ import {UserQuestHistory} from './StateTypes';
 
 const initialHistoryState: UserQuestHistory = {
   list: {},
-  selected: null,
 };
 
 export function questhistory(state: UserQuestHistory = initialHistoryState, action: Redux.Action): UserQuestHistory {
   switch (action.type) {
-    case 'USER_QUEST_INSTANCE_SELECT':
-      return {...state, selected: (action as UserQuestInstanceSelect).selected || null};
     case 'USER_QUESTS':
       return {...state, list: (action as UserQuestsAction).quests};
     case 'USER_QUESTS_DELTA':

--- a/services/app/src/reducers/QuestHistory.tsx
+++ b/services/app/src/reducers/QuestHistory.tsx
@@ -1,6 +1,6 @@
 import merge from 'deepmerge';
 import Redux from 'redux';
-import {UserQuestInstanceSelect, UserQuestsAction, UserQuestsDeltaAction} from '../actions/ActionTypes';
+import {UserQuestsAction, UserQuestsDeltaAction} from '../actions/ActionTypes';
 import {UserQuestHistory} from './StateTypes';
 
 const initialHistoryState: UserQuestHistory = {

--- a/services/app/src/reducers/Saved.tsx
+++ b/services/app/src/reducers/Saved.tsx
@@ -1,10 +1,9 @@
 import Redux from 'redux';
-import {SavedQuestListAction, SavedQuestSelectedAction} from '../actions/ActionTypes';
+import {PreviewQuestAction, SavedQuestListAction} from '../actions/ActionTypes';
 import {SavedQuestState} from './StateTypes';
 
 const initialSavedState: SavedQuestState = {
   list: [],
-  selected: null,
 };
 
 export function saved(state: SavedQuestState = initialSavedState, action: Redux.Action): SavedQuestState {
@@ -14,8 +13,6 @@ export function saved(state: SavedQuestState = initialSavedState, action: Redux.
     case 'SAVED_QUEST_STORED':
       // All these actions have the same savedQuests signature
       return {...state, list: [...(action as SavedQuestListAction).savedQuests]};
-    case 'SAVED_QUEST_SELECTED':
-      return {...state, selected: (action as SavedQuestSelectedAction).selected};
     default:
       return state;
   }

--- a/services/app/src/reducers/Saved.tsx
+++ b/services/app/src/reducers/Saved.tsx
@@ -1,5 +1,5 @@
 import Redux from 'redux';
-import {PreviewQuestAction, SavedQuestListAction} from '../actions/ActionTypes';
+import {SavedQuestListAction} from '../actions/ActionTypes';
 import {SavedQuestState} from './StateTypes';
 
 const initialSavedState: SavedQuestState = {

--- a/services/app/src/reducers/Search.tsx
+++ b/services/app/src/reducers/Search.tsx
@@ -1,5 +1,5 @@
 import Redux from 'redux';
-import {SearchResponseAction, ViewQuestAction} from '../actions/ActionTypes';
+import {SearchResponseAction} from '../actions/ActionTypes';
 import {SearchState} from './StateTypes';
 
 export const initialSearch: SearchState = {
@@ -10,14 +10,13 @@ export const initialSearch: SearchState = {
     text: '',
   },
   searching: false,
-  selected: null,
 };
 
 export function search(state: SearchState = initialSearch, action: Redux.Action): SearchState {
   switch (action.type) {
     case 'SEARCH_REQUEST':
       // Clear the searched quests if we're starting a new search.
-      return {...state, results: [], selected: null, searching: true};
+      return {...state, results: [], searching: true};
     case 'SEARCH_ERROR':
       return {...state, searching: false};
     case 'SEARCH_RESPONSE':
@@ -26,8 +25,6 @@ export function search(state: SearchState = initialSearch, action: Redux.Action)
         search: (action as SearchResponseAction).search,
         searching: false,
       };
-    case 'VIEW_QUEST':
-      return {...state, selected: (action as ViewQuestAction).quest};
     default:
       return state;
   }

--- a/services/app/src/reducers/StateTypes.tsx
+++ b/services/app/src/reducers/StateTypes.tsx
@@ -42,7 +42,7 @@ export interface EndSettings {
   text: string;
 }
 
-export type SearchPhase = 'DISCLAIMER' | 'SETTINGS' | 'DETAILS' | 'SEARCH' | 'PRIVATE';
+export type SearchPhase = 'DISCLAIMER' | 'SETTINGS' | 'SEARCH' | 'PRIVATE';
 
 export interface SearchSettings {
   [index: string]: any;
@@ -98,12 +98,24 @@ export interface SavedQuestMeta {
   ts: number;
 }
 
-export type SelectionListPhase = 'LIST' | 'DETAILS';
-
 export type MultiplayerPhase = 'CONNECT'|'LOBBY';
 export type CheckoutPhase = 'ENTRY' | 'DONE';
-export type CardName = 'QUEST_HISTORY' | 'SAVED_QUESTS' | 'CHECKOUT' | 'PLAYER_COUNT_SETTING' | 'QUEST_SETUP' | 'QUEST_END' | 'QUEST_CARD' | 'FEATURED_QUESTS' | 'SPLASH_CARD' | 'SEARCH_CARD' | 'SETTINGS' | 'ADVANCED' | 'REMOTE_PLAY';
-export type CardPhase = TemplatePhase | SearchPhase | MultiplayerPhase | CheckoutPhase | SelectionListPhase;
+export type CardName =
+  'QUEST_PREVIEW' |
+  'QUEST_HISTORY' |
+  'SAVED_QUESTS' |
+  'CHECKOUT' |
+  'PLAYER_COUNT_SETTING' |
+  'QUEST_SETUP' |
+  'QUEST_END' |
+  'QUEST_CARD' |
+  'FEATURED_QUESTS' |
+  'SPLASH_CARD' |
+  'SEARCH_CARD' |
+  'SETTINGS' |
+  'ADVANCED' |
+  'REMOTE_PLAY';
+export type CardPhase = TemplatePhase | SearchPhase | MultiplayerPhase | CheckoutPhase;
 export interface CardState {
   questId: string;
   name: CardName;
@@ -119,16 +131,18 @@ export interface QuestState {
   details: QuestDetails;
   node: ParserNode;
   seed: string;
+  // Additional details populated depending on from where
+  // the user approaches the quest
+  lastPlayed: Date|null;
+  savedTS: number|null;
 }
 
 export interface SavedQuestState {
   list: SavedQuestMeta[];
-  selected: SavedQuestMeta|null;
 }
 
 export interface SearchState {
   search: SearchSettings;
-  selected: QuestDetails|null;
   results: QuestDetails[];
   searching: boolean;
 }
@@ -152,7 +166,6 @@ export interface UserState {
 
 export interface UserQuestHistory {
   list: UserQuestsType;
-  selected: UserQuestInstance|null;
 }
 
 export type FeedbackType = 'feedback'|'rating'|'report_error'|'report_quest';
@@ -192,13 +205,13 @@ export interface AppStateBase {
   search: SearchState;
   snackbar: SnackbarState;
   user: UserState;
-  questHistory: UserQuestHistory;
   commitID: number;
 }
 
 export interface AppState extends AppStateBase {
   settings: SettingsType;
   multiplayer: MultiplayerState;
+  questHistory: UserQuestHistory;
   saved: SavedQuestState;
 }
 


### PR DESCRIPTION
- There's now a "QuestPreview" component and container that shows quest metadata. This dedupes similar logic in saved quests, quest history, featured quests, and search.
- Quest history didn't persisting when a user selected "Home" because it was counted as back-button-able... fixed this.
- FeaturedQuests interface had several dispatchers that called toCard under the hood; exposed a toCard dispatch function to reduce boilerplate.
- Redux complained about buttons within buttons when we used the StarRating component inside of a clickable quest list item; made the buttons render in a div when they're not interactive to fix this.
- Redux complained about list items when showing requirements for quests (e.g. pen & paper); I todo'd the todo comment on making this logic better.