### PR TITLE
Refactor combat scope, complete tests, deterministic selection

### DIFF
--- a/services/app/src/components/views/quest/cardtemplates/Template.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.test.tsx
@@ -2,4 +2,10 @@ describe('CardTemplates template', () => {
   describe('updateContext', () => {
     test.skip('persists readonly template nodes', () => { /* TODO */ });
   });
+
+  describe('defaultContext', () => {
+    test.skip('contentSets gets content sets', () => { /* TODO */ });
+    test.skip('numAdventurers gets adventurer count', () => { /* TODO */ });
+    test.skip('viewCount gets the view count for a node id', () => { /* TODO */ });
+  });
 });

--- a/services/app/src/components/views/quest/cardtemplates/Template.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.tsx
@@ -2,6 +2,7 @@ import {CardState, CardThemeType} from 'app/reducers/StateTypes';
 import {getStore} from 'app/Store';
 import * as React from 'react';
 import Redux from 'redux';
+import {generateSeed} from 'shared/parse/Context';
 import {initCombat} from './combat/Actions';
 import DefeatContainer from './combat/DefeatContainer';
 import DrawEnemiesContainer from './combat/DrawEnemiesContainer';
@@ -21,7 +22,6 @@ import ResolveDecisionContainer from './decision/ResolveDecisionContainer';
 import {initRoleplay} from './roleplay/Actions';
 import RoleplayContainer from './roleplay/RoleplayContainer';
 import {ParserNode, TemplateContext} from './TemplateTypes';
