### PR TITLE
Switch to compile-time checking of unused vars

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
         "strictNullChecks": true,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
+        "noUnusedLocals": true,
         "baseUrl": "./",
         "paths": {
             "api/*": ["services/api/src/*"],

--- a/tslint.json
+++ b/tslint.json
@@ -2,10 +2,8 @@
   "extends": "tslint:recommended",
   "rules": {
     "quotemark": [true, "single", "jsx-double"],
-    "no-use-before-declare": true,
     "switch-default": true,
     "indent": [true, "spaces"],
-    "no-unused-variable": [true, "react"],
     "trailing-comma": [true, {
       "multiline": {
         "objects": "always",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4386,10 +4386,6 @@ expect@^23.1.0:
     jest-message-util "^23.3.0"
     jest-regex-util "^23.3.0"
 
-"expedition-art@git+https://github.com/ExpeditionRPG/expedition-art.git":
-  version "1.2.2"
-  resolved "git+https://github.com/ExpeditionRPG/expedition-art.git#1b18e58cfee5c580c15fb900e70615e42bf059ed"
-
 export-files@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/export-files/-/export-files-2.1.1.tgz#bbf64574053a09e4eb98e5f43501d572b2c3ce7f"


### PR DESCRIPTION
There's currently a runtime warning with a couple of the linter rules we use - turns out they're already done by the compiler (`no-use-for-declare` is caught for all non-`var` variables by default and `no-unused-variable` can be replaced with `noUnusedLocals`).