### PR TITLE
fix android style, font bugs

### DIFF
--- a/services/app/config.xml
+++ b/services/app/config.xml
@@ -82,6 +82,6 @@
     <plugin name="cordova-plugin-whitelist" spec="^1.3.2" />
     <plugin name="cordova-plugin-x-socialsharing" spec="^5.1.8" />
     <plugin name="cordova-plugin-splashscreen" spec="^5.0.2" />
-    <engine name="android" spec="^7.1.0" />
-    <engine name="ios" spec="^4.5.4" />
+    <engine name="android" spec="^7.1.1" />
+    <engine name="ios" spec="^4.5.5" />
 </widget>

--- a/services/app/package.json
+++ b/services/app/package.json
@@ -31,20 +31,5 @@
       "ios"
     ]
   },
-  "dependencies": {
-    "cordova-android": "^7.1.0",
-    "cordova-ios": "^4.5.4",
-    "cordova-ios-plugin-no-export-compliance": "0.0.5",
-    "cordova-plugin-device": "^2.0.2",
-    "cordova-plugin-fullscreen": "^1.2.0",
-    "cordova-plugin-googleplus": "git+https://github.com/EddyVerbruggen/cordova-plugin-googleplus.git",
-    "cordova-plugin-hidden-statusbar-overlay": "git+https://github.com/katzer/cordova-plugin-hidden-statusbar-overlay.git",
-    "cordova-plugin-inappbrowser": "^3.0.0",
-    "cordova-plugin-insomnia": "git+https://github.com/EddyVerbruggen/Insomnia-PhoneGap-Plugin.git",
-    "cordova-plugin-splashscreen": "^5.0.2",
-    "cordova-plugin-vibration": "^3.1.0",
-    "cordova-plugin-whitelist": "^1.3.3",
-    "cordova-plugin-x-socialsharing": "^5.4.1",
-    "es6-promise-plugin": "^4.2.2"
-  }
+  "dependencies": {}
 }

--- a/services/app/src/Style.scss
+++ b/services/app/src/Style.scss
@@ -184,7 +184,7 @@ body {
 }
 
 .app_container {
-  &, & > div:not(.snackbar) {
+  &, & > div:first-child {
     height: 100%;
     width: 100%;
   }

--- a/shared/webpack.shared.js
+++ b/shared/webpack.shared.js
@@ -32,8 +32,11 @@ const options = {
           tsConfigFile: Path.resolve(__dirname, '../tsconfig.json'),
         },
       },
-      { test: /\.(ttf|eot|svg|png|gif|jpe?g|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader: 'file-loader',
-        options: { name: '[path][name].[ext]' }, // disable filename hashing for infrequently changed static assets to enable preloading
+      { test: /\.(svg|png|gif|jpe?g)(\?[a-z0-9=&.]+)?$/, loader: 'file-loader',
+        options: { name: 'images/[name].[ext]' }, // disable filename hashing for infrequently changed static assets to enable preloading
+      },
+      { test: /\.(ttf|eot|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader: 'file-loader',
+        options: { name: 'fonts/[name].[ext]' }, // disable filename hashing for infrequently changed static assets to enable preloading
       },
       { test: /\.scss$/, loaders: ['style-loader', 'css-loader', 'sass-loader'] },
       { test: /\.tsx$/, loaders: ['awesome-typescript-loader'], exclude: /node_modules/ },


### PR DESCRIPTION
CSS bug: There are two divs that are children of app_container, and the second one was also getting 100% height, which resulted in scrolling past the page

Font bug: webpack was putting fonts in `_/_/shared/fonts`, but Android builds silently fail to copy the `_` asset folders; adjusted webpack to output the fonts to just `/fonts`, which is also more human / debugging friendly (and confirmed it works on the beta web app + iOS)