-import {generateSeed} from 'shared/parse/Context';
 
 export function initCardTemplate(node: ParserNode) {
   return (dispatch: Redux.Dispatch<any>): any => {

--- a/services/app/src/components/views/quest/cardtemplates/Template.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.tsx
@@ -1,4 +1,4 @@
-import {CardState, CardThemeType} from 'app/reducers/StateTypes';
+import {AppStateWithHistory, CardState, CardThemeType} from 'app/reducers/StateTypes';
 import {getStore} from 'app/Store';
 import * as React from 'react';
 import Redux from 'redux';
@@ -104,7 +104,7 @@ export function templateScope() {
   return combatScope();
 }
 
-export function defaultContext(getState: (() => Redux.Store<any>) = getStore().getState): TemplateContext {
+export function defaultContext(getState: (() => AppStateWithHistory) = getStore().getState): TemplateContext {
   const populateScopeFn = () => {
     return {
       contentSets(): {[content: string]: boolean} {

--- a/services/app/src/components/views/quest/cardtemplates/Template.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.tsx
@@ -21,6 +21,7 @@ import ResolveDecisionContainer from './decision/ResolveDecisionContainer';
 import {initRoleplay} from './roleplay/Actions';
 import RoleplayContainer from './roleplay/RoleplayContainer';
 import {ParserNode, TemplateContext} from './TemplateTypes';
+import {generateSeed} from 'shared/parse/Context';
 
 export function initCardTemplate(node: ParserNode) {
   return (dispatch: Redux.Dispatch<any>): any => {
@@ -103,15 +104,15 @@ export function templateScope() {
   return combatScope();
 }
 
-export function defaultContext(): TemplateContext {
+export function defaultContext(getState: (() => Redux.Store<any>) = getStore().getState): TemplateContext {
   const populateScopeFn = () => {
     return {
       contentSets(): {[content: string]: boolean} {
-        const settings = getStore().getState().settings;
+        const settings = getState().settings;
         return settings && settings.contentSets;
       },
       numAdventurers(): number {
-        const settings = getStore().getState().settings;
+        const settings = getState().settings;
         return settings && settings.numPlayers;
       },
       viewCount(id: string): number {
@@ -137,6 +138,9 @@ export function defaultContext(): TemplateContext {
   for (const k of Object.keys(newContext.scope._)) {
     newContext.scope._[k] = (newContext.scope._[k] as any).bind(newContext);
   }
+
+  // Update random seed
+  newContext.seed = generateSeed();
 
   return newContext;
 }

--- a/services/app/src/components/views/quest/cardtemplates/combat/Scope.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Scope.test.tsx
@@ -16,6 +16,7 @@ describe('Combat State', () => {
         expect(scope._.randomEnemy()).toEqual(jasmine.any(String));
         expect(ENCOUNTERS[scope._.randomEnemy().toLowerCase()]).toBeDefined();
       });
+
       test('only includes enemies in the currently enabled content sets', () => {
         // Impossible to test absolutely; but we can test with high confidence.
         // Horror enabled, future disabled.
@@ -26,6 +27,13 @@ describe('Combat State', () => {
           const pick = ctx.scope._.randomEnemy();
           expect(ENCOUNTERS[Object.keys(ENCOUNTERS).filter((key) => ENCOUNTERS[key].name === pick)[0]].set).toMatch(/horror|base/);
         }
+      });
+
+      test('varies within same (seeded) scope', () => {
+        const store = newMockStore({});
+        const ctx = defaultContext(store.getState);
+        ctx.seed = 0;
+        expect(ctx.scope._.randomEnemy()).not.toEqual(ctx.scope._.randomEnemy());
       });
     });
 

--- a/services/app/src/components/views/quest/cardtemplates/combat/Scope.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Scope.test.tsx
@@ -1,79 +1,137 @@
 import {ENCOUNTERS} from 'app/Encounters';
+import {newMockStore} from 'app/Testing';
+import {initialSettings} from 'app/reducers/Settings';
+import {resolveCombat} from '../Params';
+
+// We use defaultContext here instead of combatScope as the combat scope
+// depends on templates and content sets within the broader context.
 import {defaultContext} from '../Template';
 
 describe('Combat State', () => {
   describe('combatScope', () => {
     describe('randomEnemy', () => {
-      const scope = defaultContext().scope;
       test('returns a random enemy name', () => {
+        const store = newMockStore({});
+        const scope = defaultContext(store.getState).scope;
         expect(scope._.randomEnemy()).toEqual(jasmine.any(String));
         expect(ENCOUNTERS[scope._.randomEnemy().toLowerCase()]).toBeDefined();
       });
-      test('does not include enemies in the horror set if horror set disabled', () => {
-        expect(scope._.randomEnemyOfClass('horror')).not.toBeDefined();
+      test('only includes enemies in the currently enabled content sets', () => {
+        // Impossible to test absolutely; but we can test with high confidence.
+        // Horror enabled, future disabled.
+        const store = newMockStore({settings: {...initialSettings, contentSets: {horror: true}}});
+        for (let i = 0; i < 100; i++) {
+          const ctx = defaultContext(store.getState);
+          ctx.seed = i; // deterministic
+          const pick = ctx.scope._.randomEnemy();
+          expect(ENCOUNTERS[Object.keys(ENCOUNTERS).filter((key) => ENCOUNTERS[key].name === pick)[0]].set).toMatch(/horror|base/);
+        }
       });
-      test.skip('includes enemies in the horror set if horror set enabled', () => { /* TODO */ });
-      // TODO; mock scope._.contentSets()
     });
 
     describe('randomEnemyOfTier', () => {
-      const scope = defaultContext().scope;
+      const store = newMockStore({});
+      const scope = defaultContext(store.getState).scope;
       test('returns a random enemy name', () => {
         expect(scope._.randomEnemyOfTier(1)).toEqual(jasmine.any(String));
         expect(ENCOUNTERS[scope._.randomEnemyOfTier(1).toLowerCase()]).toBeDefined();
       });
-      test.skip('only includes enemies in the currently enabled content sets', () => { /* TODO */ });
+      test('only includes enemies in the currently enabled content sets', () => {
+        // Impossible to test absolutely; but we can test with high confidence.
+        // Horror enabled, future disabled.
+        const store = newMockStore({settings: {...initialSettings, contentSets: {horror: true}}});
+        for (let i = 0; i < 100; i++) {
+          const ctx = defaultContext(store.getState);
+          ctx.seed = i; // deterministic
+          const pick = ctx.scope._.randomEnemyOfTier(1);
+          expect(ENCOUNTERS[Object.keys(ENCOUNTERS).filter((key) => ENCOUNTERS[key].name === pick)[0]].set).toMatch(/horror|base/);
+        }
+      });
     });
 
     describe('randomEnemyOfClass', () => {
-      const scope = defaultContext().scope;
+      const store = newMockStore({});
+      const scope = defaultContext(store.getState).scope;
       test('returns a random enemy name', () => {
         expect(scope._.randomEnemyOfClass('bandit')).toEqual(jasmine.any(String));
         expect(ENCOUNTERS[scope._.randomEnemyOfClass('bandit').toLowerCase()]).toBeDefined();
       });
-      test.skip('only includes enemies in the currently enabled content sets', () => { /* TODO */ });
+      test('does not include enemies in the horror set if horror set disabled', () => {
+        const store = newMockStore({});
+        const scope = defaultContext(store.getState).scope;
+        expect(scope._.randomEnemyOfClass('horror')).not.toBeDefined();
+      });
+      test('includes enemies in the horror set if horror set enabled', () => {
+        const store = newMockStore({settings: {...initialSettings, contentSets: {horror: true}}});
+        const scope = defaultContext(store.getState).scope;
+        expect(scope._.randomEnemyOfClass('horror')).toBeDefined();
+      });
     });
 
     describe('randomEnemyOfClassTier', () => {
-      const scope = defaultContext().scope;
       test('returns a random enemy name', () => {
+        const store = newMockStore({});
+        const scope = defaultContext(store.getState).scope;
         expect(scope._.randomEnemyOfClassTier('undead', 1)).toEqual(jasmine.any(String));
         expect(ENCOUNTERS[scope._.randomEnemyOfClassTier('undead', 1).toLowerCase()]).toBeDefined();
       });
-      test.skip('only includes enemies in the currently enabled content sets', () => { /* TODO */ });
+      test('only includes enemies in the currently enabled content sets', () => {
+        const store = newMockStore({settings: {...initialSettings, contentSets: {horror: true}}});
+        const scope = defaultContext(store.getState).scope;
+        expect(scope._.randomEnemyOfClassTier('undead', 1)).toEqual(jasmine.any(String));
+        expect(scope._.randomEnemyOfClassTier('synth', 1)).not.toBeDefined();
+      });
     });
 
     describe('aliveAdventurers', () => {
-      test.skip('returns the numer of alive adventurers when all alive', () => { /* TODO */ });
-      // const scope = defaultContext().scope;
-      // TODO; requires installing a fake store and changing settings
-      // expect(scope._.aliveAdventurers()).toEqual(TEST_SETTINGS.numPlayers);
-
-      test.skip('returns the numer of alive adventurers when some dead', () => { /* TODO */ });
+      test('returns the numer of alive adventurers during combat', () => {
+        const store = newMockStore();
+        const ctx = defaultContext(store.getState);
+        ctx.templates.combat = {numAliveAdventurers: 3};
+        expect(ctx.scope._.aliveAdventurers()).toEqual(3);
+      });
     });
 
     describe('currentCombatRound', () => {
       test('returns 0 on the first round / by default', () => {
-        const scope = defaultContext().scope;
+        const store = newMockStore({});
+        const scope = defaultContext(store.getState).scope;
         expect(scope._.currentCombatRound()).toEqual(0);
       });
-      test.skip('return 1 on the second round', () => { /* TODO */ });
+      test('return 1 on the second round', () => {
+        const store = newMockStore();
+        const ctx = defaultContext(store.getState);
+        ctx.templates.combat = {roundCount: 1};
+        expect(ctx.scope._.currentCombatRound()).toEqual(1);
+      });
     });
 
     describe('currentCombatTier', () => {
       test('returns 0 by default', () => {
-        const scope = defaultContext().scope;
+        const store = newMockStore({});
+        const scope = defaultContext(store.getState).scope;
         expect(scope._.currentCombatTier()).toEqual(0);
       });
-      test.skip('returns the current combat tier', () => { /* TODO */ });
+      test('returns the current combat tier', () => {
+        const store = newMockStore();
+        const ctx = defaultContext(store.getState);
+        ctx.templates.combat = {tier: 7};
+        expect(ctx.scope._.currentCombatTier()).toEqual(7);
+      });
     });
 
     describe('isCombatSurgeRound', () => {
       test('returns false if it is not a surge round / by default', () => {
-        const scope = defaultContext().scope;
+        const store = newMockStore({});
+        const scope = defaultContext(store.getState).scope;
         expect(scope._.isCombatSurgeRound()).toEqual(false);
       });
-      test.skip('returns true if it is a surge round', () => { /* TODO */ });
+      test('returns true if it is a surge round', () => {
+        const store = newMockStore();
+        const ctx = defaultContext(store.getState);
+        ctx.templates.combat = {roundCount: 4, surgePeriod: 4};
+        expect(ctx.scope._.isCombatSurgeRound()).toEqual(true);
+      });
     });
   });
 });

--- a/services/app/src/components/views/quest/cardtemplates/combat/Scope.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Scope.tsx
@@ -1,41 +1,37 @@
 import {ENCOUNTERS} from 'app/Encounters';
 import {isSurgeRound} from './Actions';
 
+const seedrandom = require('seedrandom');
+
+function supportedEnemies(scope: any): string[] {
+  const contentSets = scope._.contentSets() || [];
+  return Object.keys(ENCOUNTERS)
+          .filter((key) => ENCOUNTERS[key].set === 'base' || contentSets[ENCOUNTERS[key].set]);
+}
+
+function pickRandom<T>(list: T[], rng: () => number = Math.random): T {
+  return list[Math.floor(rng()*list.length)];
+}
+
 export function combatScope() {
   return {
     randomEnemy(): string {
-      const contentSets = this.scope._.contentSets();
-      return (randomPropertyValue(Object.assign({}, ...Object.keys(ENCOUNTERS)
-          .filter( (key) => ENCOUNTERS[key].set === 'base' || contentSets[ENCOUNTERS[key].set])
-          .map( (key) => ({ [key]: ENCOUNTERS[key] }) ) )
-        ) || {}).name;
+      const options = supportedEnemies(this.scope);
+      return ENCOUNTERS[pickRandom(options, seedrandom.alea(this.seed))].name;
     },
     randomEnemyOfTier(tier: number): string {
-      const contentSets = this.scope._.contentSets();
-      return (randomPropertyValue(Object.assign({}, ...Object.keys(ENCOUNTERS)
-          .filter( (key) => ENCOUNTERS[key].set === 'base' || contentSets[ENCOUNTERS[key].set])
-          .filter( (key) => ENCOUNTERS[key].tier === tier )
-          .map( (key) => ({ [key]: ENCOUNTERS[key] }) ) )
-        ) || {}).name;
+      const options = supportedEnemies(this.scope).filter((key) => ENCOUNTERS[key].tier === tier);
+      return (ENCOUNTERS[pickRandom(options, seedrandom.alea(this.seed))] || {}).name;
     },
     randomEnemyOfClass(className: string): string {
-      const contentSets = this.scope._.contentSets();
-      className = className.toLowerCase();
-      return (randomPropertyValue(Object.assign({}, ...Object.keys(ENCOUNTERS)
-          .filter( (key) => ENCOUNTERS[key].set === 'base' || contentSets[ENCOUNTERS[key].set])
-          .filter( (key) => ENCOUNTERS[key].class.toLowerCase() === className )
-          .map( (key) => ({ [key]: ENCOUNTERS[key] }) ) )
-        ) || {}).name;
+      const options = supportedEnemies(this.scope).filter((key) => ENCOUNTERS[key].class.toLowerCase() === className)
+      return (ENCOUNTERS[pickRandom(options, seedrandom.alea(this.seed))] || {}).name;
     },
     randomEnemyOfClassTier(className: string, tier: number): string {
-      const contentSets = this.scope._.contentSets();
-      className = className.toLowerCase();
-      return (randomPropertyValue(Object.assign({}, ...Object.keys(ENCOUNTERS)
-          .filter( (key) => ENCOUNTERS[key].set === 'base' || contentSets[ENCOUNTERS[key].set])
-          .filter( (key) => ENCOUNTERS[key].tier === tier )
-          .filter( (key) => ENCOUNTERS[key].class.toLowerCase() === className )
-          .map( (key) => ({ [key]: ENCOUNTERS[key] }) ) )
-        ) || {}).name;
+      const options = supportedEnemies(this.scope)
+        .filter( (key) => ENCOUNTERS[key].tier === tier )
+        .filter((key) => ENCOUNTERS[key].class.toLowerCase() === className)
+      return (ENCOUNTERS[pickRandom(options, seedrandom.alea(this.seed))] || {}).name;
     },
     aliveAdventurers(): number {
       return (this.templates && this.templates.combat && this.templates.combat.numAliveAdventurers) || 0;
@@ -55,7 +51,11 @@ export function combatScope() {
   };
 }
 
-function randomPropertyValue(obj: any): any {
+function randomPropertyValue(obj: any, rng: () => number): any {
+  console.log('random property value');
+  console.log(obj);
   const keys = Object.keys(obj);
-  return obj[ keys[ Math.floor(keys.length * Math.random()) ] ];
+  const i = Math.floor(keys.length * rng());;
+  console.log(obj[keys[i]]);
+  return obj[keys[i]];
 }

--- a/services/app/src/components/views/quest/cardtemplates/combat/Scope.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Scope.tsx
@@ -48,6 +48,6 @@ export function combatScope() {
       }
       return isSurgeRound(this.templates.combat.roundCount, this.templates.combat.surgePeriod);
     },
-    crng(): number { this.scope._.crng = seedrandom.alea(this.seed); return this.scope._.crng() },
+    crng(): number { this.scope._.crng = seedrandom.alea(this.seed); return this.scope._.crng(); },
   };
 }

--- a/services/app/src/components/views/quest/cardtemplates/combat/Scope.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Scope.tsx
@@ -17,21 +17,21 @@ export function combatScope() {
   return {
     randomEnemy(): string {
       const options = supportedEnemies(this.scope);
-      return ENCOUNTERS[pickRandom(options, seedrandom.alea(this.seed))].name;
+      return ENCOUNTERS[pickRandom(options, this.scope._.crng)].name;
     },
     randomEnemyOfTier(tier: number): string {
       const options = supportedEnemies(this.scope).filter((key) => ENCOUNTERS[key].tier === tier);
-      return (ENCOUNTERS[pickRandom(options, seedrandom.alea(this.seed))] || {}).name;
+      return (ENCOUNTERS[pickRandom(options, this.scope._.crng)] || {}).name;
     },
     randomEnemyOfClass(className: string): string {
       const options = supportedEnemies(this.scope).filter((key) => ENCOUNTERS[key].class.toLowerCase() === className);
-      return (ENCOUNTERS[pickRandom(options, seedrandom.alea(this.seed))] || {}).name;
+      return (ENCOUNTERS[pickRandom(options, this.scope._.crng)] || {}).name;
     },
     randomEnemyOfClassTier(className: string, tier: number): string {
       const options = supportedEnemies(this.scope)
         .filter( (key) => ENCOUNTERS[key].tier === tier )
         .filter((key) => ENCOUNTERS[key].class.toLowerCase() === className);
-      return (ENCOUNTERS[pickRandom(options, seedrandom.alea(this.seed))] || {}).name;
+      return (ENCOUNTERS[pickRandom(options, this.scope._.crng)] || {}).name;
     },
     aliveAdventurers(): number {
       return (this.templates && this.templates.combat && this.templates.combat.numAliveAdventurers) || 0;
@@ -48,5 +48,6 @@ export function combatScope() {
       }
       return isSurgeRound(this.templates.combat.roundCount, this.templates.combat.surgePeriod);
     },
+    crng(): number { this.scope._.crng = seedrandom.alea(this.seed); return this.scope._.crng() },
   };
 }

--- a/services/app/src/components/views/quest/cardtemplates/combat/Scope.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Scope.tsx
@@ -10,7 +10,7 @@ function supportedEnemies(scope: any): string[] {
 }
 
 function pickRandom<T>(list: T[], rng: () => number = Math.random): T {
-  return list[Math.floor(rng()*list.length)];
+  return list[Math.floor(rng() * list.length)];
 }
 
 export function combatScope() {
@@ -24,13 +24,13 @@ export function combatScope() {
       return (ENCOUNTERS[pickRandom(options, seedrandom.alea(this.seed))] || {}).name;
     },
     randomEnemyOfClass(className: string): string {
-      const options = supportedEnemies(this.scope).filter((key) => ENCOUNTERS[key].class.toLowerCase() === className)
+      const options = supportedEnemies(this.scope).filter((key) => ENCOUNTERS[key].class.toLowerCase() === className);
       return (ENCOUNTERS[pickRandom(options, seedrandom.alea(this.seed))] || {}).name;
     },
     randomEnemyOfClassTier(className: string, tier: number): string {
       const options = supportedEnemies(this.scope)
         .filter( (key) => ENCOUNTERS[key].tier === tier )
-        .filter((key) => ENCOUNTERS[key].class.toLowerCase() === className)
+        .filter((key) => ENCOUNTERS[key].class.toLowerCase() === className);
       return (ENCOUNTERS[pickRandom(options, seedrandom.alea(this.seed))] || {}).name;
     },
     aliveAdventurers(): number {
@@ -49,13 +49,4 @@ export function combatScope() {
       return isSurgeRound(this.templates.combat.roundCount, this.templates.combat.surgePeriod);
     },
   };
-}
-
-function randomPropertyValue(obj: any, rng: () => number): any {
-  console.log('random property value');
-  console.log(obj);
-  const keys = Object.keys(obj);
-  const i = Math.floor(keys.length * rng());;
-  console.log(obj[keys[i]]);
-  return obj[keys[i]];
 }

--- a/shared/parse/Context.test.tsx
+++ b/shared/parse/Context.test.tsx
@@ -33,9 +33,34 @@ describe('Context', () => {
     test('does not return if last operation assigns a value', () => {
       expect(evaluateOp('a=1', defaultContext())).toEqual(null);
     });
-    test.skip('has repeatable random() behavior based on seed');
-    test.skip('has repeatable randomInt() behavior based on seed');
-    test.skip('has repeatable pickRandom() behavior based on seed');
+    test('has repeatable random() behavior based on seed', () => {
+      const ctx = {...defaultContext()};
+      const rng = () => 0.1;
+      const expected = evaluateOp('random()', ctx, rng);
+      for (let i = 0; i < 50; i++) {
+        expect(evaluateOp('random()', ctx, rng)).toEqual(expected);
+      }
+      expect(evaluateOp('random(100)', ctx, rng)).toEqual(evaluateOp('random(100)', ctx, rng));
+      expect(evaluateOp('random(10, 100)', ctx, rng)).toEqual(evaluateOp('random(10, 100)', ctx, rng));
+    });
+    test('has repeatable randomInt() behavior based on seed', () => {
+      const ctx = {...defaultContext()};
+      const rng = () => 0.1;
+      const expected = evaluateOp('randomInt()', ctx, rng);
+      for (let i = 0; i < 50; i++) {
+        expect(evaluateOp('randomInt()', ctx, rng)).toEqual(expected);
+      }
+      expect(evaluateOp('randomInt(100)', ctx, rng)).toEqual(evaluateOp('randomInt(100)', ctx, rng));
+      expect(evaluateOp('randomInt(10, 100)', ctx, rng)).toEqual(evaluateOp('randomInt(10, 100)', ctx, rng));
+    });
+    test('has repeatable pickRandom() behavior based on seed', () => {
+      const ctx = {...defaultContext()};
+      const rng = () => 0.1;
+      const expected = evaluateOp('pickRandom([1,2,3])', ctx, rng);
+      for (let i = 0; i < 50; i++) {
+        expect(evaluateOp('pickRandom([1,2,3])', ctx, rng)).toEqual(expected);
+      }
+    });
   });
 
   describe('evaluateContentOps', () => {
@@ -48,6 +73,12 @@ describe('Context', () => {
     test('handles multiple ops in one string', () => {
       const ctx = defaultContext();
       expect(evaluateContentOps('{{text="TEST"}}\n{{text}}', ctx)).toEqual('TEST');
+    });
+
+    test('varies results when random() called in same set of ops', () => {
+      const ctx = defaultContext();
+      const result = evaluateContentOps('{{random()}}\n{{random()}}', ctx).split('\n');
+      expect(result[1]).not.toEqual(result[2]);
     });
   });
 
@@ -69,7 +100,11 @@ describe('Context', () => {
       updateContext(dummyElem, ctx, 2);
       expect(ctx.path).not.toEqual([2]);
     });
-    test.skip('updates view count', () => { /* TODO */ });
+    test('updates view count', () => {
+      const dummyElem = cheerio.load('<roleplay id="1234"></roleplay>')('roleplay');
+      const ctx = updateContext(dummyElem, defaultContext(), 0);
+      expect(ctx.views['1234']).toEqual(1);
+    });
   });
 
 });

--- a/shared/parse/Context.test.tsx
+++ b/shared/parse/Context.test.tsx
@@ -33,6 +33,9 @@ describe('Context', () => {
     test('does not return if last operation assigns a value', () => {
       expect(evaluateOp('a=1', defaultContext())).toEqual(null);
     });
+    test.skip('has repeatable random() behavior based on seed');
+    test.skip('has repeatable randomInt() behavior based on seed');
+    test.skip('has repeatable pickRandom() behavior based on seed');
   });
 
   describe('evaluateContentOps', () => {

--- a/shared/parse/Context.tsx
+++ b/shared/parse/Context.tsx
@@ -105,6 +105,25 @@ export function evaluateContentOps(content: string, ctx: Context): string {
 export function evaluateOp(op: string, ctx: Context): any {
   let parsed;
   let evalResult;
+
+  // override random functions to use seed
+  rng = seedrandom.alea(ctx.scope || generateSeed());
+  const random = (v1?: number, v2?: number) => {
+    const r = rng();
+    if (v2 === undefined && v1 === undefined) {
+      return r;
+    } else if (v2 === undefined) {
+      return r * v1; // v1 = max
+    } else {
+      return r * (v2 - v1) + v1; // v1 = min, v2 = max
+    }
+  }
+  Math.import({
+    random,
+    randomInt(v1?: number, v2?: number) {return Math.floor(random(v1, v2))},
+    pickRandom(a: any[]) {return a[Math.floor(random(a.length))]},
+  }, {override: true});
+
   try {
     parsed = Math.parse(HtmlDecode(op));
     evalResult = parsed.compile().eval(ctx.scope);

--- a/shared/parse/Context.tsx
+++ b/shared/parse/Context.tsx
@@ -110,18 +110,18 @@ export function evaluateOp(op: string, ctx: Context, rng: () => number = Math.ra
   // override random functions to use seed
   const random = (v1?: number, v2?: number) => {
     const r = rng();
-    if (v2 === undefined && v1 === undefined) {
-      return r;
-    } else if (v2 === undefined) {
+    if (v2 !== undefined && v1 !== undefined) {
+      return r * (v2 - v1) + v1; // v1 = min, v2 = max
+    } else if (v1 !== undefined) {
       return r * v1; // v1 = max
     } else {
-      return r * (v2 - v1) + v1; // v1 = min, v2 = max
+      return r;
     }
   };
   MathJS.import({
     random,
     randomInt(v1?: number, v2?: number) { return Math.floor(random(v1, v2)); },
-    pickRandom(a: any[]) { return a._data[Math.floor(random(a._data.length))]; },
+    pickRandom(a: {_data: any[]}) { return a._data[Math.floor(random(a._data.length))]; },
   }, {override: true});
 
   try {

--- a/shared/parse/Context.tsx
+++ b/shared/parse/Context.tsx
@@ -120,8 +120,8 @@ export function evaluateOp(op: string, ctx: Context, rng: () => number = Math.ra
   };
   MathJS.import({
     random,
-    randomInt(v1?: number, v2?: number) {return Math.floor(random(v1, v2));},
-    pickRandom(a: any[]) {return a._data[Math.floor(random(a._data.length))];},
+    randomInt(v1?: number, v2?: number) { return Math.floor(random(v1, v2)); },
+    pickRandom(a: any[]) { return a._data[Math.floor(random(a._data.length))]; },
   }, {override: true});
 
   try {

--- a/shared/parse/Context.tsx
+++ b/shared/parse/Context.tsx
@@ -1,6 +1,6 @@
 const Clone = require('clone');
 const HtmlDecode = (require('he') as any).decode;
-const Math = require('mathjs');
+const MathJS = require('mathjs');
 const seedrandom = require('seedrandom');
 
 // Later versions of MathJS come with a breaking change where
@@ -12,7 +12,7 @@ const seedrandom = require('seedrandom');
 // expected/sane.
 //
 // https://github.com/josdejong/mathjs/issues/1051#issuecomment-369930811
-Math.import({
+MathJS.import({
   equal(a: any, b: any) { return a === b; },
 }, {override: true});
 
@@ -84,10 +84,11 @@ export function evaluateContentOps(content: string, ctx: Context): string {
   }
 
   let result = '';
+  const rng = seedrandom.alea(ctx.scope || generateSeed());
   for (const m of matches) {
     const op = parseOpString(m);
     if (op) {
-      const evalResult = evaluateOp(op, ctx);
+      const evalResult = evaluateOp(op, ctx, rng);
       if (evalResult || evalResult === 0) {
         result += evalResult;
       }
@@ -102,12 +103,11 @@ export function evaluateContentOps(content: string, ctx: Context): string {
 // Attempts to evaluate op using ctx.
 // If the evaluation is successful, the context is modified as determined by the op.
 // If the last operation does not assign a value, the result is returned.
-export function evaluateOp(op: string, ctx: Context): any {
+export function evaluateOp(op: string, ctx: Context, rng: () => number = Math.random): any {
   let parsed;
   let evalResult;
 
   // override random functions to use seed
-  rng = seedrandom.alea(ctx.scope || generateSeed());
   const random = (v1?: number, v2?: number) => {
     const r = rng();
     if (v2 === undefined && v1 === undefined) {
@@ -117,15 +117,15 @@ export function evaluateOp(op: string, ctx: Context): any {
     } else {
       return r * (v2 - v1) + v1; // v1 = min, v2 = max
     }
-  }
-  Math.import({
+  };
+  MathJS.import({
     random,
-    randomInt(v1?: number, v2?: number) {return Math.floor(random(v1, v2))},
-    pickRandom(a: any[]) {return a[Math.floor(random(a.length))]},
+    randomInt(v1?: number, v2?: number) {return Math.floor(random(v1, v2));},
+    pickRandom(a: any[]) {return a._data[Math.floor(random(a._data.length))];},
   }, {override: true});
 
   try {
-    parsed = Math.parse(HtmlDecode(op));
+    parsed = MathJS.parse(HtmlDecode(op));
     evalResult = parsed.compile().eval(ctx.scope);
   } catch (err) {
     const message = err.message + ' Op: (' + op + ')';

--- a/shared/parse/Node.test.tsx
+++ b/shared/parse/Node.test.tsx
@@ -289,7 +289,7 @@ describe('Node', () => {
       const ctx = defaultContext();
       ctx.seed = 'randomseed';
       const result = new Node(cheerio.load('<roleplay><p>{{a=pickRandom([1,2,3,4,5])}}{{b=round(random(0,100), 4)}}{{c=randomInt(0, 100)}}</p></roleplay>')('roleplay'), ctx, undefined, ctx.seed);
-      expect(result.ctx.scope).toEqual(jasmine.objectContaining({a: 2, b: 32.3244, c: 40}));
+      expect(result.ctx.scope).toEqual(jasmine.objectContaining({a: 5, b: 35.0544, c: 74}));
     });
 
     test('renders next node via getNext deterministically when a seed is given', () => {
@@ -299,7 +299,7 @@ describe('Node', () => {
       if (next === null) {
         throw new Error('getNext returned null node');
       }
-      expect(next.ctx.scope).toEqual(jasmine.objectContaining({a: 2, b: 32.3244, c: 40}));
+      expect(next.ctx.scope).toEqual(jasmine.objectContaining({a: 5, b: 35.0544, c: 74}));
     });
   });
 
@@ -540,7 +540,7 @@ describe('Node', () => {
       if (result === null) {
         throw new Error('handleAction returned null node');
       }
-      expect(result.ctx.scope.a).toEqual(32.8971);
+      expect(result.ctx.scope.a).toEqual(95.2223);
     });
 
     test('handles choices with id gotos deterministically when seed is set', () => {
@@ -556,7 +556,7 @@ describe('Node', () => {
       if (result === null) {
         throw new Error('handleAction returned null node');
       }
-      expect(result.ctx.scope.a).toEqual(32.8971);
+      expect(result.ctx.scope.a).toEqual(95.2223);
     });
 
     test('handles choices with event gotos deterministically when seed is set', () => {
@@ -566,7 +566,7 @@ describe('Node', () => {
       if (result === null) {
         throw new Error('handleAction returned null node');
       }
-      expect(result.ctx.scope.a).toEqual(32.8971);
+      expect(result.ctx.scope.a).toEqual(95.2223);
     });
 
     test('handles randomly-generated triggers deterministically when seed is set', () => {
@@ -587,7 +587,7 @@ describe('Node', () => {
       if (result === null) {
         throw new Error('handleAction returned null node');
       }
-      expect(result.elem.text()).toEqual('r1');
+      expect(result.elem.text()).toEqual('r4');
     });
   });
 });


### PR DESCRIPTION
Also adds some stubs for `defaultContext()` created functions, tests/deterministic-ifies context op evaluation, and adds deterministic behavior for combat enemies - fixes #232.

57.6% -> 58.1% test stub coverage.
