### PR TITLE
Refactor loading saved quests

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,6 +243,7 @@
       "js",
       "jsx"
     ],
+    "verbose": false,
     "setupFiles": [
       "jest-localstorage-mock"
     ],

--- a/services/app/src/Style.scss
+++ b/services/app/src/Style.scss
@@ -1284,6 +1284,17 @@ body.android .dialog .textfield:focus-within {
     }
   }
 
+  .savedQuest {
+    display: flex;
+
+    & > div {
+      width: 100%;
+    }
+    & > button {
+      margin-top: size(small);
+    }
+  }
+
   .reportCategory {
     text-align: center;
     button {

--- a/services/app/src/actions/ActionTypes.tsx
+++ b/services/app/src/actions/ActionTypes.tsx
@@ -169,6 +169,11 @@ export interface SavedQuestListAction {
   savedQuests: SavedQuestMeta[];
 }
 
+export interface SavedQuestSelectAction {
+  type: 'SAVED_QUEST_SELECT';
+  ts: number;
+}
+
 export interface MultiplayerSessionAction extends Redux.Action {
   type: 'MULTIPLAYER_SESSION';
   session: {id: number, secret: string};

--- a/services/app/src/actions/Quest.tsx
+++ b/services/app/src/actions/Quest.tsx
@@ -22,7 +22,7 @@ export function initQuest(details: Quest, questNode: Cheerio, ctx: TemplateConte
   return {
     type: 'QUEST_NODE',
     node: initQuestNode(questNode, ctx),
-    details
+    details,
   };
 }
 

--- a/services/app/src/actions/Quest.tsx
+++ b/services/app/src/actions/Quest.tsx
@@ -13,10 +13,17 @@ import {
 import {toCard} from './Card';
 import {logQuestPlay} from './Web';
 
-export function initQuest(details: Quest, questNode: Cheerio, ctx: TemplateContext): QuestNodeAction {
+export function initQuestNode(questNode: Cheerio, ctx: TemplateContext): ParserNode {
   const firstNode = questNode.children().eq(0);
-  const node = new ParserNode(firstNode, ctx);
-  return {type: 'QUEST_NODE', node, details};
+  return new ParserNode(firstNode, ctx);
+}
+
+export function initQuest(details: Quest, questNode: Cheerio, ctx: TemplateContext): QuestNodeAction {
+  return {
+    type: 'QUEST_NODE',
+    node: initQuestNode(questNode, ctx),
+    details
+  };
 }
 
 export const exitQuest = remoteify(function exitQuest(): QuestExitAction {

--- a/services/app/src/actions/SavedQuests.test.tsx
+++ b/services/app/src/actions/SavedQuests.test.tsx
@@ -64,6 +64,15 @@ describe('SavedQuest actions', () => {
     });
   });
 
+  describe('recreateNodeFromPath', () => {
+    test.skip('safely handles zero path length', () => { /* TODO */ });
+    test.skip('handles simple choices, preserving op changes', () => { /* TODO */ });
+    test.skip('handles gotos', () => { /* TODO */ });
+    test.skip('handles mid-combat roleplay, preserving op changes', () => { /* TODO */ });
+    test.skip('handles exiting of combat (win/lose)', () => { /* TODO */ });
+    test.skip('returns earlier node if there was a problem with the full path', () => { /* TODO */ });
+  });
+
   describe('saveQuestForOffline', () => {
     test.skip('Saves a publishedurl to local storage', () => { /* TODO */ });
   });

--- a/services/app/src/actions/SavedQuests.test.tsx
+++ b/services/app/src/actions/SavedQuests.test.tsx
@@ -134,6 +134,16 @@ describe('SavedQuest actions', () => {
       expect(node.elem.text()).toEqual('expected');
       expect(complete).toEqual(false);
     });
+    test('stopping during combat returns the node preceding the combat', () => {
+      const {node, complete} = recreateNodeFromPath(`<quest>
+        <roleplay>expected</roleplay>
+        <combat>
+          <e>Bandit</e>
+        </combat>
+      </quest>`, [0, '|1', '|2']);
+      expect(node.elem.text()).toEqual('expected');
+      expect(complete).toEqual(false);
+    });
   });
 
   describe('saveQuestForOffline', () => {

--- a/services/app/src/actions/SavedQuests.tsx
+++ b/services/app/src/actions/SavedQuests.tsx
@@ -168,6 +168,7 @@ export function recreateNodeFromPath(xml: string, path: string|number[]): {node:
 }
 
 export function loadSavedQuest(id: string, ts: number) {
+  console.log('Gonna load that svaed quets');
   return (dispatch: Redux.Dispatch<any>) => {
     const savedQuests = getSavedQuestMeta();
     let details: Quest|null = null;
@@ -189,7 +190,7 @@ export function loadSavedQuest(id: string, ts: number) {
     }
     const {node, complete} = recreateNodeFromPath(data.xml, data.path);
     if (!complete) {
-      return dispatch(openSnackbar('Could not load fully; using earlier checkpoint'));
+      dispatch(openSnackbar('Could not load fully - using earlier checkpoint.'));
     }
     dispatch({
       type: 'QUEST_NODE',

--- a/services/app/src/actions/SavedQuests.tsx
+++ b/services/app/src/actions/SavedQuests.tsx
@@ -50,7 +50,7 @@ export function saveQuestForOffline(details: Quest) {
   return (dispatch: Redux.Dispatch<any>): any => {
     return fetchLocal(details.publishedurl).then((result: string) => {
       const elem = cheerio.load(result)('quest');
-      const node = initQuest(details, elem, defaultContext()).node;
+      const node = initQuestNode(elem, defaultContext());
       dispatch(storeSavedQuest(node, details, Date.now()));
       return dispatch(openSnackbar('Saved for offline play.'));
     })
@@ -136,7 +136,7 @@ function recreateNodeThroughCombat(node: ParserNode, i: number, path: string|num
   return {nextNode: node, i};
 }
 
-export function recreateNodeFromPath(xml: string, path: string|number[]): {node: ParserNode, complete: true} {
+export function recreateNodeFromPath(xml: string, path: string|number[]): {node: ParserNode, complete: boolean} {
   // TODO: Return partially-loaded quest if it fails at all.
   let node = initQuestNode(getCheerio().load(xml)('quest'), defaultContext());
   for (let i = 0; i < path.length; i++) {

--- a/services/app/src/components/base/Card.test.tsx
+++ b/services/app/src/components/base/Card.test.tsx
@@ -27,9 +27,9 @@ describe('Card', () => {
 
   test.skip('opens ios/android-specific rating pages on menu -> rate', () => { /* TODO */ });
 
-  test.skip('Promps user to confirm if they try to go home while in a quest', () => { /* TODO */ });
+  test.skip('prompts user to confirm if they try to go home while in a quest', () => { /* TODO */ });
 
-  test.skip('Cancelling a go home while in quest does not trigger a go home', () => { /* TODO */ });
+  test.skip('cancelling a go home while in quest does not trigger a go home', () => { /* TODO */ });
 
   test('applies default card and quest theme classes', () => {
     const {wrapper} = setup();
@@ -42,4 +42,6 @@ describe('Card', () => {
     const {wrapper} = setup({theme: 'dark'});
     expect(wrapper.find('.base_card').hasClass('card_theme_dark')).toBe(true);
   });
+
+  test.skip('always closes top-right menu when any menu button is clicked', () => { /* TODO */ });
 });

--- a/services/app/src/components/base/Card.test.tsx
+++ b/services/app/src/components/base/Card.test.tsx
@@ -43,5 +43,11 @@ describe('Card', () => {
     expect(wrapper.find('.base_card').hasClass('card_theme_dark')).toBe(true);
   });
 
-  test.skip('always closes top-right menu when any menu button is clicked', () => { /* TODO */ });
+  test('always closes top-right menu when a menu button is clicked', () => {
+    const {wrapper} = setup({});
+    wrapper.find('#menuButton').simulate('click', {currentTarget: wrapper.find('#menuButton')});
+    expect(wrapper.state('anchorEl')).toBeDefined();
+    wrapper.find('#homeButton').simulate('click');
+    expect(wrapper.state('anchorEl')).not.toBeDefined();
+  });
 });

--- a/services/app/src/components/base/Card.tsx
+++ b/services/app/src/components/base/Card.tsx
@@ -110,7 +110,7 @@ export default class Card extends React.Component<Props, {}> {
         <div className="title_container">
           <IconButton id="titlebarReturnButton" onClick={() => this.onReturn()}><ChevronLeftIcon/></IconButton>
           <span className="menu">
-            <IconButton aria-haspopup="true" onClick={(e) => this.handleMenuClick(e)}>
+            <IconButton id="menuButton" aria-haspopup="true" onClick={(e) => this.handleMenuClick(e)}>
               <MoreVertIcon/>
             </IconButton>
             <Menu
@@ -118,7 +118,7 @@ export default class Card extends React.Component<Props, {}> {
               anchorEl={anchorEl}
               classes={{paper: 'menu_popup'}}
               onClose={() => this.handleMenuClose()}>
-              <MenuItem onClick={() => {this.onMenuSelect('HOME'); }}>Home</MenuItem>
+              <MenuItem id="homeButton" onClick={() => {this.onMenuSelect('HOME'); }}>Home</MenuItem>
               {this.props.inQuest && isExperimental && <MenuItem onClick={() => {this.onMenuSelect('SAVE'); }}>Save quest</MenuItem>}
               <MenuItem onClick={() => {this.onMenuSelect('SETTINGS'); }}>Settings</MenuItem>
               {getDevicePlatform() !== 'web' && <MenuItem onClick={() => {this.onMenuSelect('RATE'); }}>Rate the App</MenuItem>}

--- a/services/app/src/components/base/Card.tsx
+++ b/services/app/src/components/base/Card.tsx
@@ -49,6 +49,7 @@ export default class Card extends React.Component<Props, {}> {
 
   public onMenuSelect(value: string) {
     const dispatch = getStore().dispatch;
+    this.handleMenuClose();
     switch (value) {
       case 'HOME':
         if (!this.props.inQuest) {
@@ -87,7 +88,6 @@ export default class Card extends React.Component<Props, {}> {
       default:
         throw new Error('Unknown menu option ' + value);
     }
-    this.handleMenuClose();
   }
 
   public render() {

--- a/services/app/src/components/base/Dialogs.tsx
+++ b/services/app/src/components/base/Dialogs.tsx
@@ -295,9 +295,7 @@ export class DeleteSavedQuestDialog extends React.Component<DeleteSavedQuestDial
   public render() {
     const savedQuest = this.props.savedQuest;
     return (
-      <Dialog
-        open={Boolean(this.props.open)}
-      >
+      <Dialog classes={{paperWidthSm: 'dialog'}} open={Boolean(this.props.open)}>
         <DialogTitle>Delete saved quest?</DialogTitle>
         <DialogContent className="dialog"></DialogContent>
         <DialogActions>

--- a/services/app/src/components/base/DialogsContainer.tsx
+++ b/services/app/src/components/base/DialogsContainer.tsx
@@ -40,7 +40,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
     },
     onDeleteSavedQuest: (savedQuest: SavedQuestMeta) => {
       dispatch(deleteSavedQuest(savedQuest.details.id, savedQuest.ts));
-      dispatch(toPrevious({name: 'SAVED_QUESTS', before: false}));
+      dispatch(setDialog(null));
       dispatch(openSnackbar('Save deleted.'));
     },
     onExitMultiplayer: () => {

--- a/services/app/src/components/views/QuestPreview.test.tsx
+++ b/services/app/src/components/views/QuestPreview.test.tsx
@@ -77,4 +77,5 @@ describe('QuestPreview', () => {
   test.skip('lists all saves for the quest', () => { /* TODO */ });
   test.skip('indicates when the quest is available offline', () => { /* TODO */ });
   test.skip('does not allow users to save local quests offline', () => { /* TODO */ });
+  test.skip('allows users to delete a saved quest instance', () => { /* TODO */ });
 });

--- a/services/app/src/components/views/QuestPreview.tsx
+++ b/services/app/src/components/views/QuestPreview.tsx
@@ -73,9 +73,9 @@ function renderSaves(props: Props): JSX.Element|null {
 
   const buttons = saves.map((s, i) => {
     return (
-      <div className="savedQuest">
-        <Button key={i} onClick={(e) => props.onPlaySaved(s.details.id, s.ts)} id="play">{Moment(s.ts).fromNow()} ({(s.pathLen === undefined) ? 'unknown position' : `${s.pathLen.toString()} ${pluralize('choice', s.pathLen || 0)}`})</Button>
-        <IconButton key={i + 'x'} onClick={(e) => props.onDeleteConfirm(quest, s.ts)} id="delete">
+      <div key={i} className="savedQuest">
+        <Button onClick={(e) => props.onPlaySaved(s.details.id, s.ts)} id="play">{Moment(s.ts).fromNow()} ({(s.pathLen === undefined) ? 'unknown position' : `${s.pathLen.toString()} ${pluralize('choice', s.pathLen || 0)}`})</Button>
+        <IconButton onClick={(e) => props.onDeleteConfirm(quest, s.ts)} id="delete">
           <CloseIcon/>
         </IconButton>
       </div>

--- a/services/app/src/components/views/QuestPreview.tsx
+++ b/services/app/src/components/views/QuestPreview.tsx
@@ -1,3 +1,5 @@
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
 import DoneIcon from '@material-ui/icons/Done';
 import OfflinePin from '@material-ui/icons/OfflinePin';
 import StarsIcon from '@material-ui/icons/Stars';
@@ -25,7 +27,7 @@ export interface DispatchProps {
   onPlaySaved: (id: string, ts: number) => void;
   onSave: (quest: Quest) => void;
   onDeleteOffline: (id: string, ts: number) => void;
-  onDeleteConfirm: () => void;
+  onDeleteConfirm: (quest: Quest, ts: number) => void;
   onReturn: () => void;
 }
 
@@ -62,10 +64,23 @@ function renderSaves(props: Props): JSX.Element|null {
   if (!props.settings.experimental || saves.length === 0) {
     return null;
   }
+  const quest = props.quest;
+  if (!quest) {
+    return <span/>;
+  }
 
   saves.sort((a, b) => b.ts - a.ts);
 
-  const buttons = saves.map((s, i) => <Button key={i} onClick={(e) => props.onPlaySaved(s.details.id, s.ts)} id="play">{Moment(s.ts).fromNow()} ({(s.pathLen === undefined) ? 'unknown position' : `${s.pathLen.toString()} ${pluralize('choice', s.pathLen || 0)}`})</Button>);
+  const buttons = saves.map((s, i) => {
+    return (
+      <div className="savedQuest">
+        <Button key={i} onClick={(e) => props.onPlaySaved(s.details.id, s.ts)} id="play">{Moment(s.ts).fromNow()} ({(s.pathLen === undefined) ? 'unknown position' : `${s.pathLen.toString()} ${pluralize('choice', s.pathLen || 0)}`})</Button>
+        <IconButton key={i + 'x'} onClick={(e) => props.onDeleteConfirm(quest, s.ts)} id="delete">
+          <CloseIcon/>
+        </IconButton>
+      </div>
+    );
+  });
   return (
     <span>
       <h3>Saves</h3>

--- a/services/app/src/components/views/QuestPreviewContainer.tsx
+++ b/services/app/src/components/views/QuestPreviewContainer.tsx
@@ -1,6 +1,7 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
 import {Quest} from 'shared/schema/Quests';
+import {SavedQuestSelectAction} from '../../actions/ActionTypes';
 import {toCard, toPrevious} from '../../actions/Card';
 import {setDialog} from '../../actions/Dialog';
 import {deleteSavedQuest, loadSavedQuest, saveQuestForOffline} from '../../actions/SavedQuests';
@@ -43,7 +44,8 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       dispatch(deleteSavedQuest(id, ts));
       dispatch(openSnackbar('Deleted offline version.'));
     },
-    onDeleteConfirm(): void {
+    onDeleteConfirm(quest: Quest, ts: number): void {
+      dispatch({type: 'SAVED_QUEST_SELECT', ts} as SavedQuestSelectAction);
       dispatch(setDialog('DELETE_SAVED_QUEST'));
     },
     onReturn: () => {

--- a/services/app/src/components/views/SavedQuests.test.tsx
+++ b/services/app/src/components/views/SavedQuests.test.tsx
@@ -10,7 +10,7 @@ function setup(props: Partial<Props>) {
 }
 
 describe('SavedQuests', () => {
-  test('promps the user when there are no saved quests', () => {
+  test('prompts the user when there are no saved quests', () => {
     const {wrapper} = setup({
       saved: [],
     });

--- a/services/app/src/components/views/SavedQuests.test.tsx
+++ b/services/app/src/components/views/SavedQuests.test.tsx
@@ -2,12 +2,18 @@ import {configure, render} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import * as React from 'react';
 import SavedQuests, {Props} from './SavedQuests';
+import {FEATURED_QUESTS} from '../../Constants';
+import {Quest} from 'shared/schema/Quests';
+
 configure({ adapter: new Adapter() });
 
 function setup(props: Partial<Props>) {
   const wrapper = render(<SavedQuests {...(props as any as Props)} />, undefined /*renderOptions*/);
   return {props, wrapper};
 }
+
+const SAVED_QUEST = {details: FEATURED_QUESTS[0], ts: 123, pathLen: 5};
+const OFFLINE_QUEST = {details: FEATURED_QUESTS[0], ts: 123, pathLen: 0};
 
 describe('SavedQuests', () => {
   test('prompts the user when there are no saved quests', () => {
@@ -16,4 +22,21 @@ describe('SavedQuests', () => {
     });
     expect(wrapper.text()).toContain('You have no saved/offline quests.');
   });
+  test('shows only saved quests if no offline quests', () => {
+    const {wrapper} = setup({
+      saved: [SAVED_QUEST],
+    });
+    const text = wrapper.find('h3').text();
+    expect(text).not.toContain('Offline Quests');
+    expect(text).toContain('Saved Quests');
+  });
+  test('shows only offline quests if no saved quests', () => {
+    const {wrapper} = setup({
+      saved: [OFFLINE_QUEST],
+    });
+    const text = wrapper.find('h3').text();
+    expect(text).not.toContain('Saved Quests');
+    expect(text).toContain('Offline Quests');
+  });
+  test.skip('groups saves by quest and shows count', () => { /* TODO */ });
 });

--- a/services/app/src/components/views/SavedQuests.tsx
+++ b/services/app/src/components/views/SavedQuests.tsx
@@ -1,10 +1,10 @@
-import pluralize from 'pluralize';
 import * as React from 'react';
 import {smartTruncateSummary} from '../../Format';
 import {SavedQuestMeta} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
 
+const pluralize = require('pluralize');
 const Moment = require('moment');
 
 export interface StateProps {

--- a/services/app/src/components/views/SavedQuests.tsx
+++ b/services/app/src/components/views/SavedQuests.tsx
@@ -1,4 +1,4 @@
-import * as pluralize from 'pluralize';
+import pluralize from 'pluralize';
 import * as React from 'react';
 import {smartTruncateSummary} from '../../Format';
 import {SavedQuestMeta} from '../../reducers/StateTypes';

--- a/services/app/src/components/views/SavedQuests.tsx
+++ b/services/app/src/components/views/SavedQuests.tsx
@@ -82,10 +82,14 @@ const SavedQuests = (props: Props): JSX.Element => {
 
   return (
     <Card title="Saved & Offline Quests">
-      <h3>Saved Quests</h3>
-      {groupedQuestSaves}
-      <h3>Offline Quests</h3>
-      {offlineQuests}
+      {groupedQuestSaves.length > 0 && <span>
+        <h3>Saved Quests</h3>
+        {groupedQuestSaves}
+      </span>}
+      {offlineQuests.length > 0 && <span>
+        <h3>Offline Quests</h3>
+        {offlineQuests}
+      </span>}
     </Card>
   );
 };

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
@@ -56,7 +56,7 @@ export function getNextMidCombatNode(node: ParserNode, index: number): {nextNode
         // If the trigger exits via the win/lose handlers, go to the appropriate
         // combat end card
         return {
-          nextNode: new ParserNode(parentCombatElem, node.ctx),
+          nextNode: new ParserNode(parentCombatElem, node.ctx, index),
           state: (triggerName === 'win') ? 'VICTORY' : 'DEFEAT',
         };
       } else if (triggerName.startsWith('goto') && nextIsInSameCombat) {
@@ -79,7 +79,7 @@ export function getNextMidCombatNode(node: ParserNode, index: number): {nextNode
   } else {
     // If the next node is out of this combat, that means we've dropped off the end of the
     // interestitial roleplay. Go back to combat resolution phase.
-    return {nextNode: new ParserNode(parentCombatElem, node.ctx), state: 'ENDROUND'};
+    return {nextNode: new ParserNode(parentCombatElem, node.ctx, index), state: 'ENDROUND'};
   }
 }
 

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
@@ -101,6 +101,7 @@ export const midCombatChoice = remoteify(function midCombatChoice(a: MidCombatCh
   switch (state) {
     case 'ENDCOMBAT':
       dispatch(loadNode(nextNode));
+      dispatch(audioSet({intensity: 0}));
       break;
     case 'VICTORY':
     case 'DEFEAT':

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
@@ -1,7 +1,7 @@
 import {QuestNodeAction, remoteify} from 'app/actions/ActionTypes';
 import {audioSet} from 'app/actions/Audio';
 import {toCard} from 'app/actions/Card';
-import {choice, endQuest, loadNode} from 'app/actions/Quest';
+import {endQuest, loadNode} from 'app/actions/Quest';
 import {AppStateWithHistory, SettingsType} from 'app/reducers/StateTypes';
 import Redux from 'redux';
 import {findCombatParent, handleCombatEnd} from '../combat/Actions';
@@ -19,6 +19,70 @@ export function initRoleplay(node: ParserNode, custom?: boolean) {
   };
 }
 
+type evalState = 'END'|'ENDROUND'|'ENDCOMBAT'|'VICTORY'|'DEFEAT';
+
+function combatContainsNode(combatElem: Cheerio, node: ParserNode) {
+  const nodeParent = findCombatParent(node);
+  if (nodeParent !== null && combatElem !== null) {
+    return nodeParent.length > 0 && combatElem.attr('data-line') === nodeParent.attr('data-line');
+  }
+  return false;
+}
+
+export function getNextMidCombatNode(node: ParserNode, index: number): {nextNode: ParserNode, state: evalState|null} {
+  const parentCombatElem = findCombatParent(node);
+  const nextNode = node.handleAction(index);
+
+  // If there's no parent combat element, we've made a mistake somewhere and shouldn't even be in combat.
+  // Handle the action and load the node as if it were a regular choice.
+  if (parentCombatElem === null) {
+    console.log('No parent combat element - handling as regular choice');
+    if (nextNode === null) {
+      throw new Error('Could not find next node');
+    }
+    return {nextNode, state: 'ENDCOMBAT'};
+  }
+
+  const next = node.getNext(index);
+  let nextIsInSameCombat = false;
+  if (nextNode && next) {
+    nextIsInSameCombat = combatContainsNode(parentCombatElem, nextNode);
+
+    // Check for and resolve triggers
+    const nextIsTrigger = (next && next.getTag() === 'trigger');
+    if (nextIsTrigger) {
+      const triggerName = next.elem.text().trim().toLowerCase();
+      if (triggerName === 'win' || triggerName === 'lose') {
+        // If the trigger exits via the win/lose handlers, go to the appropriate
+        // combat end card
+        return {
+          nextNode: new ParserNode(parentCombatElem, node.ctx),
+          state: (triggerName === 'win') ? 'VICTORY' : 'DEFEAT',
+        };
+      } else if (triggerName.startsWith('goto') && nextIsInSameCombat) {
+        // If we jump to somewhere in the same combat,
+        // it's handled like a normal combat RP choice change (below).
+      } else if (next.isEnd()) {
+        // Treat quest end as normal, also stopping combat audio.
+        return {nextNode: node, state: 'END'};
+      } else {
+        // Otherwise, treat like a typical event trigger.
+        // Make sure we stop combat audio since we're exiting this combat.
+        return {nextNode, state: 'ENDCOMBAT'};
+      }
+    }
+  }
+
+  if (nextNode && nextIsInSameCombat) {
+    // Continue in-combat roleplay with the next node.
+    return {nextNode, state: null};
+  } else {
+    // If the next node is out of this combat, that means we've dropped off the end of the
+    // interestitial roleplay. Go back to combat resolution phase.
+    return {nextNode: new ParserNode(parentCombatElem, node.ctx), state: 'ENDROUND'};
+  }
+}
+
 interface MidCombatChoiceArgs {
   index: number;
   maxTier: number;
@@ -31,71 +95,37 @@ export const midCombatChoice = remoteify(function midCombatChoice(a: MidCombatCh
     a.node = getState().quest.node;
     a.settings = getState().settings;
   }
+
   const remoteArgs: MidCombatChoiceArgs = {index: a.index, seed: a.seed, maxTier: a.maxTier};
-  const parentCombatElem = findCombatParent(a.node);
-
-  // If there's no parent combat element, we've made a mistake somewhere and shouldn't even be in combat.
-  // Handle the action and load the node as if it were a regular choice.
-  if (parentCombatElem === null) {
-    console.log('No parent combat element - handling as regular choice');
-    dispatch(choice({node: a.node, index: a.index}));
-    return remoteArgs;
-  }
-
-  const nextNode = a.node.handleAction(a.index);
-  const next = a.node.getNext(a.index);
-  let nextIsInSameCombat = false;
-  if (nextNode && next) {
-    const nextParentCombatElem = findCombatParent(nextNode);
-    if (nextParentCombatElem !== null) {
-      nextIsInSameCombat = nextParentCombatElem.length > 0 && parentCombatElem.attr('data-line') === nextParentCombatElem.attr('data-line');
-    }
-
-    // Check for and resolve triggers
-    const nextIsTrigger = (next && next.getTag() === 'trigger');
-    if (nextIsTrigger) {
-      const triggerName = next.elem.text().trim().toLowerCase();
-      if (triggerName === 'win' || triggerName === 'lose') {
-        // If the trigger exits via the win/lose handlers, go to the appropriate
-        // combat end card
-        const victory = triggerName === 'win';
-        dispatch(handleCombatEnd({
-          maxTier: a.maxTier,
-          node: new ParserNode(parentCombatElem, a.node.ctx),
-          seed: a.seed,
-          settings: a.settings,
-          victory,
-        }));
-        return remoteArgs;
-      } else if (triggerName.startsWith('goto') && nextIsInSameCombat) {
-        // If we jump to somewhere in the same combat,
-        // it's handled like a normal combat RP choice change (below).
-      } else if (next.isEnd()) {
-        // Treat quest end as normal, also stopping combat audio.
-        dispatch(endQuest({}));
-        dispatch(audioSet({intensity: 0}));
-        return remoteArgs;
-      } else {
-        // Otherwise, treat like a typical event trigger.
-        // Make sure we stop combat audio since we're exiting this combat.
-        dispatch(loadNode(nextNode));
-        dispatch(audioSet({intensity: 0}));
-        return remoteArgs;
-      }
-    }
-  }
-
-  if (nextIsInSameCombat) {
-    // Continue in-combat roleplay with the next node.
-    dispatch({type: 'PUSH_HISTORY'});
-    dispatch({type: 'QUEST_NODE', node: nextNode} as QuestNodeAction);
-    dispatch(toCard({name: 'QUEST_CARD', phase: 'MID_COMBAT_ROLEPLAY', overrideDebounce: true, noHistory: true}));
-  } else {
-    // If the next node is out of this combat, that means we've dropped off the end of the
-    // interestitial roleplay. Go back to combat resolution phase.
-    dispatch({type: 'PUSH_HISTORY'});
-    dispatch({type: 'QUEST_NODE', node: new ParserNode(parentCombatElem, a.node.ctx)} as QuestNodeAction);
-    dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true, noHistory: true}));
+  const {nextNode, state} = getNextMidCombatNode(a.node, a.index);
+  switch (state) {
+    case 'ENDCOMBAT':
+      dispatch(loadNode(nextNode));
+      break;
+    case 'VICTORY':
+    case 'DEFEAT':
+      dispatch(handleCombatEnd({
+        maxTier: a.maxTier,
+        node: nextNode,
+        seed: a.seed,
+        settings: a.settings,
+        victory: (state === 'VICTORY'),
+      }));
+      break;
+    case 'END':
+      dispatch(endQuest({}));
+      dispatch(audioSet({intensity: 0}));
+      break;
+    case 'ENDROUND':
+      dispatch({type: 'PUSH_HISTORY'});
+      dispatch({type: 'QUEST_NODE', node: nextNode} as QuestNodeAction);
+      dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true, noHistory: true}));
+      break;
+    default: // in-combat roleplay continues
+      dispatch({type: 'PUSH_HISTORY'});
+      dispatch({type: 'QUEST_NODE', node: nextNode} as QuestNodeAction);
+      dispatch(toCard({name: 'QUEST_CARD', phase: 'MID_COMBAT_ROLEPLAY', overrideDebounce: true, noHistory: true}));
+      break;
   }
   return remoteArgs;
 });

--- a/services/app/src/reducers/Saved.tsx
+++ b/services/app/src/reducers/Saved.tsx
@@ -1,9 +1,10 @@
 import Redux from 'redux';
-import {SavedQuestListAction} from '../actions/ActionTypes';
+import {SavedQuestListAction, SavedQuestSelectAction} from '../actions/ActionTypes';
 import {SavedQuestState} from './StateTypes';
 
 const initialSavedState: SavedQuestState = {
   list: [],
+  selectedTS: null,
 };
 
 export function saved(state: SavedQuestState = initialSavedState, action: Redux.Action): SavedQuestState {
@@ -13,6 +14,8 @@ export function saved(state: SavedQuestState = initialSavedState, action: Redux.
     case 'SAVED_QUEST_STORED':
       // All these actions have the same savedQuests signature
       return {...state, list: [...(action as SavedQuestListAction).savedQuests]};
+    case 'SAVED_QUEST_SELECT':
+      return {...state, selectedTS: (action as SavedQuestSelectAction).ts};
     default:
       return state;
   }

--- a/services/app/src/reducers/StateTypes.tsx
+++ b/services/app/src/reducers/StateTypes.tsx
@@ -140,6 +140,7 @@ export interface QuestState {
 
 export interface SavedQuestState {
   list: SavedQuestMeta[];
+  selectedTS: number|null;
 }
 
 export interface SearchState {

--- a/shared/parse/Node.test.tsx
+++ b/shared/parse/Node.test.tsx
@@ -97,6 +97,16 @@ describe('Node', () => {
     });
   });
 
+  describe('addToPath', () => {
+    test('adds to path', () => {
+      const pnode = new Node(cheerio.load('<roleplay></roleplay>')('roleplay'), defaultContext());
+      pnode.addToPath('test_string');
+      pnode.addToPath(1);
+      expect(pnode.ctx.path[pnode.ctx.path.length-1]).toEqual(1);
+      expect(pnode.ctx.path[pnode.ctx.path.length-2]).toEqual('test_string');
+    });
+  });
+
   describe('gotoId', () => {
     test('goes to ID', () => {
       const quest = cheerio.load('<quest><roleplay></roleplay><roleplay>wrong</roleplay><roleplay id="test">expected</roleplay></quest>')('quest');

--- a/shared/parse/Node.tsx
+++ b/shared/parse/Node.tsx
@@ -149,7 +149,7 @@ export class Node<C extends Context> {
     }
   }
 
-  public gotoId(id: string, seed?: string, origAction?: number|string): this|null {
+  public gotoId(id: string, seed?: string): this|null {
     const root = this.getRootElem();
     if (root === null) {
       return null;
@@ -158,7 +158,7 @@ export class Node<C extends Context> {
     if (search.length === 0) {
       return null;
     }
-    return new (this.constructor as any)(search.eq(0), this.ctx, origAction, seed);
+    return new (this.constructor as any)(search.eq(0), this.ctx, undefined, seed);
   }
 
   // Loop through all rendered children. If a call to cb() returns a value
@@ -299,14 +299,14 @@ export class Node<C extends Context> {
     return this;
   }
 
-  private handleTrigger(seed?: string, origAction?: number|string): this|null {
+  private handleTrigger(seed?: string): this|null {
     // Immediately act on any gotos (with a max depth)
     let i = 0;
     let ref: this|null = this.clone();
     for (; i < MAX_GOTO_FOLLOW_DEPTH && ref !== null && ref.getTag() === 'trigger'; i++) {
       const id = getTriggerId(ref.elem);
       if (id !== null) {
-        ref = ref.gotoId(evaluateContentOps(id, ref.ctx), seed, origAction);
+        ref = ref.gotoId(evaluateContentOps(id, ref.ctx), seed);
       } else {
         return ref.handleTriggerEvent(seed);
       }
@@ -328,7 +328,7 @@ export class Node<C extends Context> {
     }
 
     if (next.getTag() === 'trigger') {
-      return next.handleTrigger(seed, action);
+      return next.handleTrigger(seed);
     }
     return next;
   }


### PR DESCRIPTION
- Saved quest loading now shares the same mid-combat roleplay logic as regular quest parsing, so it no longer breaks when there's roleplay nodes during combat.
- Filled out a lot of additional tests for loading from saved quests
- Cleaned up saved quest page so it hides unnecessary headers
- Added an 'x' next to saves so that users can actually delete them.

![image](https://user-images.githubusercontent.com/607666/45257566-1e42b080-b376-11e8-9078-3e7ced3e2948.png)

fixes #244