### PR TITLE
consolidate webpack files

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "webpack": "^4.12.1",
     "webpack-cli": "^3.0.7",
     "webpack-dev-server": "^3.1.4",
+    "webpack-merge": "^4.1.3",
     "whatwg-fetch": "^2.0.4",
     "winston": "^2.4.2",
     "ws": "^5.0.0"

--- a/services/admin/src/Globals.tsx
+++ b/services/admin/src/Globals.tsx
@@ -2,8 +2,6 @@ declare var device: any;
 declare var ga: any;
 declare var gapi: any;
 
-const PACKAGE = require('../package.json');
-
 export interface ReactDocument extends Document {
   addEventListener: (e: string, f: (this: any, ev: MouseEvent) => any, useCapture?: boolean) => void;
   dispatchEvent: (e: Event) => boolean;
@@ -54,8 +52,4 @@ export function getGA(): any {
 
 export function getGapi(): any {
   return refs.gapi;
-}
-
-export function getAppVersion(): string {
-  return PACKAGE.version;
 }

--- a/services/admin/webpack.config.js
+++ b/services/admin/webpack.config.js
@@ -1,64 +1,20 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const Path = require('path');
 const Webpack = require('webpack');
-
-const port = process.env.DOCKER_PORT || 8080;
+const Merge = require('webpack-merge');
+const shared = require('../../shared/webpack.shared');
 
 const options = {
-  mode: 'development',
-  cache: true,
   entry: {
     bundle: [
-      'webpack-dev-server/client?http://localhost:' + port,
-      'webpack/hot/only-dev-server',
       './src/React.tsx',
       './src/Style.scss',
     ],
   },
-  resolve: {
-    extensions: ['.js', '.ts', '.tsx', '.json', '.txt'],
-  },
-  devServer: {
-    host: '0.0.0.0',
-    disableHostCheck: true,
-    contentBase: Path.join(__dirname, 'src'),
-    publicPath: '/',
-    port: port,
-    hot: true,
-    quiet: false,
-    noInfo: false,
-    historyApiFallback: true,
-  },
-  output: {
-    path: Path.join(__dirname, 'dist'),
-    publicPath: 'http://localhost:' + port + '/',
-    filename: '[name].js',
-  },
-  stats: {
-    colors: true,
-    reasons: true,
-  },
-  module: {
-    rules: [
-      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader' },
-      { test: /\.(ttf|eot|svg|png|gif|jpe?g|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader : 'file-loader' },
-      { test: /\.scss$/, loader: 'style-loader!css-loader!sass-loader' },
-      { test: /\.tsx$/, loaders: ['react-hot-loader/webpack', 'awesome-typescript-loader'], exclude: /\/node_modules\/((?!expedition\-api).)*$/ },
-    ]
-  },
   plugins: [
-    new Webpack.HotModuleReplacementPlugin(),
-    new Webpack.DefinePlugin({
-      'process.env': {
-        'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
-        'API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
-      },
-    }),
     new CopyWebpackPlugin([
-      { from: 'src/index.html' },
       { from: 'src/assets' },
     ]),
   ],
 };
 
-module.exports = options
+module.exports = Merge(shared, options);

--- a/services/admin/webpack.dist.config.js
+++ b/services/admin/webpack.dist.config.js
@@ -1,55 +1,25 @@
-// This config is run to compile and export the production environment to the dist/ folder.
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const Path = require('path');
 const Webpack = require('webpack');
+const Merge = require('webpack-merge');
+const shared = require('../../shared/webpack.dist.shared');
+const dev = require('./webpack.config');
+
+// TODO this does not export images to static/ for maintenance pages,
+// but attempting to do so then breaks export to dist/
+// Will be auto-fixed when we migrate all static pages to quests.expedition
+// In the mean time, can manually copy images over when deploying static files
 
 const options = {
-  mode: 'production',
-  entry: {
-    bundle: [
-      './src/React.tsx',
-      './src/Style.scss',
-    ],
-  },
-  resolve: {
-    extensions: ['.js', '.ts', '.tsx', '.json', '.txt'],
-  },
-  output: {
-    path: __dirname,
-    filename: 'dist/[name].js',
-  },
-  module: {
-    loaders: [
-      { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
-      // TODO this does not export images to static/ for maintenance pages,
-      // but attempting to do so then breaks export to dist/
-      // Will be auto-fixed when we migrate all static pages to quests.expedition
-      // In the mean time, can manually copy images over when deploying static files
-      { test: /\.(ttf|eot|svg|png|gif|jpe?g|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader : 'file-loader?outputPath=dist/' },
-      { test: /\.scss$/, loader: 'style-loader!css-loader!sass-loader' },
-      { test: /\.tsx$/, loaders: ['awesome-typescript-loader'], exclude: /\/node_modules\/((?!expedition\-api).)*$/ },
-    ],
-  },
+  entry: dev.entry,
   plugins: [
-    new Webpack.optimize.AggressiveMergingPlugin(),
-    new Webpack.DefinePlugin({
-      'process.env': {
-        // Default to beta for safety
-        'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
-        'API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
-      }
-    }),
     new CopyWebpackPlugin([
-      // Copy ops for dist folder (main app)
-      { from: 'src/index.html', to: 'dist' },
-      { from: 'src/assets', to: 'dist' },
       { from: 'src/scripts', to: 'dist/scripts' },
 
       // Copy ops for static folder (error/maintenance pages)
-      { from: 'src/error.html', to: 'dist' },
-      { from: 'src/maintenance.html', to: 'dist' },
+      { from: 'src/error.html' },
+      { from: 'src/maintenance.html' },
     ]),
   ],
 };
 
-module.exports = options;
+module.exports = Merge(shared, options);

--- a/services/api/webpack.dist.config.js
+++ b/services/api/webpack.dist.config.js
@@ -1,3 +1,8 @@
+// This does not use the shared webpack config
+// Because it is an entirely different use case
+// Most importantly - because it is deployed on Heroku
+// which has memory constraints and does not benefit from minification, etc
+
 const Path = require('path');
 const Webpack = require('webpack');
 
@@ -40,11 +45,6 @@ const options = {
     minimize: false,
   },
   externals: {'pg': "require('pg')", 'sqlite3': "require('sqlite3')", 'tedious': "require('tedious')", 'pg-hstore': "require('pg-hstore')"},
-  plugins: [
-    new Webpack.DefinePlugin({
-      VERSION: JSON.stringify(require('./package.json').version)
-    }),
-  ],
 };
 
 module.exports = options;

--- a/services/app/src/Constants.tsx
+++ b/services/app/src/Constants.tsx
@@ -1,8 +1,6 @@
 import {QuestDetails} from './reducers/QuestTypes';
 
-declare var PACKAGE_VERSION: string;
-
-export const VERSION = PACKAGE_VERSION; // Webpack
+export const VERSION = (process && process.env && process.env.VERSION) || '0.0.1'; // Webpack
 export const NODE_ENV = (process && process.env && process.env.NODE_ENV) || 'dev';
 // Should be overriden via env vars to use local server
 export const API_HOST = (process && process.env && process.env.API_HOST) || 'http://betaapi.expeditiongame.com';

--- a/services/app/src/Constants.tsx
+++ b/services/app/src/Constants.tsx
@@ -1,5 +1,8 @@
 import {QuestDetails} from './reducers/QuestTypes';
 
+declare var PACKAGE_VERSION: string;
+
+export const VERSION = PACKAGE_VERSION; // Webpack
 export const NODE_ENV = (process && process.env && process.env.NODE_ENV) || 'dev';
 // Should be overriden via env vars to use local server
 export const API_HOST = (process && process.env && process.env.API_HOST) || 'http://betaapi.expeditiongame.com';

--- a/services/app/src/Globals.test.tsx
+++ b/services/app/src/Globals.test.tsx
@@ -1,4 +1,4 @@
-import {getAppVersion, getDevicePlatform, setDevice} from './Globals';
+import {getDevicePlatform, setDevice} from './Globals';
 
 describe('Globals', () => {
 
@@ -22,12 +22,6 @@ describe('Globals', () => {
     it('reports android if android device initialized', () => {
       setDevice({platform: 'android'});
       expect(getDevicePlatform()).toEqual('android');
-    });
-  });
-
-  describe('getAppVersion', () => {
-    it('gets a version string', () => {
-      expect(getAppVersion()).toMatch(/[0-9]+\.[0-9]+\.[0-9]+/);
     });
   });
 });

--- a/services/app/src/Globals.tsx
+++ b/services/app/src/Globals.tsx
@@ -2,12 +2,6 @@ declare var device: any;
 declare var ga: any;
 declare var gapi: any;
 
-const PACKAGE = require('../package.json');
-
-export function getAppVersion(): string {
-  return PACKAGE.version;
-}
-
 export interface ReactDocument extends Document {
   addEventListener: (e: string, f: (this: any, ev: MouseEvent) => any,
                      useCapture?: boolean) => void;
@@ -23,7 +17,7 @@ export interface CordovaLoginPlugin {
 
 export interface ReactWindow extends Window {
   platform?: string;
-  APP_VERSION?: string;
+  VERSION?: string;
   AndroidFullScreen?: {
     immersiveMode: (success: () => any, failure: () => any) => void,
   };

--- a/services/app/src/Init.tsx
+++ b/services/app/src/Init.tsx
@@ -22,8 +22,8 @@ import {searchAndPlay} from './actions/Search';
 import {changeSettings} from './actions/Settings';
 import {openSnackbar} from './actions/Snackbar';
 import {silentLogin} from './actions/User';
-import {AUTH_SETTINGS, INIT_DELAY, NODE_ENV, UNSUPPORTED_BROWSERS} from './Constants';
-import {getAppVersion, getDevicePlatform, getDocument, getNavigator, getWindow, setGA} from './Globals';
+import {AUTH_SETTINGS, INIT_DELAY, NODE_ENV, UNSUPPORTED_BROWSERS, VERSION} from './Constants';
+import {getDevicePlatform, getDocument, getNavigator, getWindow, setGA} from './Globals';
 import {getStorageBoolean} from './LocalStorage';
 import {SettingsType} from './reducers/StateTypes';
 import {getStore} from './Store';
@@ -58,7 +58,7 @@ declare module 'redux' {
 
 Raven.config(AUTH_SETTINGS.RAVEN, {
     environment: NODE_ENV,
-    release: getAppVersion(),
+    release: VERSION,
     shouldSendCallback(data) {
       const supportedBrowser = !UNSUPPORTED_BROWSERS.test(getNavigator().userAgent);
       return supportedBrowser && NODE_ENV !== 'dev' && !getStore().getState().settings.simulator;
@@ -147,7 +147,7 @@ function setupGoogleAnalytics() {
   ReactGA.initialize('UA-47408800-9', {
     gaOptions: {
       appName: getDevicePlatform(),
-      appVersion: getAppVersion(),
+      appVersion: VERSION,
     },
     titleCase: false,
   });

--- a/services/app/src/actions/Announcement.tsx
+++ b/services/app/src/actions/Announcement.tsx
@@ -1,7 +1,7 @@
 import Redux from 'redux';
 import * as semver from 'semver';
-import {AUTH_SETTINGS, URLS} from '../Constants';
-import {getAppVersion, getDevicePlatform} from '../Globals';
+import {AUTH_SETTINGS, URLS, VERSION} from '../Constants';
+import {getDevicePlatform} from '../Globals';
 import {logEvent} from '../Logging';
 import {AnnouncementSetAction, FetchAnnouncementResponse} from './ActionTypes';
 import {handleFetchErrors} from './Web';
@@ -26,7 +26,7 @@ export function handleAnnouncements(data: FetchAnnouncementResponse) {
       dispatch(setAnnouncement(true, data.message, data.link));
     } else {
       const newVersion = data.versions[getDevicePlatform()];
-      const oldVersion = getAppVersion();
+      const oldVersion = VERSION;
       if (semver.valid(newVersion) && semver.valid(oldVersion)) {
         if (semver.gt(newVersion, oldVersion)) {
           const url = URLS[getDevicePlatform()];

--- a/services/app/src/actions/Web.tsx
+++ b/services/app/src/actions/Web.tsx
@@ -2,8 +2,8 @@ import Redux from 'redux';
 import {defaultContext} from '../components/views/quest/cardtemplates/Template';
 import {ParserNode, TemplateContext} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {MIN_FEEDBACK_LENGTH} from '../Constants';
-import {AUTH_SETTINGS} from '../Constants';
-import {getAppVersion, getDevicePlatform, getPlatformDump} from '../Globals';
+import {AUTH_SETTINGS, VERSION} from '../Constants';
+import {getDevicePlatform, getPlatformDump} from '../Globals';
 import {logEvent} from '../Logging';
 import {getLogBuffer} from '../Logging';
 import {MultiplayerCounters} from '../Multiplayer';
@@ -102,7 +102,7 @@ export function logQuestPlay(a: {phase: 'start'|'end'}) {
         questid: quest.id,
         questversion: quest.questversion,
         userid: state.user.id,
-        version: getAppVersion(),
+        version: VERSION,
       };
       fetch(AUTH_SETTINGS.URL_BASE + '/analytics/quest/' + a.phase, {
         body: JSON.stringify(data),
@@ -169,7 +169,7 @@ export function submitUserFeedback(a: {quest: QuestState, settings: SettingsType
       rating: a.rating,
       text: a.text,
       userid: a.user.id,
-      version: getAppVersion(),
+      version: VERSION,
     };
 
     // If we're not rating, we're providing other feedback.
@@ -229,7 +229,7 @@ export function logMultiplayerStats(user: UserState, quest: QuestDetails, stats:
       questid: quest.id,
       questversion: quest.questversion,
       userid: user.id,
-      version: getAppVersion(),
+      version: VERSION,
     };
 
     return fetch(AUTH_SETTINGS.URL_BASE + '/analytics/multiplayer/stats', {

--- a/services/app/src/components/views/Tools.tsx
+++ b/services/app/src/components/views/Tools.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import {NODE_ENV} from '../../Constants';
-import {getAppVersion, openWindow} from '../../Globals';
+import {NODE_ENV, VERSION} from '../../Constants';
+import {openWindow} from '../../Globals';
 import {SettingsType, UserState} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
@@ -56,7 +56,7 @@ const Tools = (props: ToolsProps): JSX.Element => {
           <Button onClick={() => props.testMusic()}>Set Music Intensity</Button>
         </div>
       }
-      <div className="version">Expedition App v{getAppVersion()}</div>
+      <div className="version">Expedition App v{VERSION}</div>
       <div className="privacy"><a href="#" onClick={() => openWindow('https://expeditiongame.com/privacy')}>Privacy Policy</a></div>
     </Card>
   );

--- a/services/app/webpack.config.js
+++ b/services/app/webpack.config.js
@@ -12,7 +12,7 @@ const options = {
   },
   plugins: [
     new Webpack.DefinePlugin({
-      PACKAGE_VERSION: JSON.stringify(require('./package.json').version),
+      'process.env.VERSION': JSON.stringify(require('./package.json').version),
     }),
     new CopyWebpackPlugin([
       { from: { glob: '../../node_modules/expedition-art/icons/*.svg' }, flatten: true, to: './images' },

--- a/services/app/webpack.config.js
+++ b/services/app/webpack.config.js
@@ -1,72 +1,24 @@
-const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const Path = require('path');
-const port = process.env.DOCKER_PORT || 8082;
+const Webpack = require('webpack');
+const Merge = require('webpack-merge');
+const shared = require('../../shared/webpack.shared');
 
 const options = {
-  mode: 'development',
-  cache: true,
-  entry: [
-    'whatwg-fetch',
-    'promise-polyfill',
-    'webpack-dev-server/client?http://localhost:' + port,
-    'webpack/hot/only-dev-server',
+  entry: {
+    bundle: [
     './src/Init.tsx',
     './src/Style.scss',
-  ],
-  resolve: {
-    extensions: ['.js', '.ts', '.tsx', '.json'],
-  },
-  devServer: {
-    host: '0.0.0.0',
-    contentBase: Path.join(__dirname, "src"),
-    disableHostCheck: true,
-    publicPath: '/',
-    port: port,
-    hot: true,
-    quiet: false,
-    noInfo: false,
-    historyApiFallback: true
-  },
-  output: {
-    path: Path.join(__dirname, 'dist'),
-    filename: 'bundle.js',
-  },
-  stats: {
-    colors: true,
-    reasons: true
-  },
-  module: {
-    rules: [
-      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader', options: {fix: true}},
-      { test: /\.(ttf|eot|svg|png|gif|jpe?g|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader: 'file-loader',
-        options: { name: '[name].[ext]' }, // disable filename hashing for infrequently changed static assets to enable preloading
-      },
-      { test: /\.scss$/, loader: 'style-loader!css-loader!sass-loader' },
-      { test: /\.tsx$/, loaders: ['react-hot-loader/webpack', 'awesome-typescript-loader'], exclude: /node_modules/ },
     ],
   },
   plugins: [
-    new webpack.DefinePlugin({
-      'process.env': {
-        'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
-        'API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
-        'OAUTH2_CLIENT_ID': JSON.stringify(process.env.OAUTH2_CLIENT_ID || '545484140970-jq9jp7gdqdugil9qoapuualmkupigpdl.apps.googleusercontent.com'),
-      },
+    new Webpack.DefinePlugin({
+      PACKAGE_VERSION: JSON.stringify(require('./package.json').version),
     }),
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), // Don't import bloated Moment locales
     new CopyWebpackPlugin([
       { from: { glob: '../../node_modules/expedition-art/icons/*.svg' }, flatten: true, to: './images' },
       { from: { glob: '../../node_modules/expedition-art/art/*.png' }, flatten: true, to: './images' },
     ]),
-    new webpack.HotModuleReplacementPlugin(),
   ],
-  node: {
-    console: true,
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty',
-  },
 }
 
-module.exports = options;
+module.exports = Merge(shared, options);

--- a/services/app/webpack.dist.config.js
+++ b/services/app/webpack.dist.config.js
@@ -1,49 +1,24 @@
-const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const Merge = require('webpack-merge');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const Webpack = require('webpack');
+const shared = require('../../shared/webpack.dist.shared');
+const dev = require('./webpack.config');
 
 const options = {
-  mode: 'production',
-  entry: [
-    'whatwg-fetch',
-    'promise-polyfill',
-    './src/Init.tsx',
-    './src/Style.scss',
-  ],
-  resolve: {
-    extensions: ['.js', '.ts', '.tsx', '.json'],
-  },
+  entry: dev.entry,
   output: {
     path: __dirname + '/www/',
-    filename: 'bundle.js',
   },
-  module: {
-    rules: [
-      { test: /\.(ttf|eot|svg|png|gif|jpe?g|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader : 'file-loader',
-        options: { name: '[name].[ext]' }, // disable filename hashing for infrequently changed static assets to enable preloading
-      },
-      { test: /\.scss$/, loader: 'style-loader!css-loader!sass-loader' },
-      { test: /\.tsx$/, loaders: ['awesome-typescript-loader'], exclude: /node_modules\/((?!expedition\-qdl).)*$/ },
-    ],
-  },
-  devtool: 'source-map',
   plugins: [
-    new webpack.DefinePlugin({
-      'process.env': {
-        // Default to dev for safety
-        'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
-        'API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
-        'OAUTH2_CLIENT_ID': JSON.stringify(process.env.OAUTH2_CLIENT_ID || '545484140970-jq9jp7gdqdugil9qoapuualmkupigpdl.apps.googleusercontent.com'),
-      },
+    new Webpack.DefinePlugin({
+      PACKAGE_VERSION: JSON.stringify(require('./package.json').version),
     }),
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), // Don't import bloated Moment locales
-    new webpack.optimize.AggressiveMergingPlugin(),
     new CopyWebpackPlugin([
-      { from: 'src/images', to: 'images'},
-      { from: 'src/quests', to: 'quests'},
-      { from: 'src/index.html' },
       { from: 'src/robots.txt' },
       { from: 'src/manifest.json' },
+      { from: 'src/images', to: 'images'},
+      { from: 'src/quests', to: 'quests'},
       { from: { glob: '**/*.mp3' }, context: 'src/audio', to: './audio' },
       { from: { glob: '../../node_modules/expedition-art/icons/*.svg' }, flatten: true, to: './images' },
       { from: { glob: '../../node_modules/expedition-art/art/*.png' }, flatten: true, to: './images' },
@@ -66,4 +41,4 @@ const options = {
   },
 };
 
-module.exports = options;
+module.exports = Merge(shared, options);

--- a/services/app/webpack.dist.config.js
+++ b/services/app/webpack.dist.config.js
@@ -12,7 +12,7 @@ const options = {
   },
   plugins: [
     new Webpack.DefinePlugin({
-      PACKAGE_VERSION: JSON.stringify(require('./package.json').version),
+      'process.env.VERSION': JSON.stringify(require('./package.json').version),
     }),
     new CopyWebpackPlugin([
       { from: 'src/robots.txt' },

--- a/services/cards/beta.sh
+++ b/services/cards/beta.sh
@@ -7,7 +7,7 @@
 read -p "This will remove built files, rebuild, and deploy to S3. Continue? [Y/N]" -n 1 -r
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-  rm -rf www
+  rm -rf dist
 
   # Rebuild the web app files
   export NODE_ENV='dev'
@@ -15,5 +15,5 @@ then
 
   # Deploy web app to beta once apps built
   export AWS_DEFAULT_REGION='us-east-2'
-  aws s3 cp www s3://betacards.expeditiongame.com --recursive
+  aws s3 cp dist s3://betacards.expeditiongame.com --recursive
 fi

--- a/services/cards/prod.sh
+++ b/services/cards/prod.sh
@@ -5,7 +5,7 @@
 read -p "Did you test a quest on the beta build? (y/N) " -n 1
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-  rm -rf www
+  rm -rf dist
 
   # Rebuild the web app files
   export NODE_ENV='production'
@@ -13,7 +13,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 
   # Deploy web app to prod once apps built
   export AWS_DEFAULT_REGION='us-east-2'
-  aws s3 cp www s3://cards.expeditiongame.com --recursive
+  aws s3 cp dist s3://cards.expeditiongame.com --recursive
 else
   echo "Prod build cancelled until tested on beta."
 fi

--- a/services/cards/webpack.config.js
+++ b/services/cards/webpack.config.js
@@ -1,53 +1,20 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const Webpack = require('webpack');
-const Path = require('path');
+const Merge = require('webpack-merge');
+const shared = require('../../shared/webpack.shared');
 
-const port = process.env.DOCKER_PORT || 8080;
-
-module.exports = {
-  mode: 'development',
-  cache: true,
-  entry: [
-    'webpack-dev-server/client?http://localhost:' + port,
-    'webpack/hot/only-dev-server',
-    './src/React.tsx',
-    './src/styles/index.scss',
-  ],
-  output: {
-    path: Path.resolve('dist'),
-    filename: 'bundle.js',
-  },
-  resolve: {
-    extensions: ['.js', '.tsx', '.json'],
-  },
-  devServer: {
-    contentBase: Path.resolve('src'),
-    publicPath: '/',
-    port: port,
-    hot: true,
-    quiet: false,
-    noInfo: false,
-    historyApiFallback: true,
-    watchOptions: ((process.env.WATCH_POLL) ? {aggregateTimeout: 300, poll: 1000} : {}),
-  },
-  module: {
-    rules: [
-      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader', options: {fix: true} },
-      { test: /\.(ttf|eot|svg|png|gif|jpg|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader : 'file-loader' },
-      { test: /\.scss$/, loader: 'style-loader!css-loader!sass-loader' },
-      { test: /\.tsx$/, loaders: ['react-hot-loader/webpack', 'awesome-typescript-loader'], exclude: /node_modules/ },
+const options = {
+  entry: {
+    bundle: [
+      './src/React.tsx',
+      './src/styles/index.scss',
     ],
   },
   plugins: [
-    new Webpack.HotModuleReplacementPlugin(),
     new CopyWebpackPlugin([
       { context: '../../node_modules/expedition-art', from: '**/*.+(jpg|svg|png)', to: 'expedition-art' },
     ]),
   ],
-  node: {
-    console: true,
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty',
-  },
 };
+
+module.exports = Merge(shared, options);

--- a/services/cards/webpack.dist.config.js
+++ b/services/cards/webpack.dist.config.js
@@ -1,42 +1,17 @@
-const Webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const Webpack = require('webpack');
+const Merge = require('webpack-merge');
+const shared = require('../../shared/webpack.dist.shared');
+const dev = require('./webpack.config');
 
-module.exports = {
-  mode: 'production',
-  entry: [
-    './src/React.tsx',
-    './src/styles/index.scss',
-  ],
-  resolve: {
-    extensions: ['.js', '.tsx', '.json'],
-  },
-  output: {
-    path: __dirname + '/www/',
-    filename: 'bundle.js'
-  },
-  module: {
-    rules: [
-      { test: /\.scss$/, loader: 'style-loader!css-loader!sass-loader' },
-      { test: /\.(ttf|eot|svg|png|gif|jpe?g|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader : 'file-loader' },
-      { test: /\.tsx$/, loaders: ['awesome-typescript-loader'], exclude: /node_modules/ },
-    ],
-  },
+const options = {
+  entry: dev.entry,
   plugins: [
-    new Webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production'),
-      },
-    }),
     new CopyWebpackPlugin([
       { from: 'src/index.html' },
       { context: '../../node_modules/expedition-art', from: '**/*.+(jpg|svg|png)', to: 'expedition-art' },
     ]),
-    new Webpack.optimize.AggressiveMergingPlugin(),
   ],
-  node: {
-    console: true,
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty',
-  },
 };
+
+module.exports = Merge(shared, options);

--- a/services/quests/src/Constants.tsx
+++ b/services/quests/src/Constants.tsx
@@ -1,6 +1,4 @@
-declare var PACKAGE_VERSION: string;
-
-export const VERSION = PACKAGE_VERSION; // Webpack
+export const VERSION = (process && process.env && process.env.VERSION) || '0.0.1'; // Webpack
 export const NODE_ENV = (process && process.env && process.env.NODE_ENV) || 'dev';
 export const API_HOST = (process && process.env && process.env.API_HOST) || 'http://betaapi.expeditiongame.com';
 export const GITHUB_DOCS = 'https://github.com/ExpeditionRPG/expedition/blob/master/services/quests/docs/';

--- a/services/quests/src/Constants.tsx
+++ b/services/quests/src/Constants.tsx
@@ -1,8 +1,8 @@
-const packageJson: any = require('../package.json');
+declare var PACKAGE_VERSION: string;
 
+export const VERSION = PACKAGE_VERSION; // Webpack
 export const NODE_ENV = (process && process.env && process.env.NODE_ENV) || 'dev';
 export const API_HOST = (process && process.env && process.env.API_HOST) || 'http://betaapi.expeditiongame.com';
-export const VERSION = packageJson.version;
 export const GITHUB_DOCS = 'https://github.com/ExpeditionRPG/expedition/blob/master/services/quests/docs/';
 export const DOCS_INDEX_URL = GITHUB_DOCS + 'index.md';
 export const DEV_CONTACT_URL = 'http://expeditiongame.com/contact';

--- a/services/quests/webpack.config.js
+++ b/services/quests/webpack.config.js
@@ -19,7 +19,7 @@ const options = {
   },
   plugins: [
     new Webpack.DefinePlugin({
-      PACKAGE_VERSION: JSON.stringify(require('./package.json').version),
+      'process.env.VERSION': JSON.stringify(require('./package.json').version),
     }),
     new CopyWebpackPlugin([
       { from: 'src/index.html' },

--- a/services/quests/webpack.config.js
+++ b/services/quests/webpack.config.js
@@ -1,20 +1,11 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const Path = require('path');
 const Webpack = require('webpack');
-
-const port = process.env.DOCKER_PORT || 8080;
+const Merge = require('webpack-merge');
+const shared = require('../../shared/webpack.shared');
 
 const options = {
-  mode: 'development',
-  cache: true,
   entry: {
     bundle: [
-      'webpack-dev-server/client?http://localhost:' + port,
-      // HMR disabled for now, potentially fixable with
-      // https://github.com/webpack/webpack/issues/6642
-      // or
-      // https://github.com/webpack-contrib/worker-loader
-      // 'webpack/hot/only-dev-server',
       './src/React.tsx',
       './src/Style.scss',
       '../app/src/Style.scss',
@@ -23,45 +14,12 @@ const options = {
       './src/playtest/PlaytestWorker.tsx',
     ],
   },
-  resolve: {
-    extensions: ['.js', '.ts', '.tsx', '.json', '.txt'],
-  },
-  devServer: {
-    host: '0.0.0.0',
-    contentBase: Path.join(__dirname, 'src'),
-    publicPath: '/',
-    port: port,
-    // hot: true,
-    hot: false,
-    quiet: false,
-    noInfo: false,
-    historyApiFallback: true,
-  },
   output: {
-    path: Path.join(__dirname, 'dist'),
-    publicPath: 'http://localhost:' + port + '/',
-    filename: '[name].js',
-  },
-  stats: {
-    colors: true,
-    reasons: true,
-  },
-  module: {
-    rules: [
-      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader', options: {fix: true} },
-      { test: /\.(ttf|eot|svg|png|gif|jpe?g|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader : 'file-loader' },
-      { test: /\.scss$/, loader: 'style-loader!css-loader!sass-loader' },
-      { test: /\.tsx$/, loaders: ['react-hot-loader/webpack', 'awesome-typescript-loader'], exclude: /\/node_modules\/.*$/ },
-    ]
+    globalObject: "this", // Fixes web workers - https://github.com/webpack/webpack/issues/6642
   },
   plugins: [
-    // new Webpack.HotModuleReplacementPlugin(),
     new Webpack.DefinePlugin({
-      'process.env': {
-        'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
-        'API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
-        'OAUTH2_CLIENT_ID': JSON.stringify(process.env.OAUTH2_CLIENT_ID || '545484140970-jq9jp7gdqdugil9qoapuualmkupigpdl.apps.googleusercontent.com'),
-      },
+      PACKAGE_VERSION: JSON.stringify(require('./package.json').version),
     }),
     new CopyWebpackPlugin([
       { from: 'src/index.html' },
@@ -73,4 +31,4 @@ const options = {
   ],
 };
 
-module.exports = options
+module.exports = Merge(shared, options);

--- a/services/quests/webpack.dist.config.js
+++ b/services/quests/webpack.dist.config.js
@@ -9,7 +9,7 @@ const options = {
   entry: dev.entry,
   plugins: [
     new Webpack.DefinePlugin({
-      PACKAGE_VERSION: JSON.stringify(require('./package.json').version),
+      'process.env.VERSION': JSON.stringify(require('./package.json').version),
     }),
     new CopyWebpackPlugin([
       // Copy ops for dist folder (main app)

--- a/services/quests/webpack.dist.config.js
+++ b/services/quests/webpack.dist.config.js
@@ -1,52 +1,18 @@
-// This config is run to compile and export the production environment to the dist/ folder.
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const Path = require('path');
 const Webpack = require('webpack');
+const Merge = require('webpack-merge');
+const shared = require('../../shared/webpack.dist.shared');
+const dev = require('./webpack.config');
+const app = require('../app/webpack.dist.config');
 
 const options = {
-  mode: 'production',
-  entry: {
-    bundle: [
-      './src/React.tsx',
-      './src/Style.scss',
-      '../app/src/Style.scss',
-    ],
-    playtest: [
-      './src/playtest/PlaytestWorker.tsx',
-    ],
-  },
-  resolve: {
-    extensions: ['.js', '.ts', '.tsx', '.json', '.txt'],
-  },
-  output: {
-    path: __dirname + '/dist/',
-    filename: '[name].js',
-  },
-  module: {
-    rules: [
-      { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
-      // TODO this does not export images to static/ for maintenance pages,
-      // but attempting to do so then breaks export to dist/
-      // Will be auto-fixed when we migrate all static pages to quests.expedition
-      // In the mean time, can manually copy images over when deploying static files
-      { test: /\.(ttf|eot|svg|png|gif|jpe?g|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader : 'file-loader' },
-      { test: /\.scss$/, loader: 'style-loader!css-loader!sass-loader' },
-      { test: /\.tsx$/, loaders: ['awesome-typescript-loader'], exclude: /\/node_modules\/((?!expedition\-.*).)*$/ },
-    ],
-  },
+  entry: dev.entry,
   plugins: [
-    new Webpack.optimize.AggressiveMergingPlugin(),
     new Webpack.DefinePlugin({
-      'process.env': {
-        // Default to beta for safety
-        'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
-        'API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
-        'OAUTH2_CLIENT_ID': JSON.stringify(process.env.OAUTH2_CLIENT_ID || '545484140970-jq9jp7gdqdugil9qoapuualmkupigpdl.apps.googleusercontent.com'),
-      }
+      PACKAGE_VERSION: JSON.stringify(require('./package.json').version),
     }),
     new CopyWebpackPlugin([
       // Copy ops for dist folder (main app)
-      { from: 'src/index.html' },
       { from: '../app/src/images', to: 'images' },
       { from: { glob: '../../node_modules/expedition-art/icons/*.svg' }, flatten: true, to: 'images' },
       { from: { glob: '../../node_modules/expedition-art/art/*.png' }, flatten: true, to: 'images' },
@@ -58,6 +24,7 @@ const options = {
       { from: 'src/maintenance.html' },
     ]),
   ],
+  optimization: app.optimization,
 };
 
-module.exports = options;
+module.exports = Merge(shared, options);

--- a/shared/webpack.config.js
+++ b/shared/webpack.config.js
@@ -1,37 +1,8 @@
-const Path = require('path');
-const Webpack = require('webpack');
-const child_process = require('child_process');
-
-const port = process.env.DOCKER_PORT || 8080;
+const Merge = require('webpack-merge');
+const shared = require('./webpack.shared');
 
 const options = {
-  mode: 'development',
-  cache: true,
-  entry: {},
-  resolve: {
-    extensions: ['.js', '.ts', '.tsx', '.json', '.txt'],
-  },
-  output: {
-    path: Path.join(__dirname, 'dist'),
-    publicPath: 'http://localhost:' + port + '/',
-    filename: '[name].js',
-  },
-  stats: {
-    colors: true,
-    reasons: true,
-  },
-  module: {
-    rules: [
-      { test: /\.(ttf|eot|svg|png|gif|jpe?g|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader : 'file-loader' },
-      { test: /\.scss$/, loader: 'style-loader!css-loader!sass-loader' },
-      { test: /\.tsx$/, loaders: ['awesome-typescript-loader'], exclude: /\/node_modules\/.*$/ },
-    ]
-  },
-  plugins: [
-    new Webpack.DefinePlugin({
-      VERSION: JSON.stringify(require('./package.json').version)
-    }),
-  ],
+  // Nice and simple!
 };
 
-module.exports = options;
+module.exports = Merge(shared, options);

--- a/shared/webpack.dist.shared.js
+++ b/shared/webpack.dist.shared.js
@@ -1,0 +1,45 @@
+// This config is run to compile and export the production environment to the dist/ folder.
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const Webpack = require('webpack');
+const shared = require('./webpack.shared');
+
+const options = {
+  mode: 'production',
+  devtool: 'source-map',
+  resolve: {
+    extensions: ['.js', '.ts', '.tsx', '.json', '.txt'],
+  },
+  output: {
+    // This must be an absolute path, and thus must be defined per-service
+    // path: 'dist',
+    filename: '[name].js',
+  },
+  module: {
+    rules: [
+      { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
+      ...shared.module.rules,
+    ],
+  },
+  plugins: [
+    new Webpack.optimize.AggressiveMergingPlugin(),
+    new Webpack.DefinePlugin({
+      'process.env': {
+        // Default to beta for safety
+        'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
+        'API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
+        'OAUTH2_CLIENT_ID': JSON.stringify(process.env.OAUTH2_CLIENT_ID || '545484140970-jq9jp7gdqdugil9qoapuualmkupigpdl.apps.googleusercontent.com'),
+      }
+    }),
+    new CopyWebpackPlugin([
+      { from: 'src/index.html' },
+    ]),
+  ],
+  node: {
+    console: true,
+    fs: 'empty',
+    net: 'empty',
+    tls: 'empty',
+  },
+};
+
+module.exports = options;

--- a/shared/webpack.dist.shared.js
+++ b/shared/webpack.dist.shared.js
@@ -23,12 +23,10 @@ const options = {
   plugins: [
     new Webpack.optimize.AggressiveMergingPlugin(),
     new Webpack.DefinePlugin({
-      'process.env': {
-        // Default to beta for safety
-        'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
-        'API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
-        'OAUTH2_CLIENT_ID': JSON.stringify(process.env.OAUTH2_CLIENT_ID || '545484140970-jq9jp7gdqdugil9qoapuualmkupigpdl.apps.googleusercontent.com'),
-      }
+      // Default to beta for safety
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
+      'process.env.API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
+      'process.env.OAUTH2_CLIENT_ID': JSON.stringify(process.env.OAUTH2_CLIENT_ID || '545484140970-jq9jp7gdqdugil9qoapuualmkupigpdl.apps.googleusercontent.com'),
     }),
     new CopyWebpackPlugin([
       { from: 'src/index.html' },

--- a/shared/webpack.shared.js
+++ b/shared/webpack.shared.js
@@ -1,0 +1,74 @@
+const Path = require('path');
+const Webpack = require('webpack');
+
+const port = process.env.DOCKER_PORT || 8080;
+
+const options = {
+  mode: 'development',
+  cache: true,
+  entry: [
+    'whatwg-fetch',
+    'promise-polyfill',
+    'webpack-dev-server/client?http://localhost:' + port,
+    'webpack/hot/only-dev-server',
+  ],
+  output: {
+    publicPath: 'http://localhost:' + port + '/',
+    filename: '[name].js',
+  },
+  resolve: {
+    extensions: ['.js', '.ts', '.tsx', '.json', '.txt'],
+  },
+  stats: {
+    colors: true,
+    reasons: true,
+  },
+  module: {
+    rules: [
+      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader',
+        options: {
+          fix: true,
+          typeCheck: false, // Explicitly disable extended type checking for dev workflow due to performance
+          tsConfigFile: Path.resolve(__dirname, '../tsconfig.json'),
+        },
+      },
+      { test: /\.(ttf|eot|svg|png|gif|jpe?g|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader: 'file-loader',
+        options: { name: '[name].[ext]' }, // disable filename hashing for infrequently changed static assets to enable preloading
+      },
+      { test: /\.scss$/, loaders: ['style-loader', 'css-loader', 'sass-loader'] },
+      { test: /\.tsx$/, loaders: ['react-hot-loader/webpack', 'awesome-typescript-loader'], exclude: /node_modules/ },
+    ]
+  },
+  plugins: [
+    new Webpack.DefinePlugin({
+      'process.env': {
+        // Default to beta for safety
+        'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
+        'API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
+        'OAUTH2_CLIENT_ID': JSON.stringify(process.env.OAUTH2_CLIENT_ID || '545484140970-jq9jp7gdqdugil9qoapuualmkupigpdl.apps.googleusercontent.com'),
+      },
+    }),
+    new Webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), // Don't import bloated Moment locales
+    new Webpack.HotModuleReplacementPlugin(),
+  ],
+  node: {
+    console: true,
+    fs: 'empty',
+    net: 'empty',
+    tls: 'empty',
+  },
+  devServer: {
+    host: '0.0.0.0',
+    contentBase: 'src',
+    disableHostCheck: true,
+    publicPath: '/',
+    port: port,
+    hot: true,
+    quiet: false,
+    noInfo: false,
+    historyApiFallback: true,
+    watchOptions: ((process.env.WATCH_POLL) ? {aggregateTimeout: 300, poll: 1000} : {}),
+  },
+};
+
+module.exports = options;

--- a/shared/webpack.shared.js
+++ b/shared/webpack.shared.js
@@ -41,12 +41,10 @@ const options = {
   },
   plugins: [
     new Webpack.DefinePlugin({
-      'process.env': {
-        // Default to beta for safety
-        'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
-        'API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
-        'OAUTH2_CLIENT_ID': JSON.stringify(process.env.OAUTH2_CLIENT_ID || '545484140970-jq9jp7gdqdugil9qoapuualmkupigpdl.apps.googleusercontent.com'),
-      },
+      // Default to beta for safety
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
+      'process.env.API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
+      'process.env.OAUTH2_CLIENT_ID': JSON.stringify(process.env.OAUTH2_CLIENT_ID || '545484140970-jq9jp7gdqdugil9qoapuualmkupigpdl.apps.googleusercontent.com'),
     }),
     new Webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), // Don't import bloated Moment locales
     new Webpack.HotModuleReplacementPlugin(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6809,10 +6809,6 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
-json-loader@^0.5.4:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
-
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -12430,6 +12426,12 @@ webpack-log@^1.0.1, webpack-log@^1.1.2, webpack-log@^1.2.0:
     log-symbols "^2.1.0"
     loglevelnext "^1.0.1"
     uuid "^3.1.0"
+
+webpack-merge@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.3.tgz#8aaff2108a19c29849bc9ad2a7fd7fce68e87c4a"
+  dependencies:
+    lodash "^4.17.5"
 
 webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
- dramatic reduction in config duplication - over 200 lines removed!
- fixes HMR for quests
- actually uses the package version injection so that our front end code no longer imports / loads package.json
- Consolidates ports: API runs on 8081, everything else on 8080 (aka app no longer the outlier on port 8082); still accepts DOCKER_PORT, though