### PR TITLE
wrap main component in error handler so that we can show error message to users

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "react-ga": "^2.3.6",
     "react-hot-loader": "~4.3.0",
     "react-redux": "^5.0.7",
-    "react-split-pane": "^0.1.59",
+    "react-split-pane": "^0.1.82",
     "react-transition-group": "^2.3.1",
     "react-truncate": "^2.3.0",
     "redux": "^4.0.0",

--- a/services/quests/src/Style.scss
+++ b/services/quests/src/Style.scss
@@ -609,8 +609,6 @@ body .olark-launch-button { /*must be more specifc than olark styles */
 }
 
 .publishForm {
-  max-width: none;
-  width: 75%;
   color: #FFFFFF;
 
   & > :nth-child(2) {

--- a/services/quests/src/components/Main.tsx
+++ b/services/quests/src/components/Main.tsx
@@ -29,20 +29,23 @@ export interface MainDispatchProps {
 
 interface MainProps extends MainStateProps, MainDispatchProps {}
 
-class Main extends React.Component<MainProps, {hasError: boolean}> {
+class Main extends React.Component<MainProps, {hasError: Error|null}> {
   constructor(props: MainProps) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { hasError: null };
   }
 
   public componentDidCatch(error: Error, info: any) {
     // Display fallback UI
-    this.setState({ hasError: true });
+    this.setState({ hasError: error });
   }
 
   public render() {
     if (this.state.hasError) {
-      return (<div style={{color: 'white'}}>Oh no, an error has occured! Try reloading the page - if the error persists, please email contact@expeditiongame.com</div>);
+      return (<span style={{color: 'white'}}>
+          <div>Oh no, an error has occured! Try reloading the page - if the error persists, please email contact@expeditiongame.com with the current page URL + below error message:</div>
+          <div>Error: {this.state.hasError.toString()}</div>
+        </span>);
     }
     if (this.props.editor.loadingQuest) {
       return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -9639,9 +9639,9 @@ react-redux@^5.0.7:
     loose-envify "^1.1.0"
     prop-types "^15.6.0"
 
-react-split-pane@^0.1.59:
-  version "0.1.81"
-  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.81.tgz#b1e8b82e0a6edd10f18fd639a5f512db3cbbb4e6"
+react-split-pane@^0.1.83:
+  version "0.1.82"
+  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.82.tgz#42fbb9fd4823f05e037de0dab3cd6cf9bf0cf4ea"
   dependencies:
     inline-style-prefixer "^3.0.6"
     prop-types "^15.5.10"


### PR DESCRIPTION
Turns out at some point at / since the monorepo migration, the split pane context / notes tabs have been broken. Filed a bug with them, but entirely possible they won't help or know how to fix it... https://github.com/tomkp/react-split-pane/issues/300

As of right now on beta, they crash the app. But with this change (using `componentDidCatch` added in React 16.4), we can now at least intercept the error and prevent the entire page from crashing!