### PR TITLE
Check if MathJS block should be conditional

### DIFF
--- a/shared/render/render/XMLRenderer.test.tsx
+++ b/shared/render/render/XMLRenderer.test.tsx
@@ -35,6 +35,25 @@ describe('XMLRenderer', () => {
     });
 
     it('renders decision'); // TODO
+
+    it('renders conditional ops as ifs', () => {
+      expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ gold == 0 }} Test'], 0).toString())
+        .toEqual('<roleplay data-line="0"><p if=" gold == 0 "> Test</p></roleplay>');
+    });
+
+    it('renders nonconditional ops as output', () => {  
+      expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ gold }}'], 0).toString())
+      .toEqual('<roleplay data-line="0"><p>{{ gold }}</p></roleplay>');
+
+      expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ gold }} Test'], 0).toString())
+        .toEqual('<roleplay data-line="0"><p>{{ gold }} Test</p></roleplay>');
+        
+      expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ gold }}', 'Test on a new line'], 0).toString())
+      .toEqual('<roleplay data-line="0"><p>{{ gold }} Test on a new line</p></roleplay>');
+      
+      expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ test = false }}', '{{ gold = 10 }}'], 0).toString())
+        .toEqual('<roleplay data-line="0"><p>{{ test = false }} {{ gold = 10 }}</p></roleplay>');
+    });
   });
 
   describe('toTrigger', () => {

--- a/shared/render/render/XMLRenderer.test.tsx
+++ b/shared/render/render/XMLRenderer.test.tsx
@@ -39,7 +39,7 @@ describe('XMLRenderer', () => {
     it('renders conditional ops as ifs', () => {
       expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ gold == 0 }} Test'], 0).toString())
         .toEqual('<roleplay data-line="0"><p if=" gold == 0 "> Test</p></roleplay>');
-      
+
       expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ wallet.gold == 0 }} Test'], 0).toString())
       .toEqual('<roleplay data-line="0"><p if=" wallet.gold == 0 "> Test</p></roleplay>');
     });
@@ -57,29 +57,29 @@ describe('XMLRenderer', () => {
 
     it('renders ternary ops as output', () => {
       expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ gold == 0 ? "broke" : "rich" }} Test'], 0).toString())
-        .toEqual('<roleplay data-line="0"><p>{{ gold == 0 ? "broke" : "rich" }} Test</p></roleplay>');
+        .toEqual('<roleplay data-line="0"><p>{{ gold == 0 ? &quot;broke&quot; : &quot;rich&quot; }} Test</p></roleplay>');
     });
 
     it('treats assignment ops as output', () => {
       expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ a = {b: "c"} }} Test'], 0).toString())
-        .toEqual('<roleplay data-line="0"><p>{{ a = {b: "c"} }} Test</p></roleplay>');
+        .toEqual('<roleplay data-line="0"><p>{{ a = {b: &quot;c&quot;} }} Test</p></roleplay>');
 
       expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ a = [b, "c"] }} Test'], 0).toString())
-        .toEqual('<roleplay data-line="0"><p>{{ a = [b, "c"] }} Test</p></roleplay>');
+        .toEqual('<roleplay data-line="0"><p>{{ a = [b, &quot;c&quot;] }} Test</p></roleplay>');
     });
 
-    it('renders nonconditional ops as output', () => {  
+    it('renders nonconditional ops as output', () => {
       expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ gold }}'], 0).toString())
       .toEqual('<roleplay data-line="0"><p>{{ gold }}</p></roleplay>');
 
       expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ gold }} Test'], 0).toString())
         .toEqual('<roleplay data-line="0"><p>{{ gold }} Test</p></roleplay>');
-        
+
       expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ gold }}', 'Test on a new line'], 0).toString())
       .toEqual('<roleplay data-line="0"><p>{{ gold }}</p><p>Test on a new line</p></roleplay>');
-      
+
       expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ test = false }}', '{{ gold = 10 }}'], 0).toString())
-        .toEqual('<roleplay data-line="0"><p>{{ test = false }} {{ gold = 10 }}</p></roleplay>');
+        .toEqual('<roleplay data-line="0"><p>{{ test = false }}</p><p>{{ gold = 10 }}</p></roleplay>');
     });
   });
 

