### PR TITLE
Migrate app to Quest schema, improve search results page when no results or when errors.

### DIFF
--- a/services/api/src/Handlers.ts
+++ b/services/api/src/Handlers.ts
@@ -121,7 +121,7 @@ function doSearch(db: Database, userId: string, params: QuestSearchParams): Blue
     return {
       error: e.toString(),
       hasMore: false,
-      quests: []
+      quests: [],
     };
   });
 }

--- a/services/api/src/Handlers.ts
+++ b/services/api/src/Handlers.ts
@@ -92,12 +92,45 @@ export function announcement(req: express.Request, res: express.Response) {
     });
 }
 
+export interface QuestSearchResponse {
+  error: null|string;
+  hasMore: boolean;
+  quests: Quest[];
+}
+function doSearch(db: Database, userId: string, params: QuestSearchParams): Bluebird<QuestSearchResponse> {
+  return searchQuests(db, userId, params)
+  .then((quests: QuestInstance[]) => {
+    // Map quest published URL to the API server so we can proxy quest data.
+    const results: Quest[] = quests
+      .map((q: QuestInstance) => Quest.create(q.dataValues))
+      .filter((q: Quest|Error) => !(q instanceof Error))
+      .map((q: Quest) => {
+        proxifyQuestURL(q);
+        return q;
+      });
+
+    console.log(`Found ${quests.length} quests for user ${userId}, params: ${JSON.stringify(params)}`);
+    return {
+      error: null,
+      hasMore: (quests.length === (params.limit || MAX_SEARCH_LIMIT)),
+      quests: results,
+    };
+  })
+  .catch((e: Error) => {
+    console.error(e);
+    return {
+      error: e.toString(),
+      hasMore: false,
+      quests: []
+    };
+  });
+}
 export function search(db: Database, req: express.Request, res: express.Response) {
   let body: any;
   try {
     body = JSON.parse(req.body);
   } catch (e) {
-    return res.status(500).end('Error reading request.');
+    return res.status(500).end({error: 'Could not parse request.'});
   }
   const params: QuestSearchParams = {
     age: body.age,
@@ -116,27 +149,8 @@ export function search(db: Database, req: express.Request, res: express.Response
     requirespenpaper: body.requirespenpaper,
     text: body.text,
   };
-  return searchQuests(db, res.locals.id, params)
-  .then((quests: QuestInstance[]) => {
-    // Map quest published URL to the API server so we can proxy quest data.
-    const results: Quest[] = quests
-      .map((q: QuestInstance) => Quest.create(q.dataValues))
-      .filter((q: Quest|Error) => !(q instanceof Error))
-      .map((q: Quest) => {
-        proxifyQuestURL(q);
-        return q;
-      });
-
-    console.log(`Found ${quests.length} quests for user ${res.locals.id}, params: ${JSON.stringify(params)}`);
-    res.status(200).end(JSON.stringify({
-      error: null,
-      hasMore: (quests.length === (params.limit || MAX_SEARCH_LIMIT)),
-      quests: results,
-    }));
-  })
-  .catch((e: Error) => {
-    console.error(e);
-    return res.status(500).end(GENERIC_ERROR_MESSAGE);
+  return doSearch(db, res.locals.id, params).then((result) => {
+    res.status((result.error) ? 500 : 200).end(JSON.stringify(result));
   });
 }
 

--- a/services/app/karma.conf.js
+++ b/services/app/karma.conf.js
@@ -4,7 +4,6 @@ webpackConfig.module.rules.unshift({
   test: /isIterable/,
   loader: 'imports?Symbol=>false'
 });
-webpackConfig.entry = undefined;
 
 // Remove copy plugin - which is the only plugin of constructor "object"
 for (let i = 0; i < webpackConfig.plugins.length; i++) {
@@ -25,7 +24,18 @@ module.exports = function(config) {
     preprocessors: {
       'src/**/*.test.tsx': ['webpack'],
     },
-    webpack: webpackConfig,
+    webpack: {
+      module: webpackConfig.module,
+      resolve: webpackConfig.resolve,
+      node: webpackConfig.node,
+      // Pull in module-specific configs (esp. tslint)
+      plugins: [webpackConfig.plugins[webpackConfig.plugins.length-1]],
+      externals: {
+        'react/addons': true,
+        'react/lib/ExecutionEnvironment': true,
+        'react/lib/ReactContext': true
+      },
+    },
     webpackMiddleware: {
       watchOptions: {
         ignored: [/\/\./, 'node_modules'],

--- a/services/app/karma.conf.js
+++ b/services/app/karma.conf.js
@@ -5,14 +5,6 @@ webpackConfig.module.rules.unshift({
   loader: 'imports?Symbol=>false'
 });
 
-// Remove copy plugin - which is the only plugin of constructor "object"
-for (let i = 0; i < webpackConfig.plugins.length; i++) {
-  if (webpackConfig.plugins[i].constructor.name == 'Object') {
-    webpackConfig.plugins.splice(i, 1);
-    break;
-  }
-}
-
 module.exports = function(config) {
   config.set({
     basePath: '',

--- a/services/app/package.json
+++ b/services/app/package.json
@@ -4,7 +4,7 @@
   "description": "The App for Expedition: The Roleplaying Card Game",
   "homepage": "http://app.expeditiongame.com",
   "scripts": {
-    "test": "karma start --single-run --browsers NoSandboxChromeHeadless",
+    "test": "node --max_old_space_size=4096 ../../node_modules/karma/bin/karma start --single-run --browsers NoSandboxChromeHeadless",
     "watch-test": "node --max_old_space_size=4096 ../../node_modules/karma/bin/karma start --browsers NoSandboxChromeHeadless",
     "start": "webpack-dev-server --progress --hot",
     "build": "webpack --config ./webpack.dist.config.js --progress",

--- a/services/app/src/Constants.tsx
+++ b/services/app/src/Constants.tsx
@@ -1,4 +1,4 @@
-import {QuestDetails} from './reducers/QuestTypes';
+import {Quest} from 'shared/schema/Quests';
 
 export const VERSION = (process && process.env && process.env.VERSION) || '0.0.1'; // Webpack
 export const NODE_ENV = (process && process.env && process.env.NODE_ENV) || 'dev';
@@ -23,15 +23,103 @@ export const MULTIPLAYER_SETTINGS = {
   websocketSession: ((NODE_ENV === 'production') ? 'wss://' : 'ws://') + splitURL[splitURL.length - 1] + '/ws/multiplayer/v1/session',
 };
 
-export const FEATURED_QUESTS: QuestDetails[] = [ // Featured quest ids generated from publishing, but don't leave them published!
-  {id: '0B7K9abSH1xEOeEZSVVMwNHNqaFE', partition: 'expedition-public', theme: 'base', official: true, title: 'Learning to Adventure', summary: 'Your first adventure.', author: 'Todd Medema', publishedurl: 'quests/learning_to_adventure.xml', minplayers: 1, maxplayers: 6, mintimeminutes: 20, maxtimeminutes: 30, genre: 'Drama', contentrating: 'Everyone', language: 'English' },
-  {id: '0B7K9abSH1xEOWVpEV1JGWDFtWmc', partition: 'expedition-public', theme: 'horror', official: true, title: 'Learning 2: The Horror', summary: 'Your first adventure continues with Expedition: The Horror.', author: 'Todd Medema', publishedurl: 'quests/learning_to_adventure_2_the_horror.xml', expansionhorror: true, minplayers: 1, maxplayers: 6, mintimeminutes: 20, maxtimeminutes: 40, genre: 'Drama', contentrating: 'Everyone', language: 'English' },
-  {id: '0BzrQOdaJcH9MU3Z4YnE2Qi1oZGs', partition: 'expedition-public', theme: 'base', official: true, title: 'Oust Albanus', summary: 'Your party encounters a smelly situation.', author: 'Scott Martin', publishedurl: 'quests/oust_albanus.xml', minplayers: 1, maxplayers: 6, mintimeminutes: 20, maxtimeminutes: 40, genre: 'Comedy', contentrating: 'Everyone', language: 'English' },
-  {id: '0B7K9abSH1xEORjdkMWtTY3ZtNGs', partition: 'expedition-public', theme: 'base', official: true, title: 'Mistress Malaise', summary: 'Mystery, Misfortune, and a Mistress.', author: 'Scott Martin', publishedurl: 'quests/mistress_malaise.xml', minplayers: 1, maxplayers: 6, mintimeminutes: 30, maxtimeminutes: 60, genre: 'Drama', contentrating: 'Everyone', language: 'English' },
-  {id: '0B7K9abSH1xEOUUR1Z0lncm9NRjQ', partition: 'expedition-public', theme: 'base', official: true, title: 'Dungeon Crawl', summary: 'How deep can you delve?', author: 'Todd Medema', publishedurl: 'quests/dungeon_crawl.xml', minplayers: 1, maxplayers: 6, mintimeminutes: 20, maxtimeminutes: 60, genre: 'Drama', contentrating: 'Everyone'},
+export const FEATURED_QUESTS: Quest[] = [ // Featured quest ids generated from publishing, but don't leave them published!
+  new Quest({
+    id: '0B7K9abSH1xEOeEZSVVMwNHNqaFE',
+    partition: 'expedition-public',
+    theme: 'base',
+    official: true,
+    title: 'Learning to Adventure',
+    summary: 'Your first adventure.',
+    author: 'Todd Medema',
+    publishedurl: 'quests/learning_to_adventure.xml',
+    minplayers: 1,
+    maxplayers: 6,
+    mintimeminutes: 20,
+    maxtimeminutes: 30,
+    genre: 'Drama',
+    contentrating: 'Kid-friendly',
+    language: 'English',
+  }),
+  new Quest({
+    id: '0B7K9abSH1xEOWVpEV1JGWDFtWmc',
+    partition: 'expedition-public',
+    theme: 'horror',
+    official: true,
+    title: 'Learning 2: The Horror',
+    summary: 'Your first adventure continues with Expedition: The Horror.',
+    author: 'Todd Medema',
+    publishedurl: 'quests/learning_to_adventure_2_the_horror.xml',
+    minplayers: 1,
+    maxplayers: 6,
+    mintimeminutes: 20,
+    maxtimeminutes: 40,
+    genre: 'Drama',
+    contentrating: 'Kid-friendly',
+    language: 'English',
+    expansionhorror: true,
+  }),
+  new Quest({
+    id: '0BzrQOdaJcH9MU3Z4YnE2Qi1oZGs',
+    partition: 'expedition-public',
+    theme: 'base',
+    official: true,
+    title: 'Oust Albanus',
+    summary: 'Your party encounters a smelly situation.',
+    author: 'Scott Martin',
+    publishedurl: 'quests/oust_albanus.xml',
+    minplayers: 1,
+    maxplayers: 6,
+    mintimeminutes: 20,
+    maxtimeminutes: 40,
+    genre: 'Comedy',
+    contentrating: 'Kid-friendly',
+    language: 'English',
+  }),
+  new Quest({
+    id: '0B7K9abSH1xEORjdkMWtTY3ZtNGs',
+    partition: 'expedition-public',
+    theme: 'base',
+    official: true,
+    title: 'Mistress Malaise',
+    summary: 'Mystery, Misfortune, and a Mistress.',
+    author: 'Scott Martin',
+    publishedurl: 'quests/mistress_malaise.xml',
+    minplayers: 1,
+    maxplayers: 6,
+    mintimeminutes: 30,
+    maxtimeminutes: 60,
+    genre: 'Drama',
+    contentrating: 'Kid-friendly',
+    language: 'English',
+  }),
+  new Quest({
+    id: '0B7K9abSH1xEOUUR1Z0lncm9NRjQ',
+    partition: 'expedition-public',
+    theme: 'base',
+    official: true,
+    title: 'Dungeon Crawl',
+    summary: 'How deep can you delve?',
+    author: 'Todd Medema',
+    publishedurl: 'quests/dungeon_crawl.xml',
+    minplayers: 1,
+    maxplayers: 6,
+    mintimeminutes: 20,
+    maxtimeminutes: 60,
+    genre: 'Drama',
+    contentrating: 'Kid-friendly',
+    language: 'English',
+  }),
 ];
 if (NODE_ENV === 'dev') { // http://quests.expeditiongame.com/#0B7K9abSH1xEOV3M2bTVMdWc4NVk
-  FEATURED_QUESTS.unshift({id: '1', title: 'Test quest', summary: 'DEV', author: 'DEV', publishedurl: 'quests/test_quest.xml'});
+  FEATURED_QUESTS.unshift(new Quest({
+    id: '1',
+    partition: 'expedition-public',
+    title: 'Test quest',
+    summary: 'DEV',
+    author: 'DEV',
+    publishedurl: 'quests/test_quest.xml',
+  }));
 }
 
 export const MAX_ADVENTURER_HEALTH = 12;

--- a/services/app/src/Style.scss
+++ b/services/app/src/Style.scss
@@ -1416,7 +1416,7 @@ body.android .dialog .textfield:focus-within {
       width: 11px;
       height: 11px;
       border-radius: 50%;
-      background: #fff;
+      background: #bg_dark_titlebar;
       animation-timing-function: cubic-bezier(0, 1, 1, 0);
     }
     div:nth-child(1) {

--- a/services/app/src/actions/ActionTypes.tsx
+++ b/services/app/src/actions/ActionTypes.tsx
@@ -1,7 +1,7 @@
 import Redux from 'redux';
 import {ClientID, InstanceID, StatusEvent} from 'shared/multiplayer/Events';
+import {Quest} from 'shared/schema/Quests';
 import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
-import {QuestDetails} from '../reducers/QuestTypes';
 import {
   AppState,
   AudioState,
@@ -81,13 +81,13 @@ export interface QuestExitAction extends Redux.Action {
 
 export interface QuestDetailsAction extends Redux.Action {
   type: 'QUEST_DETAILS';
-  details: QuestDetails;
+  details: Quest;
 }
 
 export interface QuestNodeAction extends Redux.Action {
   type: 'QUEST_NODE';
   node: ParserNode;
-  details?: QuestDetails;
+  details?: Quest;
 }
 
 export interface ChangeSettingsAction extends Redux.Action {
@@ -107,15 +107,14 @@ export interface SearchRequestAction extends Redux.Action {
 
 export interface SearchResponseAction extends Redux.Action {
   type: 'SEARCH_RESPONSE';
-  quests: QuestDetails[];
-  nextToken: string;
-  receivedAt: number;
+  quests: Quest[];
   search: SearchSettings;
+  error: string;
 }
 
 export interface PreviewQuestAction extends Redux.Action {
   type: 'PREVIEW_QUEST';
-  quest: QuestDetails;
+  quest: Quest;
   savedTS: number|null;
   lastPlayed: Date|null;
 }

--- a/services/app/src/actions/Quest.tsx
+++ b/services/app/src/actions/Quest.tsx
@@ -1,7 +1,7 @@
 import Redux from 'redux';
+import {Quest} from 'shared/schema/Quests';
 import {initCardTemplate} from '../components/views/quest/cardtemplates/Template';
 import {ParserNode, TemplateContext} from '../components/views/quest/cardtemplates/TemplateTypes';
-import {QuestDetails} from '../reducers/QuestTypes';
 import {AppStateWithHistory} from '../reducers/StateTypes';
 import {
   PreviewQuestAction,
@@ -13,7 +13,7 @@ import {
 import {toCard} from './Card';
 import {logQuestPlay} from './Web';
 
-export function initQuest(details: QuestDetails, questNode: Cheerio, ctx: TemplateContext): QuestNodeAction {
+export function initQuest(details: Quest, questNode: Cheerio, ctx: TemplateContext): QuestNodeAction {
   const firstNode = questNode.children().eq(0);
   const node = new ParserNode(firstNode, ctx);
   return {type: 'QUEST_NODE', node, details};
@@ -72,7 +72,7 @@ export const event = remoteify(function event(a: EventArgs, dispatch: Redux.Disp
 });
 
 // Used externally by the quest creator
-export function loadNode(node: ParserNode, details?: QuestDetails) {
+export function loadNode(node: ParserNode, details?: Quest) {
   return (dispatch: Redux.Dispatch<any>): any => {
     const tag = node.getTag();
     if (tag === 'trigger') {
@@ -92,7 +92,7 @@ export function loadNode(node: ParserNode, details?: QuestDetails) {
 }
 
 interface PreviewQuestArgs {
-  quest: QuestDetails;
+  quest: Quest;
   saveTS?: number;
   lastPlayed?: Date;
 }

--- a/services/app/src/actions/SavedQuests.test.tsx
+++ b/services/app/src/actions/SavedQuests.test.tsx
@@ -1,8 +1,8 @@
+import {Quest} from 'shared/schema/Quests';
 import {defaultContext} from '../components/views/quest/cardtemplates/Template';
 import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {getCheerio} from '../Globals';
 import {getStorageJson, getStorageString} from '../LocalStorage';
-import {Quest} from 'shared/schema/Quests';
 import {deleteSavedQuest, listSavedQuests, loadSavedQuest, SAVED_QUESTS_KEY, savedQuestKey, storeSavedQuest} from './SavedQuests';
 
 describe('SavedQuest actions', () => {

--- a/services/app/src/actions/SavedQuests.test.tsx
+++ b/services/app/src/actions/SavedQuests.test.tsx
@@ -2,7 +2,7 @@ import {defaultContext} from '../components/views/quest/cardtemplates/Template';
 import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {getCheerio} from '../Globals';
 import {getStorageJson, getStorageString} from '../LocalStorage';
-import {QuestDetails} from '../reducers/QuestTypes';
+import {Quest} from 'shared/schema/Quests';
 import {deleteSavedQuest, listSavedQuests, loadSavedQuest, SAVED_QUESTS_KEY, savedQuestKey, storeSavedQuest} from './SavedQuests';
 
 describe('SavedQuest actions', () => {
@@ -15,7 +15,7 @@ describe('SavedQuest actions', () => {
     if (next === null) {
       throw new Error('Initial setup failed');
     }
-    storeSavedQuest(next, {id: STORED_QUEST_ID} as any as QuestDetails, STORED_QUEST_TS);
+    storeSavedQuest(next, {id: STORED_QUEST_ID} as any as Quest, STORED_QUEST_TS);
   });
   afterEach(() => {
     localStorage.clear();
@@ -40,11 +40,11 @@ describe('SavedQuest actions', () => {
     }
 
     it('adds to the listing without affecting other quests', () => {
-      storeSavedQuest(pnode, {id: NEW_ID} as any as QuestDetails, NEW_TS);
+      storeSavedQuest(pnode, {id: NEW_ID} as any as Quest, NEW_TS);
       expect(getStorageJson(SAVED_QUESTS_KEY, [])).toContain({ts: NEW_TS, details: {id: NEW_ID}, pathLen: 1});
     });
     it('stores xml and context path', () => {
-      storeSavedQuest(pnode, {id: NEW_ID} as any as QuestDetails, NEW_TS);
+      storeSavedQuest(pnode, {id: NEW_ID} as any as Quest, NEW_TS);
       expect(getStorageJson(savedQuestKey(NEW_ID, NEW_TS), {})).toEqual({xml: (quest + ''), path: [0]});
     });
   });

--- a/services/app/src/actions/SavedQuests.tsx
+++ b/services/app/src/actions/SavedQuests.tsx
@@ -1,10 +1,10 @@
 import * as Redux from 'redux';
+import {Quest} from 'shared/schema/Quests';
 import {defaultContext} from '../components/views/quest/cardtemplates/Template';
 import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {getCheerio} from '../Globals';
 import {getStorageJson, setStorageKeyValue} from '../LocalStorage';
 import {logEvent} from '../Logging';
-import {QuestDetails} from '../reducers/QuestTypes';
 import {SavedQuestMeta} from '../reducers/StateTypes';
 import {QuestNodeAction, SavedQuestDeletedAction, SavedQuestListAction, SavedQuestStoredAction} from './ActionTypes';
 import {initQuest} from './Quest';
@@ -44,7 +44,7 @@ export function deleteSavedQuest(id: string, ts: number) {
   throw new Error('No such quest with ID ' + id + ', timestamp ' + ts.toString() + '.');
 }
 
-export function saveQuestForOffline(details: QuestDetails) {
+export function saveQuestForOffline(details: Quest) {
   return (dispatch: Redux.Dispatch<any>): any => {
     return fetchLocal(details.publishedurl).then((result: string) => {
       const elem = cheerio.load(result)('quest');
@@ -58,7 +58,7 @@ export function saveQuestForOffline(details: QuestDetails) {
   };
 }
 
-export function storeSavedQuest(node: ParserNode, details: QuestDetails, ts: number): SavedQuestStoredAction {
+export function storeSavedQuest(node: ParserNode, details: Quest, ts: number): SavedQuestStoredAction {
   logEvent('save', 'quest_save', { ...details, action: details.title, label: details.id });
   // Update the listing
   const savedQuests = getSavedQuestMeta();
@@ -79,7 +79,7 @@ export function storeSavedQuest(node: ParserNode, details: QuestDetails, ts: num
   return {type: 'SAVED_QUEST_STORED', savedQuests};
 }
 
-function recreateNodeFromPath(details: QuestDetails, xml: string, path: string|number[]): ParserNode {
+function recreateNodeFromPath(details: Quest, xml: string, path: string|number[]): ParserNode {
   let node = initQuest(details, getCheerio().load(xml)('quest'), defaultContext()).node;
   for (const action of path) {
     // TODO: Also save random seed with path in context
@@ -94,7 +94,7 @@ function recreateNodeFromPath(details: QuestDetails, xml: string, path: string|n
 
 export function loadSavedQuest(id: string, ts: number): QuestNodeAction {
   const savedQuests = getSavedQuestMeta();
-  let details: QuestDetails|null = null;
+  let details: Quest|null = null;
   for (const savedQuest of savedQuests) {
     if (savedQuest.details.id === id && savedQuest.ts === ts) {
       details = savedQuest.details;

--- a/services/app/src/actions/Search.tsx
+++ b/services/app/src/actions/Search.tsx
@@ -1,7 +1,8 @@
+import {QuestSearchResponse} from 'api/Handlers';
 import * as Redux from 'redux';
+import {Quest} from 'shared/schema/Quests';
 import {openSnackbar} from '../actions/Snackbar';
 import {AUTH_SETTINGS, FEATURED_QUESTS} from '../Constants';
-import {QuestDetails} from '../reducers/QuestTypes';
 import {CardPhase, ExpansionsType, SearchSettings, SettingsType} from '../reducers/StateTypes';
 import {SearchResponseAction} from './ActionTypes';
 import {remoteify} from './ActionTypes';
@@ -20,11 +21,10 @@ export const search = remoteify(function search(a: {search: SearchSettings, sett
   const dispatchPhase = (params.partition === 'expedition-private') ? 'PRIVATE' : 'SEARCH';
   params.expansions = Object.keys(a.settings.contentSets).filter( (key) => a.settings.contentSets[key] ) as ExpansionsType[],
   dispatch(toCard({name: 'SEARCH_CARD', phase: dispatchPhase as CardPhase}));
-  dispatch(getSearchResults(params, (quests: QuestDetails[], response: any) => {
+  dispatch(getSearchResults(params, (response: QuestSearchResponse) => {
     dispatch({
-      nextToken: response.nextToken,
-      quests,
-      receivedAt: response.receivedAt,
+      quests: response.quests,
+      error: response.error,
       search: params,
       type: 'SEARCH_RESPONSE',
     } as SearchResponseAction);
@@ -38,25 +38,24 @@ export const searchAndPlay = remoteify(function searchAndPlay(id: string, dispat
     id,
     partition: 'expedition-public',
   } as SearchSettings;
-  const featuredQuest = FEATURED_QUESTS.filter((q: QuestDetails) => q.id === id);
+  const featuredQuest = FEATURED_QUESTS.filter((q) => q.id === id);
   if (featuredQuest.length === 1) {
     dispatch(previewQuest({quest: featuredQuest[0]}));
   } else {
-    dispatch(getSearchResults(params, (quests: QuestDetails[], response: any) => {
+    dispatch(getSearchResults(params, (response: QuestSearchResponse) => {
       dispatch({
-        nextToken: response.nextToken,
-        quests,
-        receivedAt: response.receivedAt,
+        quests: response.quests,
+        error: response.error,
         search: {}, // Don't specify search params because this one's weird and uses ID
         type: 'SEARCH_RESPONSE',
       } as SearchResponseAction);
-      if (quests.length === 0) {
+      if (response.quests.length === 0) {
         // TODO better alert / failure UI (dialog)
         // https://github.com/ExpeditionRPG/expedition-app/issues/625
         alert('Quest not found, returning to home screen.');
         dispatch(toCard({name: 'SPLASH_CARD'}));
       } else {
-        dispatch(previewQuest({quest: quests[0]}));
+        dispatch(previewQuest({quest: response.quests[0]}));
       }
     }));
   }
@@ -64,7 +63,7 @@ export const searchAndPlay = remoteify(function searchAndPlay(id: string, dispat
 });
 
 // TODO switch to fetch since this never loads local files
-function getSearchResults(params: SearchSettings, callback: (quests: QuestDetails[], response: any) => void) {
+function getSearchResults(params: SearchSettings, callback: (response: QuestSearchResponse) => void) {
   return (dispatch: Redux.Dispatch<any>) => {
     // Clear previous results
     dispatch({type: 'SEARCH_REQUEST'});
@@ -74,22 +73,29 @@ function getSearchResults(params: SearchSettings, callback: (quests: QuestDetail
     xhr.open('POST', AUTH_SETTINGS.URL_BASE + '/quests', true);
     xhr.setRequestHeader('Content-Type', 'text/plain');
     xhr.onload = () => {
-      const response: any = JSON.parse(xhr.responseText);
-      if (response.error) {
-        dispatch({type: 'SEARCH_ERROR'});
-        return dispatch(openSnackbar(Error('Search error: ' + response.error)));
+      let response: QuestSearchResponse;
+      try {
+        response = JSON.parse(xhr.responseText);
+        if (response.error) {
+          throw Error(response.error);
+        }
+      } catch (e) {
+        response = {error: e.toString(), hasMore: false, quests: []};
       }
-
       // Simple validation of response quests
-      const quests: QuestDetails[] = [];
-      for (const q of response.quests) {
-        if (!q.id || !q.title || !q.summary || !q.author || !q.publishedurl) {
-          console.error('Parsed invalid quest: ' + JSON.stringify(q));
-        } else {
-          quests.push(q);
+      const quests: Quest[] = [];
+      if (response.quests) {
+        for (const q of response.quests) {
+          const i = Quest.create(q);
+          if (i instanceof Error) {
+            console.error('Parsed invalid quest: ' + JSON.stringify(q));
+          } else {
+            quests.push(i);
+          }
         }
       }
-      callback(quests, response);
+      response.quests = quests;
+      callback(response);
     };
     xhr.onerror = () => {
       dispatch(openSnackbar(Error('Network error: Please check your connection.')));

--- a/services/app/src/actions/Search.tsx
+++ b/services/app/src/actions/Search.tsx
@@ -76,9 +76,6 @@ function getSearchResults(params: SearchSettings, callback: (response: QuestSear
       let response: QuestSearchResponse;
       try {
         response = JSON.parse(xhr.responseText);
-        if (response.error) {
-          throw Error(response.error);
-        }
       } catch (e) {
         response = {error: e.toString(), hasMore: false, quests: []};
       }

--- a/services/app/src/actions/Search.tsx
+++ b/services/app/src/actions/Search.tsx
@@ -79,6 +79,13 @@ function getSearchResults(params: SearchSettings, callback: (response: QuestSear
       } catch (e) {
         response = {error: e.toString(), hasMore: false, quests: []};
       }
+
+      // Log silently to console, so we can see if users file feedback
+      // with recurrent search problems.
+      if (response.error) {
+        console.error(response.error);
+      }
+
       // Simple validation of response quests
       const quests: Quest[] = [];
       if (response.quests) {

--- a/services/app/src/actions/Web.tsx
+++ b/services/app/src/actions/Web.tsx
@@ -1,4 +1,5 @@
 import Redux from 'redux';
+import {Quest} from 'shared/schema/Quests';
 import {defaultContext} from '../components/views/quest/cardtemplates/Template';
 import {ParserNode, TemplateContext} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {MIN_FEEDBACK_LENGTH} from '../Constants';
@@ -7,7 +8,6 @@ import {getDevicePlatform, getPlatformDump} from '../Globals';
 import {logEvent} from '../Logging';
 import {getLogBuffer} from '../Logging';
 import {MultiplayerCounters} from '../Multiplayer';
-import {QuestDetails} from '../reducers/QuestTypes';
 import {AppState, FeedbackType, QuestState, SettingsType, UserQuestsType, UserState} from '../reducers/StateTypes';
 import {remoteify, UserQuestsAction} from './ActionTypes';
 import {toCard} from './Card';
@@ -55,7 +55,7 @@ export function fetchUserQuests() {
   };
 }
 
-export const fetchQuestXML = remoteify(function fetchQuestXML(details: QuestDetails, dispatch: Redux.Dispatch<any>) {
+export const fetchQuestXML = remoteify(function fetchQuestXML(details: Quest, dispatch: Redux.Dispatch<any>) {
   const promise = fetchLocal(details.publishedurl).then((result: string) => {
     const questNode = cheerio.load(result)('quest');
     return dispatch(loadQuestXML({details, questNode, ctx: defaultContext()}));
@@ -68,7 +68,7 @@ export const fetchQuestXML = remoteify(function fetchQuestXML(details: QuestDeta
 });
 
 // for loading quests in the app - Quest Creator injects directly into initQuest.
-export function loadQuestXML(a: {details: QuestDetails, questNode: Cheerio, ctx: TemplateContext}) {
+export function loadQuestXML(a: {details: Quest, questNode: Cheerio, ctx: TemplateContext}) {
   return (dispatch: Redux.Dispatch<any>) => {
     dispatch(initQuest(a.details, a.questNode, a.ctx));
 
@@ -228,7 +228,7 @@ function postUserFeedback(type: string, data: any) {
   };
 }
 
-export function logMultiplayerStats(user: UserState, quest: QuestDetails, stats: MultiplayerCounters): Promise<Response> {
+export function logMultiplayerStats(user: UserState, quest: Quest, stats: MultiplayerCounters): Promise<Response> {
   try {
     const data = {
       console: getLogBuffer(),

--- a/services/app/src/components/base/Dialogs.tsx
+++ b/services/app/src/components/base/Dialogs.tsx
@@ -5,9 +5,9 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import TextField from '@material-ui/core/TextField';
 import * as React from 'react';
+import {Quest} from 'shared/schema/Quests';
 import {openWindow} from '../../Globals';
 import {MultiplayerCounters} from '../../Multiplayer';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import {ContentSetsType, DialogState, FeedbackType, QuestState, SavedQuestMeta, SettingsType, UserState} from '../../reducers/StateTypes';
 import Checkbox from './Checkbox';
 import Picker from './Picker';
@@ -60,9 +60,9 @@ export class ExitMultiplayerDialog extends React.Component<ExitMultiplayerDialog
 
 interface MultiplayerStatusDialogProps extends React.Props<any> {
   onClose: () => void;
-  onSendReport: (user: UserState, quest: QuestDetails, stats: MultiplayerCounters) => void;
+  onSendReport: (user: UserState, quest: Quest, stats: MultiplayerCounters) => void;
   open: boolean;
-  questDetails: QuestDetails;
+  questDetails: Quest;
   stats: MultiplayerCounters;
   user: UserState;
 }
@@ -228,8 +228,8 @@ interface SetPlayerCountDialogProps extends React.Props<any> {
   onMultitouchChange: (v: boolean) => void;
   onPlayerDelta: (numPlayers: number, delta: number) => void;
   open: boolean;
-  playQuest: (quest: QuestDetails) => void;
-  quest: QuestDetails;
+  playQuest: (quest: Quest) => void;
+  quest: Quest;
   settings: SettingsType;
 }
 
@@ -321,8 +321,8 @@ export interface DispatchProps {
   onFeedbackSubmit: (type: FeedbackType, quest: QuestState, settings: SettingsType, user: UserState, text: string) => void;
   onMultitouchChange: (v: boolean) => void;
   onPlayerDelta: (numPlayers: number, delta: number) => void;
-  onSendMultiplayerReport: (user: UserState, quest: QuestDetails, stats: MultiplayerCounters) => void;
-  playQuest: (quest: QuestDetails) => void;
+  onSendMultiplayerReport: (user: UserState, quest: Quest, stats: MultiplayerCounters) => void;
+  playQuest: (quest: Quest) => void;
 }
 
 interface Props extends StateProps, DispatchProps {}

--- a/services/app/src/components/base/DialogsContainer.tsx
+++ b/services/app/src/components/base/DialogsContainer.tsx
@@ -1,6 +1,7 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
 
+import {Quest} from 'shared/schema/Quests';
 import {toPrevious} from '../../actions/Card';
 import {setDialog} from '../../actions/Dialog';
 import {multiplayerDisconnect} from '../../actions/Multiplayer';
@@ -11,7 +12,6 @@ import {openSnackbar} from '../../actions/Snackbar';
 import {fetchQuestXML, logMultiplayerStats, submitUserFeedback} from '../../actions/Web';
 import {MIN_FEEDBACK_LENGTH} from '../../Constants';
 import {getMultiplayerClient, initialMultiplayerCounters, MultiplayerCounters} from '../../Multiplayer';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import {AppState, ContentSetsType, FeedbackType, QuestState, SavedQuestMeta, SettingsType, UserState} from '../../reducers/StateTypes';
 import Dialogs, {DispatchProps, StateProps} from './Dialogs';
 
@@ -77,14 +77,14 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       }
       dispatch(changeSettings({numPlayers}));
     },
-    onSendMultiplayerReport: (user: UserState, quest: QuestDetails, stats: MultiplayerCounters) => {
+    onSendMultiplayerReport: (user: UserState, quest: Quest, stats: MultiplayerCounters) => {
       logMultiplayerStats(user, quest, stats)
         .then((r: Response) => {
           dispatch(openSnackbar('Stats submitted. Thank you!'));
           dispatch(setDialog(null));
         });
     },
-    playQuest: (quest: QuestDetails) => {
+    playQuest: (quest: Quest) => {
       dispatch(setDialog(null));
       dispatch(fetchQuestXML(quest));
     },

--- a/services/app/src/components/views/FeaturedQuests.tsx
+++ b/services/app/src/components/views/FeaturedQuests.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
+import {Quest} from 'shared/schema/Quests';
 import {openWindow} from '../../Globals';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import {CardName, SettingsType, UserState} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
 
 export interface StateProps {
-  quests: QuestDetails[];
+  quests: Quest[];
   settings: SettingsType;
   user: UserState;
 }
@@ -14,17 +14,17 @@ export interface StateProps {
 export interface DispatchProps {
   toCard: (name: CardName) => any;
   onSearchSelect: (user: UserState, settings: SettingsType) => any;
-  onQuestSelect: (quest: QuestDetails) => any;
+  onQuestSelect: (quest: Quest) => any;
 }
 
 export interface Props extends StateProps, DispatchProps {}
 
 const FeaturedQuests = (props: Props): JSX.Element => {
   const items: JSX.Element[] = props.quests
-    .filter((quest: QuestDetails): boolean => {
+    .filter((quest: Quest): boolean => {
       return (!quest.expansionhorror || props.settings.contentSets.horror);
     })
-    .map((quest: QuestDetails, index: number): JSX.Element => {
+    .map((quest: Quest, index: number): JSX.Element => {
       return (
         <Button onClick={() => props.onQuestSelect(quest)} key={index} id={'quest' + index.toString()}>
           <div className="questButton">

--- a/services/app/src/components/views/FeaturedQuestsContainer.tsx
+++ b/services/app/src/components/views/FeaturedQuestsContainer.tsx
@@ -1,11 +1,11 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
 
+import {Quest} from 'shared/schema/Quests';
 import {toCard} from '../../actions/Card';
 import {previewQuest} from '../../actions/Quest';
 import {search} from '../../actions/Search';
 import {FEATURED_QUESTS} from '../../Constants';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import {initialSearch} from '../../reducers/Search';
 import {AppState, CardName, SettingsType, UserState} from '../../reducers/StateTypes';
 import FeaturedQuests, {DispatchProps, StateProps} from './FeaturedQuests';
@@ -33,7 +33,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
         dispatch(toCard({name: 'SEARCH_CARD', phase: 'DISCLAIMER'}));
       }
     },
-    onQuestSelect(quest: QuestDetails): void {
+    onQuestSelect(quest: Quest): void {
       dispatch(previewQuest({quest}));
     },
   };

--- a/services/app/src/components/views/QuestPreview.test.tsx
+++ b/services/app/src/components/views/QuestPreview.test.tsx
@@ -33,10 +33,9 @@ describe('QuestPreview', () => {
     expect(wrapper.html()).toContain(quest.genre);
     expect(wrapper.html()).toContain(quest.summary);
     expect(wrapper.html()).toContain(quest.author);
-    expect(wrapper.html()).toContain(quest.official);
-    expect(wrapper.html()).not.toContain(quest.expansionhorror);
-    expect(wrapper.html()).not.toContain(quest.requirespenpaper);
-    expect(wrapper.html()).not.toContain(quest.awarded);
+    expect(wrapper.html()).toContain('Official Quest');
+    expect(wrapper.html()).not.toContain('The Horror');
+    expect(wrapper.html()).not.toContain('Pen and Paper');
   });
 
   it('shows last played information if it has been played before', () => {

--- a/services/app/src/components/views/QuestPreview.test.tsx
+++ b/services/app/src/components/views/QuestPreview.test.tsx
@@ -1,18 +1,18 @@
 import {configure, render} from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
+import {Quest} from 'shared/schema/Quests';
 import {FEATURED_QUESTS} from '../../Constants';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import {initialSettings} from '../../reducers/Settings';
 import QuestPreview, {Props} from './QuestPreview';
 configure({ adapter: new Adapter() });
 
 describe('QuestPreview', () => {
-  function setup(questTitle: string, overrides?: Partial<Props>, questOverrides?: Partial<QuestDetails>) {
+  function setup(questTitle: string, overrides?: Partial<Props>, questOverrides?: Partial<Quest>) {
     const props: Props = {
       isDirectLinked: false,
       savedInstances: [],
       lastPlayed: null,
-      quest: {...FEATURED_QUESTS.filter((el) => el.title === questTitle)[0], ...questOverrides},
+      quest: new Quest({...FEATURED_QUESTS.filter((el) => el.title === questTitle)[0], ...questOverrides}),
       settings: initialSettings,
       onPlay: jasmine.createSpy('onPlay'),
       onPlaySaved: jasmine.createSpy('onPlaySaved'),

--- a/services/app/src/components/views/QuestPreview.tsx
+++ b/services/app/src/components/views/QuestPreview.tsx
@@ -3,8 +3,8 @@ import OfflinePin from '@material-ui/icons/OfflinePin';
 import StarsIcon from '@material-ui/icons/Stars';
 import * as pluralize from 'pluralize';
 import * as React from 'react';
+import {Quest} from 'shared/schema/Quests';
 import {formatPlayPeriod} from '../../Format';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import {SavedQuestMeta, SettingsType} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
@@ -14,16 +14,16 @@ const Moment = require('moment');
 
 export interface StateProps {
   settings: SettingsType;
-  quest: QuestDetails | null;
+  quest: Quest | null;
   lastPlayed: Date | null;
   savedInstances: SavedQuestMeta[];
   isDirectLinked: boolean;
 }
 
 export interface DispatchProps {
-  onPlay: (quest: QuestDetails, isDirectLinked: boolean) => void;
+  onPlay: (quest: Quest, isDirectLinked: boolean) => void;
   onPlaySaved: (id: string, ts: number) => void;
-  onSave: (quest: QuestDetails) => void;
+  onSave: (quest: Quest) => void;
   onDeleteOffline: (id: string, ts: number) => void;
   onDeleteConfirm: () => void;
   onReturn: () => void;
@@ -31,7 +31,7 @@ export interface DispatchProps {
 
 export interface Props extends StateProps, DispatchProps {}
 
-function renderRequirements(quest: QuestDetails): JSX.Element[] {
+function renderRequirementsRow(quest: Quest): JSX.Element|null {
   const requires = [];
   if (quest.expansionhorror) {
     requires.push(<span key="horror"><img className="inline_icon" src="images/horror_small.svg"/>The Horror</span>);
@@ -41,7 +41,7 @@ function renderRequirements(quest: QuestDetails): JSX.Element[] {
   }
 
   if (requires.length === 0) {
-    return [<span key={0}>None</span>];
+    return null;
   }
 
   const delimited = [];
@@ -51,7 +51,7 @@ function renderRequirements(quest: QuestDetails): JSX.Element[] {
       delimited.push(<span key={i}>,&nbsp;</span>);
     }
   }
-  return delimited;
+  return <tr><th>Requires</th><td>{delimited}</td></tr>;
 }
 
 function renderSaves(props: Props): JSX.Element|null {
@@ -132,7 +132,7 @@ const QuestPreview = (props: Props): JSX.Element => {
         <h3>Details</h3>
         <table className="searchDetailsTable">
           <tbody>
-            <tr><th>Requires</th><td>{renderRequirements(quest)}</td></tr>
+            {renderRequirementsRow(quest)}
             <tr><th>Content rating</th><td>{quest.contentrating}</td></tr>
             {quest.mintimeminutes !== undefined && quest.maxtimeminutes !== undefined &&
               <tr><th>Play time</th><td>{formatPlayPeriod(quest.mintimeminutes, quest.maxtimeminutes)}</td></tr>

--- a/services/app/src/components/views/QuestPreviewContainer.tsx
+++ b/services/app/src/components/views/QuestPreviewContainer.tsx
@@ -1,11 +1,11 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
+import {Quest} from 'shared/schema/Quests';
 import {toCard, toPrevious} from '../../actions/Card';
 import {setDialog} from '../../actions/Dialog';
 import {deleteSavedQuest, loadSavedQuest, saveQuestForOffline} from '../../actions/SavedQuests';
 import {openSnackbar} from '../../actions/Snackbar';
 import {fetchQuestXML} from '../../actions/Web';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import {AppStateWithHistory, SavedQuestMeta} from '../../reducers/StateTypes';
 import QuestPreview, {DispatchProps, StateProps} from './QuestPreview';
 
@@ -25,7 +25,7 @@ const mapStateToProps = (state: AppStateWithHistory): StateProps => {
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
-    onPlay: (quest: QuestDetails, isDirectLinked: boolean) => {
+    onPlay: (quest: Quest, isDirectLinked: boolean) => {
       if (isDirectLinked) {
         dispatch(setDialog('SET_PLAYER_COUNT'));
       } else {
@@ -36,7 +36,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       dispatch(loadSavedQuest(id, ts));
       dispatch(toCard({name: 'QUEST_CARD'}));
     },
-    onSave(quest: QuestDetails) {
+    onSave(quest: Quest) {
       dispatch(saveQuestForOffline(quest));
     },
     onDeleteOffline(id: string, ts: number): void {

--- a/services/app/src/components/views/Search.test.tsx
+++ b/services/app/src/components/views/Search.test.tsx
@@ -1,9 +1,9 @@
 import {configure, render} from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
 import {LanguageType} from 'shared/schema/Constants';
+import {Quest} from 'shared/schema/Quests';
 import {FEATURED_QUESTS} from '../../Constants';
 import {SearchSettings} from '../../reducers/StateTypes';
-import {Quest} from 'shared/schema/Quests';
 import {
   renderResult,
   SearchResultProps,
@@ -127,7 +127,8 @@ describe('Search', () => {
   });
 
   describe('Results', () => {
-    it('gracefully handles no search results');
+    it('offers tips when no search results');
     it('renders some search results');
+    it('shows spinner when loading results');
   });
 });

--- a/services/app/src/components/views/Search.test.tsx
+++ b/services/app/src/components/views/Search.test.tsx
@@ -2,8 +2,8 @@ import {configure, render} from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
 import {LanguageType} from 'shared/schema/Constants';
 import {FEATURED_QUESTS} from '../../Constants';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import {SearchSettings} from '../../reducers/StateTypes';
+import {Quest} from 'shared/schema/Quests';
 import {
   renderResult,
   SearchResultProps,
@@ -64,13 +64,13 @@ describe('Search', () => {
   });
 
   describe('Result', () => {
-    function setup(questTitle: string, overrides?: Partial<SearchResultProps>, questOverrides?: Partial<QuestDetails>) {
+    function setup(questTitle: string, overrides?: Partial<SearchResultProps>, questOverrides?: Partial<Quest>) {
       const props: SearchResultProps = {
         index: 0,
         lastPlayed: null,
         offlineQuests: {},
         onQuest: jasmine.createSpy('onQuest'),
-        quest: {...FEATURED_QUESTS.filter((el) => el.title === questTitle)[0], ...questOverrides},
+        quest: new Quest({...FEATURED_QUESTS.filter((el) => el.title === questTitle)[0], ...questOverrides}),
         search: TEST_SEARCH,
         ...overrides,
       };

--- a/services/app/src/components/views/Search.tsx
+++ b/services/app/src/components/views/Search.tsx
@@ -8,9 +8,9 @@ import StarsIcon from '@material-ui/icons/Stars';
 import * as React from 'react';
 import Truncate from 'react-truncate';
 import {CONTENT_RATING_DESC, GenreType, LANGUAGES} from 'shared/schema/Constants';
+import {Quest} from 'shared/schema/Quests';
 import {PLAYTIME_MINUTES_BUCKETS} from '../../Constants';
 import {formatPlayPeriod, smartTruncateSummary} from '../../Format';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import {SearchPhase, SearchSettings, SearchState, SettingsType, UserQuestHistory, UserState} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
@@ -32,7 +32,7 @@ export interface StateProps extends SearchState {
 export interface DispatchProps {
   onFilter: () => void;
   onLoginRequest: (subscribe: boolean) => void;
-  onQuest: (quest: QuestDetails) => void;
+  onQuest: (quest: Quest) => void;
   onReturn: () => void;
   onSearch: (search: SearchSettings, settings: SettingsType) => void;
 }
@@ -219,8 +219,8 @@ function renderSettings(props: Props): JSX.Element {
 export interface SearchResultProps {
   index: number;
   lastPlayed: Date | null;
-  onQuest: (quest: QuestDetails) => void;
-  quest: QuestDetails;
+  onQuest: (quest: Quest) => void;
+  quest: Quest;
   search: SearchSettings;
   offlineQuests: {[id: string]: boolean};
 }
@@ -284,7 +284,7 @@ export function renderResult(props: SearchResultProps): JSX.Element {
 }
 
 function renderResults(props: Props, hideHeader?: boolean): JSX.Element {
-  const results: JSX.Element[] = (props.results || []).map((quest: QuestDetails, index: number) => {
+  const results: JSX.Element[] = (props.results || []).map((quest: Quest, index: number) => {
     return renderResult({index, quest, search: props.search, onQuest: props.onQuest, lastPlayed: (props.questHistory.list[quest.id] || {}).lastPlayed, offlineQuests: props.offlineQuests});
   });
 

--- a/services/app/src/components/views/Search.tsx
+++ b/services/app/src/components/views/Search.tsx
@@ -284,9 +284,33 @@ export function renderResult(props: SearchResultProps): JSX.Element {
 }
 
 function renderResults(props: Props, hideHeader?: boolean): JSX.Element {
-  const results: JSX.Element[] = (props.results || []).map((quest: Quest, index: number) => {
-    return renderResult({index, quest, search: props.search, onQuest: props.onQuest, lastPlayed: (props.questHistory.list[quest.id] || {}).lastPlayed, offlineQuests: props.offlineQuests});
-  });
+  let content: JSX.Element | JSX.Element[];
+  const numResults = (props.results || []).length;
+  if (numResults === 0 && !props.searching) {
+    content = (
+      <div className="searchDescription">
+        <h2>No quests found</h2>
+        {!hideHeader && <span>
+          <p>Try broadening the search by using fewer filters.</p>
+          <p>If you still see no results, file feedback from the top corner menu.</p>
+        </span>}
+        <Button className="filter_button" onClick={() => props.onFilter()} id="filter">Modify Search</Button>
+      </div>
+    );
+  } else if (numResults === 0 && props.searching) {
+    content = (
+      <div className="lds-ellipsis">
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+    );
+  } else {
+    content = (props.results || []).map((quest: Quest, index: number) => {
+      return renderResult({index, quest, search: props.search, onQuest: props.onQuest, lastPlayed: (props.questHistory.list[quest.id] || {}).lastPlayed, offlineQuests: props.offlineQuests});
+    });
+  }
 
   return (
     <Card
@@ -297,15 +321,7 @@ function renderResults(props: Props, hideHeader?: boolean): JSX.Element {
         <Button className="filter_button" onClick={() => props.onFilter()} id="filter">Filter &amp; Sort ></Button>
       </div>}
     >
-      {results.length === 0 && !props.searching &&
-        <div>
-          <div>No quests found matching the search terms.</div>
-          {!hideHeader && <div>Try broadening the search by using fewer filters.</div>}
-          <Button className="filter_button" onClick={() => props.onFilter()} id="filter">Modify Search</Button>
-        </div>
-      }
-      {results.length === 0 && props.searching && <div className="lds-ellipsis"><div></div><div></div><div></div><div></div></div>}
-      {results}
+      {content}
     </Card>
   );
 }

--- a/services/app/src/components/views/Search.tsx
+++ b/services/app/src/components/views/Search.tsx
@@ -283,7 +283,7 @@ export function renderResult(props: SearchResultProps): JSX.Element {
   );
 }
 
-function renderResults(props: Props, hideHeader?: boolean): JSX.Element {
+export function renderResults(props: Props, hideHeader?: boolean): JSX.Element {
   let content: JSX.Element | JSX.Element[];
   const numResults = (props.results || []).length;
   if (numResults === 0 && !props.searching) {

--- a/services/app/src/components/views/SearchContainer.tsx
+++ b/services/app/src/components/views/SearchContainer.tsx
@@ -1,11 +1,11 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
+import {Quest} from 'shared/schema/Quests';
 import {toCard, toPrevious} from '../../actions/Card';
 import {previewQuest} from '../../actions/Quest';
 import {search} from '../../actions/Search';
 import {ensureLogin} from '../../actions/User';
 import {subscribe} from '../../actions/Web';
-import {QuestDetails} from '../../reducers/QuestTypes';
 import {AppStateWithHistory, SearchSettings, SettingsType, UserState} from '../../reducers/StateTypes';
 import Search, {DispatchProps, StateProps} from './Search';
 
@@ -43,7 +43,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
           return dispatch(toCard({name: 'SEARCH_CARD', phase: 'SETTINGS'}));
         });
     },
-    onQuest: (quest: QuestDetails) => {
+    onQuest: (quest: Quest) => {
       dispatch(previewQuest({quest}));
     },
     onReturn: () => {

--- a/services/app/src/reducers/Quest.tsx
+++ b/services/app/src/reducers/Quest.tsx
@@ -1,5 +1,6 @@
 import Redux from 'redux';
 import * as seedrandom from 'seedrandom';
+import {Quest} from 'shared/schema/Quests';
 import {PreviewQuestAction, QuestDetailsAction, QuestNodeAction} from '../actions/ActionTypes';
 import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {QuestState} from './StateTypes';
@@ -16,14 +17,14 @@ function autoseed(): string {
 }
 
 export const initialQuestState: QuestState = {
-  details: {
+  details: new Quest({
     author: '',
     id: '',
     partition: '',
     publishedurl: '',
     summary: '',
     title: '',
-  },
+  }),
   node: new ParserNode(cheerio.load('<quest></quest>')('quest'), {
     _templateScopeFn: () => ({}),
     path: ([] as any),

--- a/services/app/src/reducers/QuestTypes.tsx
+++ b/services/app/src/reducers/QuestTypes.tsx
@@ -1,35 +1,3 @@
-import {ThemeType} from 'shared/schema/Constants';
-
-// TODO: Dedupe this with api/models/Quests QuestAttributes interface.
-export interface QuestDetails {
-  id: string;
-  title: string;
-  summary: string;
-  author: string;
-  publishedurl: string;
-  xml?: string;
-  created?: string;
-  published?: string;
-  minplayers?: number;
-  maxplayers?: number;
-  email?: string;
-  url?: string;
-  mintimeminutes?: number;
-  maxtimeminutes?: number;
-  ratingcount?: number;
-  ratingavg?: number;
-  genre?: string;
-  contentrating?: string;
-  expansionhorror?: boolean;
-  questversion?: number;
-  partition?: string;
-  language?: string;
-  theme?: ThemeType;
-  official?: boolean;
-  awarded?: string;
-  requirespenpaper?: boolean;
-}
-
 export interface Choice {
   idx: number;
   jsx: JSX.Element;

--- a/services/app/src/reducers/StateTypes.tsx
+++ b/services/app/src/reducers/StateTypes.tsx
@@ -1,9 +1,9 @@
 import {StatusEvent} from 'shared/multiplayer/Events';
 import {SessionID} from 'shared/multiplayer/Session';
 import {ContentRatingLabelType, GenreType, LanguageType} from 'shared/schema/Constants';
+import {Quest} from 'shared/schema/Quests';
 import {TemplatePhase} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
-import {Quest} from 'shared/schema/Quests';
 
 export interface AnnouncementState {
   open: boolean;

--- a/services/app/src/reducers/StateTypes.tsx
+++ b/services/app/src/reducers/StateTypes.tsx
@@ -3,7 +3,7 @@ import {SessionID} from 'shared/multiplayer/Session';
 import {ContentRatingLabelType, GenreType, LanguageType} from 'shared/schema/Constants';
 import {TemplatePhase} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
-import {QuestDetails} from './QuestTypes';
+import {Quest} from 'shared/schema/Quests';
 
 export interface AnnouncementState {
   open: boolean;
@@ -94,7 +94,7 @@ export interface SnackbarState {
 }
 
 export interface SavedQuestMeta {
-  details: QuestDetails;
+  details: Quest;
   ts: number;
   pathLen?: number;
 }
@@ -129,7 +129,7 @@ export interface CardState {
 export type TransitionClassType = 'next' | 'prev' | 'instant';
 
 export interface QuestState {
-  details: QuestDetails;
+  details: Quest;
   node: ParserNode;
   seed: string;
   // Additional details populated depending on from where
@@ -144,12 +144,12 @@ export interface SavedQuestState {
 
 export interface SearchState {
   search: SearchSettings;
-  results: QuestDetails[];
+  results: Quest[];
   searching: boolean;
 }
 
 export interface UserQuestInstance {
-  details: QuestDetails;
+  details: Quest;
   lastPlayed: Date;
 }
 

--- a/services/quests/src/actions/Editor.tsx
+++ b/services/quests/src/actions/Editor.tsx
@@ -9,6 +9,7 @@ import {store} from '../Store';
 import {SetDirtyAction, SetDirtyTimeoutAction, SetLineAction, SetWordCountAction} from './ActionTypes';
 import {pushError} from './Dialogs';
 import {saveQuest} from './Quest';
+import {Quest} from 'shared/schema/Quests';
 
 declare var window: any;
 
@@ -143,7 +144,7 @@ export function renderAndPlay(quest: QuestType, qdl: string, line: number, oldWo
       }));
       // Unfortunately can't just expand quest b/c it includes stuff beyond what app expects
       // Fortunately we really only /need/ to send things that affect display of quest (such as theme)
-      dispatch(loadNode(newNode, {
+      dispatch(loadNode(newNode, new Quest({
         author: quest.author || '',
         id: quest.id || '',
         maxplayers: quest.maxplayers || 6,
@@ -152,7 +153,7 @@ export function renderAndPlay(quest: QuestType, qdl: string, line: number, oldWo
         summary: quest.summary || '',
         theme: quest.theme || 'base',
         title: quest.title || '',
-      }));
+      })));
       // Results will be shown and added to annotations as they arise.
       dispatch(startPlaytestWorker(oldWorker, questNode, {
         expansionhorror: Boolean(quest.expansionhorror),

--- a/services/quests/src/actions/Editor.tsx
+++ b/services/quests/src/actions/Editor.tsx
@@ -4,12 +4,12 @@ import {defaultContext} from 'app/components/views/quest/cardtemplates/Template'
 import {ParserNode, TemplateContext} from 'app/components/views/quest/cardtemplates/TemplateTypes';
 import Redux from 'redux';
 import {renderXML} from 'shared/render/QDLParser';
+import {Quest} from 'shared/schema/Quests';
 import {PanelType, PlaytestSettings, QuestType} from '../reducers/StateTypes';
 import {store} from '../Store';
 import {SetDirtyAction, SetDirtyTimeoutAction, SetLineAction, SetWordCountAction} from './ActionTypes';
 import {pushError} from './Dialogs';
 import {saveQuest} from './Quest';
-import {Quest} from 'shared/schema/Quests';
 
 declare var window: any;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/607666/44948928-fe027700-adf4-11e8-84d7-674e9eef712a.png)

Also includes an updated & shared search interface between the API server and some code to hide the requirements section of the quest details when there's no additional requirements.

Unit tests stubbed, implementation to follow in a separate PR as it's easier to split the `Search` component up and remove the switch-based rendering to keep unit testing light.