### PR TITLE
fix horror multiplayer footer color

### DIFF
--- a/services/app/src/Style.scss
+++ b/services/app/src/Style.scss
@@ -196,6 +196,10 @@ body {
     }
   }
 
+  &.quest_theme_horror {
+    background-color: $bg_primary_faded;
+  }
+
   &.card_theme_dark {
     background-color: $bg_dark_primary;
     color: $font_color_dark_primary;

--- a/services/app/src/components/Compositor.tsx
+++ b/services/app/src/components/Compositor.tsx
@@ -132,7 +132,7 @@ export default class Compositor extends React.Component<Props, {}> {
                 </div>
             </CSSTransition>
         </TransitionGroup>
-        {this.props.multiplayer && this.props.multiplayer.session && <MultiplayerFooterContainer theme={this.props.theme}/>}
+        {this.props.multiplayer && this.props.multiplayer.session && <MultiplayerFooterContainer cardTheme={this.props.theme}/>}
         <DialogsContainer />
         <MultiplayerSyncContainer />
         <Snackbar

--- a/services/app/src/components/multiplayer/MultiplayerFooter.tsx
+++ b/services/app/src/components/multiplayer/MultiplayerFooter.tsx
@@ -9,7 +9,8 @@ import {CardThemeType, MultiplayerState} from '../../reducers/StateTypes';
 
 export interface StateProps {
   multiplayer: MultiplayerState;
-  theme: CardThemeType;
+  cardTheme: CardThemeType;
+  questTheme: string;
 }
 
 export interface DispatchProps {
@@ -20,8 +21,9 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 const MultiplayerFooter = (props: Props): JSX.Element => {
-  const color = (props.theme === 'dark') ? 'white' : 'black';
-  const adventurerIcon = (props.theme === 'dark') ? 'images/adventurer_white_small.svg' : 'images/adventurer_small.svg';
+  const classes = ['remote_footer', `card_theme_${props.cardTheme}`, `quest_theme_${props.questTheme}`];
+  const color = (props.cardTheme === 'dark') ? 'white' : 'black';
+  const adventurerIcon = (props.cardTheme === 'dark') ? 'images/adventurer_white_small.svg' : 'images/adventurer_small.svg';
   const peers: JSX.Element[] = [];
   const rpClient = getMultiplayerClient();
   for (const client of Object.keys(props.multiplayer.clientStatus)) {
@@ -41,7 +43,7 @@ const MultiplayerFooter = (props: Props): JSX.Element => {
   );
 
   return (
-    <div className={'remote_footer card_theme_' + props.theme}>
+    <div className={classes.join(' ')}>
       <IconButton onClick={(e: any) => {props.onMultiplayerExit(); }}>
          <Close nativeColor={color} />
       </IconButton>

--- a/services/app/src/components/multiplayer/MultiplayerFooterContainer.tsx
+++ b/services/app/src/components/multiplayer/MultiplayerFooterContainer.tsx
@@ -7,7 +7,8 @@ import MultiplayerFooter, {DispatchProps, Props, StateProps} from './Multiplayer
 const mapStateToProps = (state: AppState, ownProps: Partial<Props>): StateProps => {
   return {
     multiplayer: state.multiplayer,
-    theme: ownProps.theme || 'light',
+    cardTheme: ownProps.cardTheme || 'light',
+    questTheme: state.quest.details.theme || 'base',
   };
 };
 

--- a/shared/styles/constants.scss
+++ b/shared/styles/constants.scss
@@ -12,6 +12,7 @@ $border_accent_thin: 0.01in solid #333;
 $border_faded: 0.02in solid #888;
 
 $bg_primary: #F4ECC8;
+$bg_primary_faded: #ebe8da; // AKA The Horror
 $bg_inactive: #222222;
 $bg_titlebar: rgba(255, 255, 235, 0.65);
 $bg_interactive: rgba(245, 238, 210, 0.7);


### PR DESCRIPTION
Previously, was the normal bright Expedition yellow even when playing a faded Horror quest. No longer!

<img width="837" alt="screen shot 2018-09-15 at 15 51 51" src="https://user-images.githubusercontent.com/775657/45590114-6413f180-b8ff-11e8-968f-344add418b66.png">
