### PR TITLE
don't break the quest on invalid IFs

### DIFF
--- a/services/app/src/actions/SavedQuests.test.tsx
+++ b/services/app/src/actions/SavedQuests.test.tsx
@@ -9,7 +9,7 @@ describe('SavedQuest actions', () => {
   const STORED_QUEST_ID = '12345';
   const STORED_QUEST_TS = 67890;
   beforeEach(() => {
-    const quest = getCheerio().load('<quest><roleplay><choice></choice><choice if="asdf"></choice><choice><roleplay>expected</roleplay><roleplay>wrong</roleplay></choice></roleplay></quest>')('quest');
+    const quest = getCheerio().load('<quest><roleplay><choice></choice><choice if="false"></choice><choice><roleplay>expected</roleplay><roleplay>wrong</roleplay></choice></roleplay></quest>')('quest');
     const pnode = new ParserNode(quest.children().eq(0), defaultContext());
     const next = pnode.getNext(1);
     if (next === null) {
@@ -30,7 +30,7 @@ describe('SavedQuest actions', () => {
   });
 
   describe('storeSavedQuest', () => {
-    const quest = getCheerio().load('<quest><roleplay><choice><roleplay>expected</roleplay><roleplay>wrong</roleplay></choice><choice></choice><choice if="asdf"></choice></roleplay></quest>')('quest');
+    const quest = getCheerio().load('<quest><roleplay><choice><roleplay>expected</roleplay><roleplay>wrong</roleplay></choice><choice></choice><choice if="false"></choice></roleplay></quest>')('quest');
     const pnode = new ParserNode(quest.children().eq(0), defaultContext()).getNext(0);
     const NEW_ID = '0123';
     const NEW_TS = 4567;

--- a/services/app/src/quests/test_quest.xml
+++ b/services/app/src/quests/test_quest.xml
@@ -4,7 +4,7 @@
     <p>Full-width art:</p>
     <p>[Darker_at_Dawn_png_full]</p>
   </roleplay>
-  <roleplay title="Test" id="start" data-line="10">
+  <roleplay if="true" title="Test" id="start" data-line="10">
     <p>{{one=1}}</p>
     <p>{{foo="a"}}</p>
     <p>You face choices. Here's the value of one: {{one}}, a string: {{foo}}. And a symbol: ☞ and icon :roll:. There should be one paragraph below:</p>

--- a/services/app/src/quests/test_quest.xml
+++ b/services/app/src/quests/test_quest.xml
@@ -1,16 +1,16 @@
 <quest title="Test Quest" data-line="0">
   <roleplay skipSetup="true" title="Setup :loot:" data-line="2">
-    <p>Custom setup card, replacing the default quest setup card. {{_.nonsense() ? "The Horror" : "Base Game"}}. Full-width art:</p>
+    <p>Custom setup card, replacing the default quest setup card. Full-width art:</p>
     <p>[Darker_at_Dawn_png_full]</p>
   </roleplay>
   <roleplay title="Test" id="start" data-line="10">
     <p>{{one=1}}</p>
     <p>{{foo="a"}}</p>
-    <p>You should see an error notification, but everything should work.</p>
-    <p>You face choices. Here's the value of one: {{one}}. And a symbol: ☞ and icon :roll:. There should be one paragraph below:</p>
+    <p>You face choices. Here's the value of one: {{one}}, a string: {{foo}}. And a symbol: ☞ and icon :roll:. There should be one paragraph below:</p>
     <p if="true"> One paragraph</p>
     <p if="false"> Two paragraph - you shouldn't see this!</p>
-    <choice text=":fae: Fight">
+    <p if="one == 0"> Three paragraph - you shouldn't see this!</p>
+    <choice text=":fae: Fight" if="test_invalid == 1">
       <combat data-line="26">
         <e>Thief</e>
         <e>Thief</e>

--- a/services/app/src/quests/test_quest.xml
+++ b/services/app/src/quests/test_quest.xml
@@ -1,6 +1,7 @@
 <quest title="Test Quest" data-line="0">
   <roleplay skipSetup="true" title="Setup :loot:" data-line="2">
-    <p>Custom setup card, replacing the default quest setup card. Full-width art:</p>
+    <p>Custom setup card, replacing the default quest setup card. {{_.nonsense() ? "The Horror" : "Base Game"}}. You should see an error notification, but everything should work.</p>
+    <p>Full-width art:</p>
     <p>[Darker_at_Dawn_png_full]</p>
   </roleplay>
   <roleplay title="Test" id="start" data-line="10">

--- a/shared/parse/Node.test.tsx
+++ b/shared/parse/Node.test.tsx
@@ -26,7 +26,7 @@ describe('Node', () => {
       expect(next.elem.text()).toEqual('expected');
     });
     it('displays elements with invalid / undefined ops', () => {
-      const quest = cheerio.load('<quest><roleplay if="erta">expected</roleplay><roleplay>wrong</roleplay></quest>')('quest');
+      const quest = cheerio.load('<quest><roleplay>bob</roleplay><roleplay if="erta">expected</roleplay><roleplay>wrong</roleplay></quest>')('quest');
       const pnode = new Node(quest.children().eq(0), defaultContext());
       const next = pnode.getNext();
       if (next === null) {
@@ -39,7 +39,7 @@ describe('Node', () => {
       expect(pnode.getNext()).toEqual(null);
     });
     it('returns next node if choice=0 and no choice', () => {
-      const quest = cheerio.load('<quest><roleplay></roleplay><roleplay>expected</roleplay></quest>')('quest');
+      const quest = cheerio.load('<quest><roleplay>wrong</roleplay><roleplay>expected</roleplay></quest>')('quest');
       const pnode = new Node(quest.children().eq(0), defaultContext());
       const next = pnode.getNext(0);
       if (next === null) {

--- a/shared/parse/Node.tsx
+++ b/shared/parse/Node.tsx
@@ -252,6 +252,8 @@ export class Node<C extends Context> {
       // TODO(scott): Make this use Context.tsx (evaluateOp?)
       const visible = Math.eval(ifExpr, Clone(this.ctx.scope));
 
+      console.log(visible, ifExpr);
+
       // We check for truthiness here, so nonzero numbers are true, etc.
       return Boolean(visible);
     } catch (e) {

--- a/shared/parse/Node.tsx
+++ b/shared/parse/Node.tsx
@@ -255,7 +255,9 @@ export class Node<C extends Context> {
       // We check for truthiness here, so nonzero numbers are true, etc.
       return Boolean(visible);
     } catch (e) {
-      // If we fail to evaluate (e.g. symbol not defined), treat the elem as not visible.
+      // If we fail to evaluate (e.g. symbol not defined), display the element
+      // so that the quest is still playable - better too many options
+      // than not being able to finish.
       return true;
     }
   }

--- a/shared/parse/Node.tsx
+++ b/shared/parse/Node.tsx
@@ -252,8 +252,6 @@ export class Node<C extends Context> {
       // TODO(scott): Make this use Context.tsx (evaluateOp?)
       const visible = Math.eval(ifExpr, Clone(this.ctx.scope));
 
-      console.log(visible, ifExpr);
-
       // We check for truthiness here, so nonzero numbers are true, etc.
       return Boolean(visible);
     } catch (e) {

--- a/shared/parse/Node.tsx
+++ b/shared/parse/Node.tsx
@@ -256,7 +256,7 @@ export class Node<C extends Context> {
       return Boolean(visible);
     } catch (e) {
       // If we fail to evaluate (e.g. symbol not defined), treat the elem as not visible.
-      return false;
+      return true;
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/ExpeditionRPG/expedition/issues/421

Note that this specifically solves the if / conditional case, since that's the clearest way this would break a quest. It'll still throw an error and show nothing if you attempt to **display** a variable, but the optimal solution there is much less clear since clearly the writer was intending for something with meaningful context, not just true / false.