### PR TITLE
Test dialogs (incl. refactor)

### DIFF
--- a/services/app/src/components/base/Dialogs.test.tsx
+++ b/services/app/src/components/base/Dialogs.test.tsx
@@ -1,19 +1,211 @@
+import * as React from 'react';
+import {configure, shallow} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {
+  TextAreaDialog,
+  BaseDialogProps,
+  ConfirmationDialog,
+  BaseDialogProps
+  MultiplayerStatusDialogProps,
+  MultiplayerStatusDialog,
+  ExpansionSelectDialogProps,
+  ExpansionSelectDialog,
+  SetPlayerCountDialogProps,
+  SetPlayerCountDialog,
+} from './Dialogs';
+import {loggedOutUser} from '../../reducers/User';
+import {initialSettings} from '../../reducers/Settings';
+import {initialMultiplayerCounters} from '../../Multiplayer';
+import {FEATURED_QUESTS} from '../../Constants';
+import {Quest} from 'shared/schema/Quests';
+configure({ adapter: new Adapter() });
+
 describe('Dialogs', () => {
-  describe('ExitQuestDialog', () => {
-    test.skip('renders if open', () => { /* TODO */ });
+  // Simple dialog components that implement ConfirmationDialog or TextAreaDialog
+  // do not need to be tested.
+  describe('ConfirmationDialog', () => {
+    class DialogTmpl extends ConfirmationDialog<BaseDialogProps> {
+      public actionSpy: jasmine.Spy;
+      constructor(props: BaseDialogProps) {
+        super(props);
+        this.title = 'Test Title';
+        this.content = <p>Test Content</p>;
+        this.actionSpy = jasmine.createSpy('onAction');
+      }
+      public onAction() {
+        this.actionSpy();
+      }
+    }
+    function setup(overrides?: Partial<BaseDialogProps>) {
+      const props: Props = {
+        open: true,
+        onClose: jasmine.createSpy('onClose'),
+        ...overrides,
+      };
+      return {props, e: shallow(<DialogTmpl {...(props as any as BaseDialogProps)} />, undefined /*renderOptions*/)};
+    }
+    test('renders title & content', () => {
+      const {e} = setup();
+      expect(e.childAt(0).render().text()).toContain('Test Title');
+      expect(e.childAt(1).render().text()).toContain('Test Content');
+    });
+    test('calls onAction on action tap', () => {
+      const {e} = setup();
+      e.find('#actionButton').simulate('click');
+      expect(e.instance().actionSpy).toHaveBeenCalledTimes(1);
+    });
+    test('calls onClose on cancel tap', () => {
+      const {props, e} = setup();
+      e.find('#closeButton').simulate('click');
+      expect(props.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
 
-    test.skip('hides if not open', () => { /* TODO */ });
+  describe('TextAreaDialog', () => {
+    class DialogTmpl extends TextAreaDialog<BaseDialogProps> {
+      public onSubmit: jasmine.Spy;
+      constructor(props: BaseDialogProps) {
+        super(props);
+        this.title = 'Test Title';
+        this.content = <p>Test Content</p>;
+        this.helperText = 'Test HelperText';
+        this.onSubmit = jasmine.createSpy('onSubmit');
+      }
+      public onAction() {
+        this.onSubmit();
+      }
+    }
+    function setup(overrides?: Partial<BaseDialogProps>) {
+      const props: Props = {
+        open: true,
+        onClose: jasmine.createSpy('onClose'),
+        ...overrides,
+      };
+      return {props, e: shallow(<DialogTmpl {...(props as any as BaseDialogProps)} />, undefined /*renderOptions*/)};
+    }
+    test('renders title & content', () => {
+      const {e} = setup();
+      expect(e.childAt(0).render().text()).toContain('Test Title');
+      expect(e.childAt(1).render().text()).toContain('Test Content');
+    });
+    test('updates text state', () => {
+      const {e} = setup();
+      e.find('.textfield').simulate('change', {target: {value: 'asdf'}});
+      expect(e.state().text).toEqual('asdf');
+    });
+    test('calls onSubmit on submission', () => {
+      const {e} = setup();
+      e.find('#submitButton').simulate('click');
+      expect(e.instance().onSubmit).toHaveBeenCalledTimes(1);
+    });
+    test('calls onClose on Cancel tap', () => {
+      const {props, e} = setup();
+      e.find('#cancelButton').simulate('click');
+      expect(props.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
 
-    test.skip('calls onExitQuest on Exit tap', () => { /* TODO */ });
-
-    test.skip('closes on Cancel tap', () => { /* TODO */ });
+  describe('MultiplayerStatusDialog', () => {
+    function setup(counters?: Partial<MultiplayerCounters>) {
+      const props: Props = {
+        onClose: jasmine.createSpy('onClose'),
+        onSendReport: jasmine.createSpy('onSendReport'),
+        open: true,
+        questDetails: new Quest(FEATURED_QUESTS[0]),
+        stats: {...initialMultiplayerCounters, ...counters},
+        user: loggedOutUser,
+      };
+      return {props, e: shallow(<MultiplayerStatusDialog {...(props as any as MultiplayerStatusDialogProps)} />, undefined /*renderOptions*/)};
+    }
+    test('shows stats', () => {
+      const {e} = setup({receivedEvents: 500});
+      expect(e.childAt(1).render().text()).toContain("receivedEvents: 500");
+    });
+    test('sends report', () => {
+      const {props, e} = setup();
+      e.find('#sendReportButton').simulate('click');
+      expect(props.onSendReport).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('ExpansionSelectDialog', () => {
-    test.skip('sets no content sets if base game', () => { /* TODO */ });
+    function setup(overrides?: Partial<ExpansionSelectDialogProps>) {
+      const props: Props = {
+        onExpansionSelect: jasmine.createSpy('onExpansionSelect');
+        open: true,
+        ...overrides,
+      };
+      return {props, e: shallow(<ExpansionSelectDialog {...(props as any as ExpansionSelectDialogProps)} />, undefined /*renderOptions*/)};
+    }
 
-    test.skip('sets horror content set', () => { /* TODO */ });
+    test('sets no content sets if base game', () => {
+      const {props, e} = setup();
+      e.find('#base').simulate('click');
+      expect(props.onExpansionSelect).toHaveBeenCalledWith({horror: false, future: false});
+    });
+    test('sets horror content set', () => {
+      const {props, e} = setup();
+      e.find('#horror').simulate('click');
+      expect(props.onExpansionSelect).toHaveBeenCalledWith({horror: true});
+    });
+    test('sets horror + future content sets', () => {
+      const {props, e} = setup();
+      e.find('#future').simulate('click');
+      expect(props.onExpansionSelect).toHaveBeenCalledWith({horror: true, future: true});
+    });
+    test('has buttons for all content sets', () => {
+      const {props, e} = setup();
+      const sets: {[set: string]: boolean} = {};
+      FEATURED_QUESTS.map((q) => {
+        const setAttrs = Object.keys(q).filter((k) => k.startsWith('expansion')).map((k) => k.match(/^expansion(.*)/)[1]);
+        for (const a of setAttrs) {
+          sets[a] = true;
+        }
+      });
+      expect(Object.keys(sets).length).toBeGreaterThan(0);
+      for (const s of Object.keys(sets)) {
+        expect(e.find('#'+s).length).toEqual(1);
+      }
+    });
+  });
 
-    test.skip('sets horror + future content sets', () => { /* TODO */ });
+  describe('SetPlayerCountDialog', () => {
+    function setup(overrides?: Partial<SetPlayerCountDialogProps>) {
+      const props: Props = {
+        open: true,
+        quest: new Quest(FEATURED_QUESTS[0]),
+        settings: {...initialSettings},
+        onClose: jasmine.createSpy('onClose'),
+        onMultitouchChange: jasmine.createSpy('onMultitouchChange'),
+        onPlayerDelta: jasmine.createSpy('onPlayerDelta'),
+        playQuest: jasmine.createSpy('playQuest'),
+        ...overrides,
+      };
+      return {props, e: shallow(<SetPlayerCountDialog {...(props as any as SetPlayerCountDialogProps)} />, undefined /*renderOptions*/)};
+    }
+    test('enables play under normal circumstances', () => {
+      const {props, e} = setup();
+      expect(e.find('#play').prop('disabled')).toEqual(false);
+    })
+    test('can adjust player count', () => {
+      const {props, e} = setup();
+      e.find('#adventurerCount').prop('onDelta')(1);
+      expect(props.onPlayerDelta).toHaveBeenCalledWith(jasmine.any(Number), 1);
+    });
+    test('can enable/disable multitouch', () => {
+      const {props, e} = setup();
+      e.find('#multitouch').prop('onChange')(true);
+      expect(props.onMultitouchChange).toHaveBeenCalledWith(true);
+    });
+    test('shows requirement if player count is outside of quest num players range and disables play', () => {
+      const {props, e} = setup({settings: {...initialSettings, numPlayers: 7}});
+      expect(e.childAt(1).render().text()).toContain('Quest requires');
+      expect(e.find('#play').prop('disabled')).toEqual(true);
+    });
+    test('indicates required expansion (and hides Play) if not properly configured', () => {
+      const {props, e} = setup({quest: new Quest({...FEATURED_QUESTS[0], expansionhorror: true})});
+      expect(e.childAt(1).render().text()).toContain('expansion is required');
+      expect(e.find('#play').length).toEqual(0);
+    });
   });
 });

--- a/services/app/src/components/base/Dialogs.tsx
+++ b/services/app/src/components/base/Dialogs.tsx
@@ -18,7 +18,7 @@ export interface BaseDialogProps extends React.Props<any> {
 }
 export class ConfirmationDialog<T extends BaseDialogProps> extends React.Component<T, {}> {
   protected title: string;
-  protected content: JSX.Element;
+  protected content: JSX.Element|null;
   protected action?: string;
 
   constructor(props: T) {
@@ -203,7 +203,7 @@ export class TextAreaDialog<T extends BaseDialogProps> extends React.Component<T
   }
 }
 
-interface FeedbackDialogProps extends TextAreaDialogProps {
+interface FeedbackDialogProps extends BaseDialogProps {
   quest: QuestState;
   settings: SettingsType;
   user: UserState;
@@ -348,12 +348,12 @@ const Dialogs = (props: Props): JSX.Element => {
       <DeleteSavedQuestDialog
         savedQuest={props.selectedSave}
         open={props.dialog && props.dialog.open === 'DELETE_SAVED_QUEST'}
-        onDeleteSavedQuest={props.onDeleteSavedQuest}
+        onDelete={props.onDeleteSavedQuest}
         onClose={props.onClose}
       />
       <ExitQuestDialog
         open={props.dialog && props.dialog.open === 'EXIT_QUEST'}
-        onExitQuest={props.onExitQuest}
+        onExit={props.onExitQuest}
         onClose={props.onClose}
       />
       <ExpansionSelectDialog
@@ -362,7 +362,7 @@ const Dialogs = (props: Props): JSX.Element => {
       />
       <ExitMultiplayerDialog
         open={props.dialog && props.dialog.open === 'EXIT_REMOTE_PLAY'}
-        onExitMultiplayer={props.onExitMultiplayer}
+        onExit={props.onExitMultiplayer}
         onClose={props.onClose}
       />
       <MultiplayerStatusDialog

--- a/services/app/src/components/base/Dialogs.tsx
+++ b/services/app/src/components/base/Dialogs.tsx
@@ -12,49 +12,86 @@ import {ContentSetsType, DialogState, FeedbackType, QuestState, SavedQuestMeta, 
 import Checkbox from './Checkbox';
 import Picker from './Picker';
 
-interface ExitQuestDialogProps extends React.Props<any> {
+export interface BaseDialogProps extends React.Props<any> {
   onClose: () => void;
-  onExitQuest: () => void;
   open: boolean;
 }
+export class ConfirmationDialog<T extends BaseDialogProps> extends React.Component<T, {}> {
+  protected title: string;
+  protected content: JSX.Element;
+  protected action?: string;
 
-export class ExitQuestDialog extends React.Component<ExitQuestDialogProps, {}> {
+  constructor(props: T) {
+    super(props);
+  }
+
+  public onAction() {
+    throw new Error('Unimplemented');
+  }
+
   public render(): JSX.Element {
     return (
       <Dialog classes={{paperWidthSm: 'dialog'}} open={Boolean(this.props.open)}>
-        <DialogTitle>Exit quest?</DialogTitle>
+        <DialogTitle>{this.title || 'Confirm'}</DialogTitle>
         <DialogContent className="dialog">
-          <p>Tapping exit will lose your place in the quest and return you to the home screen.</p>
+          {this.content}
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => this.props.onClose()}>Cancel</Button>
-          <Button className="primary" onClick={() => this.props.onExitQuest()}>Exit</Button>
+          <Button id="closeButton" onClick={() => this.props.onClose()}>Cancel</Button>
+          <Button id="actionButton" className="primary" onClick={() => this.onAction()}>{this.action || 'Exit'}</Button>
         </DialogActions>
       </Dialog>
     );
   }
 }
 
-interface ExitMultiplayerDialogProps extends React.Props<any> {
-  onClose: () => void;
-  onExitMultiplayer: () => void;
-  open: boolean;
+interface ExitDialogProps extends BaseDialogProps {
+  onExit: () => void;
 }
 
-export class ExitMultiplayerDialog extends React.Component<ExitMultiplayerDialogProps, {}> {
-  public render(): JSX.Element {
-    return (
-      <Dialog classes={{paperWidthSm: 'dialog'}} open={Boolean(this.props.open)}>
-        <DialogTitle>Exit Multiplayer?</DialogTitle>
-        <DialogContent className="dialog">
-          <p>Tapping exit will disconnect you from your peers and return you to the home screen.</p>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => this.props.onClose()}>Cancel</Button>,
-          <Button className="primary" onClick={() => this.props.onExitMultiplayer()}>Exit</Button>
-        </DialogActions>
-      </Dialog>
-    );
+export class ExitQuestDialog extends ConfirmationDialog<ExitDialogProps> {
+  constructor(props: ExitDialogProps) {
+    super(props);
+    this.title = 'Exit Quest?';
+    this.content = <p>Tapping exit will lose your place in the quest and return you to the home screen.</p>;
+  }
+
+  public onAction() {
+    this.props.onExit();
+  }
+}
+
+export class ExitMultiplayerDialog extends ConfirmationDialog<ExitDialogProps> {
+  constructor(props: ExitDialogProps) {
+    super(props);
+    this.title = 'Exit Multiplayer?';
+    this.content = <p>Tapping exit will disconnect you from your peers and return you to the home screen.</p>;
+  }
+
+  public onAction() {
+    this.props.onExit();
+  }
+}
+
+interface DeleteSavedQuestDialogProps extends BaseDialogProps {
+  onDelete: (savedQuest: SavedQuestMeta) => void;
+  savedQuest: SavedQuestMeta|null;
+}
+
+export class DeleteSavedQuestDialog extends ConfirmationDialog<DeleteSavedQuestDialogProps> {
+  constructor(props: DeleteSavedQuestDialogProps) {
+    super(props);
+    this.title = 'Delete saved quest?';
+    this.content = null;
+    this.action = 'Delete';
+  }
+
+  public onAction() {
+    const savedQuest = this.props.savedQuest;
+    if (savedQuest === null) {
+      throw new Error('missing saved quest information');
+    }
+    this.props.onDelete(savedQuest);
   }
 }
 
@@ -90,7 +127,7 @@ export class MultiplayerStatusDialog extends React.Component<MultiplayerStatusDi
         </DialogContent>
         <DialogActions>
           <Button onClick={() => this.props.onClose()}>Cancel</Button>,
-          <Button className="primary" onClick={() => this.props.onSendReport(this.props.user, this.props.questDetails, this.props.stats)}>Send Report</Button>
+          <Button id="sendReportButton" className="primary" onClick={() => this.props.onSendReport(this.props.user, this.props.questDetails, this.props.stats)}>Send Report</Button>
         </DialogActions>
       </Dialog>
     );
@@ -108,13 +145,13 @@ export class ExpansionSelectDialog extends React.Component<ExpansionSelectDialog
       <Dialog classes={{paperWidthSm: 'dialog'}} open={Boolean(this.props.open)}>
         <DialogTitle>Choose game</DialogTitle>
         <DialogContent className="dialog">
-          <Button className="primary large" onClick={() => this.props.onExpansionSelect({horror: false, future: false})}>Base Game</Button>
+          <Button id="base" className="primary large" onClick={() => this.props.onExpansionSelect({horror: false, future: false})}>Base Game</Button>
           <br/>
           <br/>
-          <Button className="primary large" onClick={() => this.props.onExpansionSelect({horror: true})}>Base + Horror</Button>
+          <Button id="horror" className="primary large" onClick={() => this.props.onExpansionSelect({horror: true})}>Base + Horror</Button>
           <br/>
           <br/>
-          <Button className="primary large" onClick={() => this.props.onExpansionSelect({horror: true, future: true})}>Base + Horror + Future</Button>
+          <Button id="future" className="primary large" onClick={() => this.props.onExpansionSelect({horror: true, future: true})}>Base + Horror + Future</Button>
           <p style={{textAlign: 'center', marginTop: '1.5em'}}>This will only appear once, but you can change it at any time in Settings.</p>
           <p style={{textAlign: 'center', marginTop: '1.5em'}}>Don't have the cards? <strong><a href="#" onClick={() => openWindow('https://expeditiongame.com/store?utm_source=app')}>Get a copy</a></strong>.</p>
         </DialogContent>
@@ -123,15 +160,7 @@ export class ExpansionSelectDialog extends React.Component<ExpansionSelectDialog
   }
 }
 
-interface TextAreaDialogProps extends React.Props<any> {
-  onClose: () => void;
-  onFeedbackSubmit: (type: FeedbackType, quest: QuestState, settings: SettingsType, user: UserState, text: string) => void;
-  open: boolean;
-  quest: QuestState;
-  settings: SettingsType;
-  user: UserState;
-}
-class TextAreaDialog<T extends TextAreaDialogProps> extends React.Component<T, {}> {
+export class TextAreaDialog<T extends BaseDialogProps> extends React.Component<T, {}> {
   protected title: string;
   protected content: JSX.Element;
   protected helperText: string;
@@ -166,16 +195,23 @@ class TextAreaDialog<T extends TextAreaDialogProps> extends React.Component<T, {
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => this.props.onClose()}>Cancel</Button>
-          <Button className="primary" onClick={() => this.onSubmit()}>Submit</Button>
+          <Button id="cancelButton" onClick={() => this.props.onClose()}>Cancel</Button>
+          <Button id="submitButton" className="primary" onClick={() => this.onSubmit()}>Submit</Button>
         </DialogActions>
       </Dialog>
     );
   }
 }
 
-export class FeedbackDialog extends TextAreaDialog<TextAreaDialogProps> {
-  constructor(props: TextAreaDialogProps) {
+interface FeedbackDialogProps extends TextAreaDialogProps {
+  quest: QuestState;
+  settings: SettingsType;
+  user: UserState;
+  onFeedbackSubmit: (type: FeedbackType, quest: QuestState, settings: SettingsType, user: UserState, text: string) => void;
+}
+
+export class FeedbackDialog extends TextAreaDialog<FeedbackDialogProps> {
+  constructor(props: FeedbackDialogProps) {
     super(props);
     this.title = 'Send Feedback';
     this.content = <p>Thank you for taking the time to give us feedback! If you've encountered a bug, please include the steps that you can take to reproduce the issue.</p>;
@@ -187,7 +223,7 @@ export class FeedbackDialog extends TextAreaDialog<TextAreaDialogProps> {
   }
 }
 
-interface ReportErrorDialogProps extends TextAreaDialogProps {
+interface ReportErrorDialogProps extends FeedbackDialogProps {
   error: string;
 }
 export class ReportErrorDialog extends TextAreaDialog<ReportErrorDialogProps> {
@@ -203,8 +239,8 @@ export class ReportErrorDialog extends TextAreaDialog<ReportErrorDialogProps> {
   }
 }
 
-export class ReportQuestDialog extends TextAreaDialog<TextAreaDialogProps> {
-  constructor(props: TextAreaDialogProps) {
+export class ReportQuestDialog extends TextAreaDialog<FeedbackDialogProps> {
+  constructor(props: FeedbackDialogProps) {
     super(props);
     this.title = 'Report Quest';
     this.content = (
@@ -227,13 +263,13 @@ export class ReportQuestDialog extends TextAreaDialog<TextAreaDialogProps> {
 }
 
 interface SetPlayerCountDialogProps extends React.Props<any> {
+  open: boolean;
+  quest: Quest;
+  settings: SettingsType;
   onClose: () => void;
   onMultitouchChange: (v: boolean) => void;
   onPlayerDelta: (numPlayers: number, delta: number) => void;
-  open: boolean;
   playQuest: (quest: Quest) => void;
-  quest: Quest;
-  settings: SettingsType;
 }
 
 export class SetPlayerCountDialog extends React.Component<SetPlayerCountDialogProps, {}> {
@@ -245,25 +281,23 @@ export class SetPlayerCountDialog extends React.Component<SetPlayerCountDialogPr
         this.props.settings.numPlayers <= quest.maxplayers);
     }
     let contents = <div>
-        <Picker label="Adventurers" value={this.props.settings.numPlayers} onDelta={(i: number) => this.props.onPlayerDelta(this.props.settings.numPlayers, i)}>
+        <Picker id="adventurerCount" label="Adventurers" value={this.props.settings.numPlayers} onDelta={(i: number) => this.props.onPlayerDelta(this.props.settings.numPlayers, i)}>
           {!playersAllowed && `Quest requires ${quest.minplayers} - ${quest.maxplayers} players.`}
         </Picker>
-        <Checkbox label="Multitouch" value={this.props.settings.multitouch} onChange={this.props.onMultitouchChange}>
+        <Checkbox id="multitouch" label="Multitouch" value={this.props.settings.multitouch} onChange={this.props.onMultitouchChange}>
           {(this.props.settings.multitouch) ? 'All players must hold their finger on the screen to end combat.' : 'A single tap will end combat.'}
         </Checkbox>
       </div>;
-    const futureError = quest.expansionfuture && !this.props.settings.contentSets.future;
-    const horrorError = quest.expansionhorror && !this.props.settings.contentSets.horror;
-    if (futureError) {
+
+    let expansionErr = '';
+    if (quest.expansionhorror && !this.props.settings.contentSets.horror) {
+      expansionErr = 'Horror';
+    } else if (quest.expansionfuture && !this.props.settings.contentSets.future) {
+      expansionErr = 'Future';
+    }
+    if (expansionErr) {
       contents = <div className="error">
-          The Future expansion is required to play this quest.
-          If you have it, make sure to enable it in settings.
-          Otherwise, you can pick up a copy on
-          <a href="#" onClick={() => openWindow('https://expeditiongame.com/store?utm_source=app')}>the Expedition Store</a>.
-        </div>;
-    } else if (horrorError) {
-      contents = <div className="error">
-          The Horror expansion is required to play this quest.
+          The {expansionErr} expansion is required to play this quest.
           If you have it, make sure to enable it in settings.
           Otherwise, you can pick up a copy on
           <a href="#" onClick={() => openWindow('https://expeditiongame.com/store?utm_source=app')}>the Expedition Store</a>.
@@ -271,41 +305,13 @@ export class SetPlayerCountDialog extends React.Component<SetPlayerCountDialogPr
     }
     return (
       <Dialog classes={{paperWidthSm: 'dialog'}} open={Boolean(this.props.open)}>
-        <DialogTitle>{horrorError || futureError ? 'Expansion Required' : 'How many players?'}</DialogTitle>
+        <DialogTitle>{expansionErr ? 'Expansion Required' : 'How many players?'}</DialogTitle>
         <DialogContent className="dialog">
           {contents}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => this.props.onClose()}>Cancel</Button>
-          {!horrorError && <Button disabled={!playersAllowed} className="primary" onClick={() => this.props.playQuest(this.props.quest)}>Play</Button>}
-        </DialogActions>
-      </Dialog>
-    );
-  }
-}
-
-interface DeleteSavedQuestDialogProps extends React.Props<any> {
-  onClose: () => void;
-  onDeleteSavedQuest: (savedQuest: SavedQuestMeta) => void;
-  open: boolean;
-  savedQuest: SavedQuestMeta|null;
-}
-
-export class DeleteSavedQuestDialog extends React.Component<DeleteSavedQuestDialogProps, {}> {
-  public render() {
-    const savedQuest = this.props.savedQuest;
-    return (
-      <Dialog classes={{paperWidthSm: 'dialog'}} open={Boolean(this.props.open)}>
-        <DialogTitle>Delete saved quest?</DialogTitle>
-        <DialogContent className="dialog"></DialogContent>
-        <DialogActions>
-          <Button onClick={() => this.props.onClose()}>Cancel</Button>
-          <Button className="primary" onClick={() => {
-            if (savedQuest === null) {
-              throw new Error('missing saved quest information');
-            }
-            this.props.onDeleteSavedQuest(savedQuest);
-          }}>Delete</Button>
+          {!expansionErr && <Button id="play" disabled={!playersAllowed} className="primary" onClick={() => this.props.playQuest(this.props.quest)}>Play</Button>}
         </DialogActions>
       </Dialog>
     );

--- a/services/app/src/components/base/Dialogs.tsx
+++ b/services/app/src/components/base/Dialogs.tsx
@@ -245,7 +245,7 @@ export class ReportQuestDialog extends TextAreaDialog<FeedbackDialogProps> {
     this.title = 'Report Quest';
     this.content = (
       <span>
-        <p>You're reporting an issue with <i>{this.props.quest.details.title}</i>.</p>
+        <p>You're reporting an issue with <i>{props.quest.details.title}</i>.</p>
         <p>You should report a quest (instead of reviewing it at the end of the quest) if it is:</p>
         <ul>
           <li>Offensive or inappropriate for the age level it claimed to be.</li>

--- a/services/app/src/components/base/DialogsContainer.test.tsx
+++ b/services/app/src/components/base/DialogsContainer.test.tsx
@@ -2,4 +2,7 @@ describe('DialogsContainer', () => {
   test.skip('maps state', () => { /* TODO */ });
 
   test.skip('dispatches dialog change with onClose', () => { /* TODO */ });
+
+  test.skip('onFeedbackSubmit validates input', () => { /* TODO */ });
+  test.skip('onPlayerDelta does nothing when going below min/above max players', () => { /* TODO */ });
 });


### PR DESCRIPTION
Now at 59% stub test coverage.

This moves a lot of the boilerplate from the "confirmation" dialogs to its own class, and tests the base classes + highly customized dialogs.