### PR TITLE
Improve mid-combat roleplay code.

### DIFF
--- a/services/app/karma.conf.js
+++ b/services/app/karma.conf.js
@@ -1,31 +1,30 @@
 const webpackConfig = require('./webpack.config');
-const webpack = require('webpack');
 
 webpackConfig.module.rules.unshift({
   test: /isIterable/,
   loader: 'imports?Symbol=>false'
 });
+webpackConfig.entry = undefined;
+
+// Remove hot reload
+webpackConfig.plugins = [webpackConfig.plugins[webpackConfig.plugins.length-1]];
 
 module.exports = function(config) {
   config.set({
     basePath: '',
     frameworks: ['jasmine'],
     files: [
-      { pattern: 'src/**/*.test.tsx' }
+      // Set watched=false here as karma-webpack does the watching under the hood.
+      { pattern: 'src/**/*.test.tsx', watched:false},
     ],
     preprocessors: {
       'src/**/*.test.tsx': ['webpack'],
     },
-    webpack: {
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-      node: webpackConfig.node,
-      // Pull in module-specific configs (esp. tslint)
-      plugins: [webpackConfig.plugins[webpackConfig.plugins.length-1]],
-      externals: {
-        'react/addons': true,
-        'react/lib/ExecutionEnvironment': true,
-        'react/lib/ReactContext': true
+    webpack: webpackConfig,
+    webpackMiddleware: {
+      watchOptions: {
+        ignored: [/\/\./, 'node_modules'],
+        poll: 1000,
       }
     },
     browserConsoleLogOptions: {
@@ -37,7 +36,8 @@ module.exports = function(config) {
     port: 8081,
     colors: true,
     logLevel: config.LOG_INFO,
-    autoWatch: true,
+    //autoWatch: true,
+    //usePolling: true,
     browsers: ['NoSandboxChromeHeadless'],
     customLaunchers: {
       NoSandboxChromeHeadless: {

--- a/services/app/karma.conf.js
+++ b/services/app/karma.conf.js
@@ -6,8 +6,13 @@ webpackConfig.module.rules.unshift({
 });
 webpackConfig.entry = undefined;
 
-// Remove hot reload
-webpackConfig.plugins = [webpackConfig.plugins[webpackConfig.plugins.length-1]];
+// Remove copy plugin - which is the only plugin of constructor "object"
+for (let i = 0; i < webpackConfig.plugins.length; i++) {
+  if (webpackConfig.plugins[i].constructor.name == 'Object') {
+    webpackConfig.plugins.splice(i, 1);
+    break;
+  }
+}
 
 module.exports = function(config) {
   config.set({

--- a/services/app/karma.conf.js
+++ b/services/app/karma.conf.js
@@ -36,8 +36,6 @@ module.exports = function(config) {
     port: 8081,
     colors: true,
     logLevel: config.LOG_INFO,
-    //autoWatch: true,
-    //usePolling: true,
     browsers: ['NoSandboxChromeHeadless'],
     customLaunchers: {
       NoSandboxChromeHeadless: {

--- a/services/app/package.json
+++ b/services/app/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://app.expeditiongame.com",
   "scripts": {
     "test": "karma start --single-run --browsers NoSandboxChromeHeadless",
-    "watch-test": "karma start --browsers NoSandboxChromeHeadless --auto-watch",
+    "watch-test": "node --max_old_space_size=4096 ../../node_modules/karma/bin/karma start --browsers NoSandboxChromeHeadless",
     "start": "webpack-dev-server --progress --hot",
     "build": "webpack --config ./webpack.dist.config.js --progress",
     "build-all": "npm run build && cordova build android && cordova build ios"

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
@@ -173,7 +173,6 @@ describe('Combat actions', () => {
 
     it('randomly assigns damage', () => {
       const {actions} = newStore({});
-      console.log(actions);
       expect(actions[2].node.ctx.templates.combat.mostRecentAttack.damage).toBeDefined();
     });
     it('generates rolls according to player count', () => {
@@ -220,7 +219,6 @@ describe('Combat actions', () => {
     it('never assigns loot or levels up on defeat', () => {
       const store = newMockStore({});
       store.dispatch(handleCombatEnd({node: newCombatNode(), settings: TEST_SETTINGS, victory: false, maxTier: 9, seed: ''}));
-      console.log(store.getActions());
       expect(store.getActions()[1].node.ctx.templates.combat).toEqual(jasmine.objectContaining({
         levelUp: false,
         loot: [],
@@ -241,7 +239,7 @@ describe('Combat actions', () => {
       expect(store.getActions()[1].node.ctx.templates.combat.levelUp).toEqual(false);
     });
 
-    it('Fixes when given a mid-combat roleplay node', () => {
+    it('Uses parent combat node when given a mid-combat roleplay node', () => {
       const pnode = new ParserNode(cheerio.load(`
         <combat><e>lich</e>
           <event on="round">

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
@@ -173,20 +173,20 @@ describe('Combat actions', () => {
 
     it('randomly assigns damage', () => {
       const {actions} = newStore({});
-      expect(actions[3].node.ctx.templates.combat.mostRecentAttack.damage).toBeDefined();
+      console.log(actions);
+      expect(actions[2].node.ctx.templates.combat.mostRecentAttack.damage).toBeDefined();
     });
     it('generates rolls according to player count', () => {
       const {actions} = newStore({});
-      expect(actions[3].node.ctx.templates.combat.mostRecentRolls.length).toEqual(3);
+      expect(actions[2].node.ctx.templates.combat.mostRecentRolls.length).toEqual(3);
     });
     it('increments the round counter', () => {
       const {actions} = newStore({});
-      expect(actions[3].node.ctx.templates.combat.roundCount).toEqual(1);
+      expect(actions[2].node.ctx.templates.combat.roundCount).toEqual(1);
     });
-
     it('only generates rolls for local, not remote, players', () => {
       const {actions} = newStore({ rp: TEST_RP });
-      expect(actions[3].node.ctx.templates.combat.mostRecentRolls.length).toEqual(3);
+      expect(actions[2].node.ctx.templates.combat.mostRecentRolls.length).toEqual(3);
     });
   });
 
@@ -239,6 +239,32 @@ describe('Combat actions', () => {
       }));
 
       expect(store.getActions()[1].node.ctx.templates.combat.levelUp).toEqual(false);
+    });
+
+    it('Fixes when given a mid-combat roleplay node', () => {
+      const pnode = new ParserNode(cheerio.load(`
+        <combat><e>lich</e>
+          <event on="round">
+            <roleplay id="start">Roleplay node</roleplay>
+          </event>
+          <event on="win"></event>
+          <event on="lose"></event>
+        </combat>`)('combat'), defaultContext());
+      const node = Action(initCombat, {settings: TEST_SETTINGS}).execute({node: pnode.clone()})[1].node;
+      // Replace combat node elem with the roleplay node
+      node.elem = node.elem.find('#start');
+
+      const store = newMockStore({settings: TEST_SETTINGS});
+      store.dispatch(handleCombatEnd({
+        maxTier: 4,
+        node,
+        rp: TEST_RP,
+        seed: '',
+        settings: TEST_SETTINGS,
+        victory: true,
+      }));
+
+      expect(store.getActions()[1].node.getTag()).toEqual('combat');
     });
   });
 
@@ -294,8 +320,8 @@ describe('Combat actions', () => {
         <event on="lose"></event>
       </combat>`)('combat'), defaultContext());
       const actions = Action(handleResolvePhase).execute({node});
-      expect(actions[1].to.phase).toEqual('RESOLVE_ABILITIES');
-      expect(actions[2].type).toEqual('QUEST_NODE');
+      expect(actions[1].type).toEqual('QUEST_NODE');
+      expect(actions[2].to.phase).toEqual('RESOLVE_ABILITIES');
     });
 
     it('goes to resolve card if conditionally false round event handler', () => {
@@ -308,8 +334,8 @@ describe('Combat actions', () => {
         <event if="false" on="round"><roleplay>bad</roleplay></event>
       </combat>`)('combat'), defaultContext());
       const actions = Action(handleResolvePhase).execute({node});
-      expect(actions[1].to.phase).toEqual('RESOLVE_ABILITIES');
-      expect(actions[2].type).toEqual('QUEST_NODE');
+      expect(actions[1].type).toEqual('QUEST_NODE');
+      expect(actions[2].to.phase).toEqual('RESOLVE_ABILITIES');
     });
 
     it('goes to roleplay card on round event handler', () => {
@@ -325,7 +351,7 @@ describe('Combat actions', () => {
       </combat>`)('combat'), defaultContext());
       node = Action(initCombat as any).execute({node: node.clone(), settings: TEST_SETTINGS})[1].node;
       const actions = Action(handleResolvePhase).execute({node});
-      expect(actions[0].node.elem.text()).toEqual('expected');
+      expect(actions[1].node.elem.text()).toEqual('expected');
       expect(actions[2].to.phase).toEqual('MID_COMBAT_ROLEPLAY');
     });
   });

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
@@ -5,6 +5,7 @@ import {defaultContext} from '../Template';
 import {ParserNode} from '../TemplateTypes';
 import {
   adventurerDelta,
+  findCombatParent,
   handleCombatEnd,
   handleCombatTimerStop,
   handleResolvePhase,
@@ -332,6 +333,29 @@ describe('Combat actions', () => {
   it('handles global player count change');
 
   it('clears combat state on completion');
+
+  describe('findCombatParent', () => {
+    it('returns node when node is combat', () => {
+      const v = cheerio.load('<quest><combat id="start"></combat></quest>')('#start');
+      const result = findCombatParent(new ParserNode(v, defaultContext()));
+      if (result === null) {
+        throw Error('null result');
+      }
+      expect(result.attr('id')).toEqual('start');
+    });
+    it('returns combat parent', () => {
+      const v = cheerio.load('<quest><combat id="expected"><event on="round"><roleplay id="start"></roleplay></event></combat></quest>')('#start');
+      const result = findCombatParent(new ParserNode(v, defaultContext()));
+      if (result === null) {
+        throw Error('null result');
+      }
+      expect(result.attr('id')).toEqual('expected');
+    });
+    it('does not return combat when node is within a win/lose event', () => {
+      const v = cheerio.load('<quest><combat><event on="win"><roleplay id="start"></roleplay></event></combat></quest>')('#start');
+      expect(findCombatParent(new ParserNode(v, defaultContext()))).toEqual(null);
+    });
+  });
 
   describe('setupCombatDecision', () => {
     it('populates combat decision template with generated LeveledSkillChecks');

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
@@ -285,11 +285,13 @@ export const handleResolvePhase = remoteify(function handleResolvePhase(a: Handl
   a.node = a.node.clone();
   if (a.node.getVisibleKeys().indexOf('round') !== -1) {
     // Set node *before* navigation to prevent a blank first roleplay card.
+    dispatch({type: 'PUSH_HISTORY'});
     dispatch({type: 'QUEST_NODE', node: a.node.getNext('round')} as QuestNodeAction);
-    dispatch(toCard({name: 'QUEST_CARD', phase: 'MID_COMBAT_ROLEPLAY', overrideDebounce: true}));
+    dispatch(toCard({name: 'QUEST_CARD', phase: 'MID_COMBAT_ROLEPLAY', overrideDebounce: true, noHistory: true}));
   } else {
-    dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true}));
+    dispatch({type: 'PUSH_HISTORY'});
     dispatch({type: 'QUEST_NODE', node: a.node} as QuestNodeAction);
+    dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true, noHistory: true}));
   }
   return {};
 });
@@ -389,9 +391,18 @@ export const handleCombatEnd = remoteify(function handleCombatEnd(a: HandleComba
     a.rp = getState().multiplayer;
   }
 
+  // If we were given a non-combat node due to some bug in previous code,
+  // find its parent combat container and use it.
+  if (a.node.getTag() !== 'combat') {
+    const parent = findCombatParent(a.node);
+    if (parent === null) {
+      throw new Error('Non-combat node given for handleCombatEnd, soft fix failed.');
+    }
+    a.node = new ParserNode(parent, a.node.ctx);
+  }
+
   let combat = a.node.ctx.templates.combat;
   if (!combat) {
-    console.log('NO COMBAT :(');
     combat = generateCombatTemplate(a.settings, false, a.node, getState);
     a.node.ctx.templates.combat = combat;
   }

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
@@ -19,6 +19,19 @@ import {CombatAttack, CombatDifficultySettings, CombatState} from './Types';
 
 const cheerio: any = require('cheerio');
 
+export function findCombatParent(node: ParserNode): Cheerio|null {
+  let elem = node && node.elem;
+  while (elem !== null && elem.length > 0 && elem.get(0).tagName.toLowerCase() !== 'combat') {
+    // Don't count roleplay nodes within "win" and "lose" events even if they're children of
+    // a combat node; this is technically a roleplay state.
+    if (/win|lose/.test(elem.attr('on'))) {
+      return null;
+    }
+    elem = elem.parent();
+  }
+  return elem;
+}
+
 export function roundTimeMillis(settings: SettingsType, rp?: MultiplayerState) {
   const totalPlayerCount = numPlayers(settings, rp);
   return settings.timerSeconds * 1000 * PLAYER_TIME_MULT[totalPlayerCount];

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.test.tsx
@@ -35,7 +35,7 @@ describe('Roleplay actions', () => {
         <roleplay>Text</roleplay>
         <combat id="c1">
           <e>Test</e>
-          <event on="win"><roleplay>win card</roleplay></event>
+          <event on="win"><roleplay id="wincard">win card</roleplay></event>
           <event on="lose"><roleplay>lose card</roleplay></event>
           <event on="round"><roleplay>
             <choice><trigger>win</trigger></choice>
@@ -44,6 +44,7 @@ describe('Roleplay actions', () => {
             <choice><roleplay id="rp2">rp2</roleplay></choice>
             <choice><trigger>goto outside</trigger></choice>
             <choice><trigger>goto rp2</trigger></choice>
+            <choice><trigger>goto wincard</trigger></choice>
           </roleplay></event>
         </combat>
         <roleplay id="outside">Outside Roleplay</roleplay>
@@ -63,9 +64,10 @@ describe('Roleplay actions', () => {
       expect(actions[2].to.phase).toEqual('DEFEAT');
     });
 
-    it('ends quest on **end**', () => {
+    it('ends quest on **end** and zeros audio', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 2, maxTier: 0, seed: ''});
-      expect(actions[1].to.name).toEqual('QUEST_END');
+      expect(actions[0].type).toEqual('AUDIO_SET');
+      expect(actions[2].to.name).toEqual('QUEST_END');
     });
 
     it('goes to next round when pnode.getNext() falls outside of combat scope', () => {
@@ -74,10 +76,11 @@ describe('Roleplay actions', () => {
       expect(actions[2].to.phase).toEqual('RESOLVE_ABILITIES');
     });
 
-    it('handles gotos that point to outside of combat', () => {
+    it('handles gotos that point to outside of combat and zeros audio', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 4, maxTier: 0, seed: ''});
       expect(actions[2].to.phase).toEqual('ROLEPLAY');
       expect(actions[1].node.elem.text()).toEqual('Outside Roleplay');
+      expect(actions[3].type).toEqual('AUDIO_SET');
     });
 
     it('handles GOTOs that point to other roleplaying inside of the same combat', () => {
@@ -89,6 +92,12 @@ describe('Roleplay actions', () => {
     it('renders as combat for RPs inside of same combat', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 3, maxTier: 0, seed: ''});
       expect(actions[2].to.phase).toEqual('MID_COMBAT_ROLEPLAY');
+    });
+
+    it('renders as roleplay upon goto to element inside of win/lose event and zeros audio', () => {
+      const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 6, maxTier: 0, seed: ''});
+      expect(actions[2].to.phase).toEqual('ROLEPLAY');
+      expect(actions[3].type).toEqual('AUDIO_SET');
     });
   });
 });

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.test.tsx
@@ -50,7 +50,7 @@ describe('Roleplay actions', () => {
         <roleplay id="outside">Outside Roleplay</roleplay>
       </quest>`)('#c1'), defaultContext());
       baseNode = Action(initCombat as any).execute({node: baseNode, settings: TEST_SETTINGS})[1].node;
-      baseNode = Action(handleResolvePhase).execute({node: baseNode})[0].node;
+      baseNode = Action(handleResolvePhase).execute({node: baseNode})[1].node;
       return baseNode.clone();
     };
 
@@ -66,8 +66,8 @@ describe('Roleplay actions', () => {
 
     it('ends quest on **end** and zeros audio', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 2, maxTier: 0, seed: ''});
-      expect(actions[0].type).toEqual('AUDIO_SET');
-      expect(actions[2].to.name).toEqual('QUEST_END');
+      expect(actions[1].to.name).toEqual('QUEST_END');
+      expect(actions[2].type).toEqual('AUDIO_SET');
     });
 
     it('goes to next round when pnode.getNext() falls outside of combat scope', () => {

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
@@ -37,6 +37,7 @@ export const midCombatChoice = remoteify(function midCombatChoice(a: MidCombatCh
   // If there's no parent combat element, we've made a mistake somewhere and shouldn't even be in combat.
   // Handle the action and load the node as if it were a regular choice.
   if (parentCombatElem === null) {
+    console.log('No parent combat element - handling as regular choice');
     dispatch(choice({node: a.node, index: a.index}));
     return remoteArgs;
   }

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
@@ -1,10 +1,10 @@
 import {QuestNodeAction, remoteify} from 'app/actions/ActionTypes';
 import {audioSet} from 'app/actions/Audio';
 import {toCard} from 'app/actions/Card';
-import {endQuest, loadNode} from 'app/actions/Quest';
+import {choice, endQuest, loadNode} from 'app/actions/Quest';
 import {AppStateWithHistory, SettingsType} from 'app/reducers/StateTypes';
 import Redux from 'redux';
-import {handleCombatEnd} from '../combat/Actions';
+import {findCombatParent, handleCombatEnd} from '../combat/Actions';
 import {ParserNode} from '../TemplateTypes';
 
 export function initRoleplay(node: ParserNode, custom?: boolean) {
@@ -17,14 +17,6 @@ export function initRoleplay(node: ParserNode, custom?: boolean) {
     dispatch({type: 'QUEST_NODE', node} as QuestNodeAction);
     dispatch(toCard({name: 'QUEST_CARD', phase: 'ROLEPLAY', noHistory: true}));
   };
-}
-
-function findCombatParent(node: ParserNode) {
-  let elem = node && node.elem;
-  while (elem !== null && elem.length > 0 && elem.get(0).tagName.toLowerCase() !== 'combat') {
-    elem = elem.parent();
-  }
-  return elem;
 }
 
 interface MidCombatChoiceArgs {
@@ -41,44 +33,53 @@ export const midCombatChoice = remoteify(function midCombatChoice(a: MidCombatCh
   }
   const remoteArgs: MidCombatChoiceArgs = {index: a.index, seed: a.seed, maxTier: a.maxTier};
   const parentCombatElem = findCombatParent(a.node);
+
+  // If there's no parent combat element, we've made a mistake somewhere and shouldn't even be in combat.
+  // Handle the action and load the node as if it were a regular choice.
+  if (parentCombatElem === null) {
+    dispatch(choice({node: a.node, index: a.index}));
+    return remoteArgs;
+  }
+
   const nextNode = a.node.handleAction(a.index);
   const next = a.node.getNext(a.index);
   let nextIsInSameCombat = false;
   if (nextNode && next) {
     const nextParentCombatElem = findCombatParent(nextNode);
-    nextIsInSameCombat = (nextParentCombatElem && nextParentCombatElem.length > 0) && parentCombatElem.attr('data-line') === nextParentCombatElem.attr('data-line');
+    if (nextParentCombatElem !== null) {
+      nextIsInSameCombat = nextParentCombatElem.length > 0 && parentCombatElem.attr('data-line') === nextParentCombatElem.attr('data-line');
+    }
 
     // Check for and resolve triggers
     const nextIsTrigger = (next && next.getTag() === 'trigger');
     if (nextIsTrigger) {
       const triggerName = next.elem.text().trim().toLowerCase();
-      if (triggerName.startsWith('goto') && nextIsInSameCombat) {
+      if (triggerName === 'win' || triggerName === 'lose') {
+        // If the trigger exits via the win/lose handlers, go to the appropriate
+        // combat end card
+        const victory = triggerName === 'win';
+        dispatch(handleCombatEnd({
+          maxTier: a.maxTier,
+          node: new ParserNode(parentCombatElem, a.node.ctx),
+          seed: a.seed,
+          settings: a.settings,
+          victory,
+        }));
+        return remoteArgs;
+      } else if (triggerName.startsWith('goto') && nextIsInSameCombat) {
         // If we jump to somewhere in the same combat,
         // it's handled like a normal combat RP choice change (below).
       } else if (next.isEnd()) {
-        // Treat quest end as normal
+        // Treat quest end as normal, also stopping combat audio.
         dispatch(endQuest({}));
+        dispatch(audioSet({intensity: 0}));
         return remoteArgs;
       } else {
-        // If the trigger exits via the win/lose handlers, go to the appropriate
-        // combat end card
-        const parentCondition = nextNode.elem.parent().attr('on');
-        if (parentCondition === 'win' || parentCondition === 'lose') {
-          dispatch(handleCombatEnd({
-            maxTier: a.maxTier,
-            node: new ParserNode(parentCombatElem, a.node.ctx),
-            seed: a.seed,
-            settings: a.settings,
-            victory: (parentCondition === 'win'),
-          }));
-          return remoteArgs;
-        } else {
-          // Otherwise, treat like a typical event trigger.
-          // Make sure we stop combat audio since we're exiting this combat.
-          dispatch(loadNode(nextNode));
-          dispatch(audioSet({intensity: 0}));
-          return remoteArgs;
-        }
+        // Otherwise, treat like a typical event trigger.
+        // Make sure we stop combat audio since we're exiting this combat.
+        dispatch(loadNode(nextNode));
+        dispatch(audioSet({intensity: 0}));
+        return remoteArgs;
       }
     }
   }

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/Roleplay.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/Roleplay.tsx
@@ -99,6 +99,8 @@ export function loadRoleplayNode(node: ParserNode, theme: CardThemeType = 'light
           buttonText = <span>The End</span>;
           break;
         case 'goto':
+        case 'win':
+        case 'lose':
           break;
         default:
           throw new Error('Unknown trigger with text ' + triggerText);


### PR DESCRIPTION
- Now allows for `**win**` and `**lose**` trigger elements in QDL to trigger the win and lose events. This is a departure from the previous behavior, where `**goto ID**` would show the win or lose screen when the target was within the win or lose event of combat.
- Actually stop combat audio on edge cases (e.g. `**end**` trigger within combat RP)
- Fixes `yarn app-watch-test` so it actually rebuilds and executes the tests on file change
- Add some safety code to stop proliferation of "unknown event win/lose" at the end of combat. If we reach the victory card with a parsernode that's a roleplay node *within* the combat node, it correctly chooses the next node based on the parent combat node.
- resolve phase was improperly setting quest node before taking a history snapshot, which may have contributed to bugs.

#399