--- a/shared/render/render/XMLRenderer.test.tsx
+++ b/shared/render/render/XMLRenderer.test.tsx
@@ -39,6 +39,33 @@ describe('XMLRenderer', () => {
     it('renders conditional ops as ifs', () => {
       expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ gold == 0 }} Test'], 0).toString())
         .toEqual('<roleplay data-line="0"><p if=" gold == 0 "> Test</p></roleplay>');
+      
+      expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ wallet.gold == 0 }} Test'], 0).toString())
+      .toEqual('<roleplay data-line="0"><p if=" wallet.gold == 0 "> Test</p></roleplay>');
+    });
+
+    it('understands multiple-op blocks', () => {
+      expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ wallet = {gold: 0, rubees: 1}; wallet }} Test'], 0).toString())
+        .toEqual('<roleplay data-line="0"><p>{{ wallet = {gold: 0, rubees: 1}; wallet }} Test</p></roleplay>');
+
+      // Not really sure what we want to do in this case
+      // expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ wallet.gold == 0; wallet.gold > 0 }} Test'], 0).toString())
+        // .toEqual('<roleplay data-line="0"><p>{{ wallet.gold == 0; wallet.gold > 0 }} Test</p></roleplay>'); // Loses conditional
+        // OR
+        // .toEqual('<roleplay data-line="0"><p if=" wallet.gold == 0; wallet.gold > 0 ">Test</p></roleplay>'); // Loses setter
+    });
+
+    it('renders ternary ops as output', () => {
+      expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ gold == 0 ? "broke" : "rich" }} Test'], 0).toString())
+        .toEqual('<roleplay data-line="0"><p>{{ gold == 0 ? "broke" : "rich" }} Test</p></roleplay>');
+    });
+
+    it('treats assignment ops as output', () => {
+      expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ a = {b: "c"} }} Test'], 0).toString())
+        .toEqual('<roleplay data-line="0"><p>{{ a = {b: "c"} }} Test</p></roleplay>');
+
+      expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ a = [b, "c"] }} Test'], 0).toString())
+        .toEqual('<roleplay data-line="0"><p>{{ a = [b, "c"] }} Test</p></roleplay>');
     });
 
     it('renders nonconditional ops as output', () => {  
@@ -49,7 +76,7 @@ describe('XMLRenderer', () => {
         .toEqual('<roleplay data-line="0"><p>{{ gold }} Test</p></roleplay>');
         
       expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ gold }}', 'Test on a new line'], 0).toString())
-      .toEqual('<roleplay data-line="0"><p>{{ gold }} Test on a new line</p></roleplay>');
+      .toEqual('<roleplay data-line="0"><p>{{ gold }}</p><p>Test on a new line</p></roleplay>');
       
       expect(XMLRenderer.toTemplate('roleplay', {}, ['{{ test = false }}', '{{ gold = 10 }}'], 0).toString())
         .toEqual('<roleplay data-line="0"><p>{{ test = false }} {{ gold = 10 }}</p></roleplay>');

--- a/shared/render/render/XMLRenderer.tsx
+++ b/shared/render/render/XMLRenderer.tsx
@@ -50,6 +50,8 @@ export const XMLRenderer: Renderer = {
         const visible = (text.match(INITIAL_OP_WITH_PARAGRAPH) || [])[1];
         let paragraph = `<p>${sanitizeStyles(text)}</p>`;
         if (visible) {
+          // Parse AST for expression and check if outermost node/operation is of type "OperatorNode" (e.g. == >= != etc.)
+          // Used to try to be smarter about whether a MathJS evaluation should be output or an if attribute
           const visibleTree = Math.parse(visible);
           if (visibleTree.type === 'OperatorNode') {
             text = text.replace('{{' + visible + '}}', '');

--- a/shared/render/render/XMLRenderer.tsx
+++ b/shared/render/render/XMLRenderer.tsx
@@ -1,6 +1,7 @@
 import {Instruction, TEMPLATE_ATTRIBUTE_MAP, TEMPLATE_ATTRIBUTE_SHORTHAND, TemplateChild, TemplateType} from '../../schema/templates/Templates';
 import {Renderer, sanitizeStyles} from './Renderer';
 
+const Math = require('mathjs') as any;
 const cheerio: any = require('cheerio') as CheerioAPI;
 
 // from https://stackoverflow.com/questions/7918868/how-to-escape-xml-entities-in-javascript
@@ -49,8 +50,11 @@ export const XMLRenderer: Renderer = {
         const visible = (text.match(INITIAL_OP_WITH_PARAGRAPH) || [])[1];
         let paragraph = `<p>${sanitizeStyles(text)}</p>`;
         if (visible) {
-          text = text.replace('{{' + visible + '}}', '');
-          paragraph = `<p if="${escapeXml(visible)}">${sanitizeStyles(text)}</p>`;
+          const visibleTree = Math.parse(visible);
+          if (visibleTree.type === 'OperatorNode') {
+            text = text.replace('{{' + visible + '}}', '');
+            paragraph = `<p if="${escapeXml(visible)}">${sanitizeStyles(text)}</p>`;
+          }
         }
         tmpl.append(paragraph);
       } else if (Boolean((section as TemplateChild).outcome)) { // choice or event


### PR DESCRIPTION
Closes #63 . Fix is based on the method we discussed @toddmedema , using MathJS's AST API to parse each block ahead of time and determine if it should be conditional. Surprisingly that entire check seemed to fall under simply checking if the outermost node was an OperatorNode - this almost seems too good to be true to be honest, but as far as I can tell it does the trick.

I added some tests for 'normal' cases, idk how far we want to go on testing this, but I can add more if needed.