### PR TITLE
highlight new quests

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -28,17 +28,18 @@ getTarget() {
 
 deploy() {
   echo "Deploying $service to $target"
+  cd $service
   if [ "$target" = "beta" ]; then
-    (cd $service && ./deploy.sh beta)
+    ./deploy.sh beta
   elif [ "$target" = "local-beta" ]; then
-    (cd $service && ./deploy.sh betabuild)
+    ./deploy.sh betabuild
   elif [ "$target" = "local-prod" ]; then
-    (cd $service && ./deploy.sh prodbuild)
+    ./deploy.sh prodbuild
   elif [ "$target" = "prod" ]; then
     read -p "Did you test on beta? (y/N) " -n 1
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
-      (cd $s && ./deploy.sh prod)
+      ./deploy.sh prod
     else
       echo "Prod build cancelled until tested on beta."
     fi

--- a/services/api/src/models/Quests.test.ts
+++ b/services/api/src/models/Quests.test.ts
@@ -7,6 +7,8 @@ import {
   testingDBWithState,
 } from './TestData';
 
+const Moment = require('moment');
+
 describe('quest', () => {
   describe('searchQuests', () => {
     const quests = [q.basic, q.horror, q.future];
@@ -63,15 +65,16 @@ describe('quest', () => {
         .catch(done.fail);
     });
 
-    fit('orders by rating, then rating count when +ratingavg order is given', (done: DoneFn) => {
-      const q1 = new Quest({...q.basic, id: 'q1', ratingavg: 4.0, ratingcount: 6});
-      const q2 = new Quest({...q.basic, id: 'q2', ratingavg: 5.0, ratingcount: 1});
-      const q3 = new Quest({...q.basic, id: 'q3', ratingavg: 5.0, ratingcount: 3});
+    test('+ratingavg (default) orders by newly published, rating, then rating count when ', (done: DoneFn) => {
+      const q1 = new Quest({...q.basic, id: 'q1', ratingavg: 4.0, ratingcount: 6, created: Moment().subtract(1, 'month')});
+      const q2 = new Quest({...q.basic, id: 'q2', ratingavg: 5.0, ratingcount: 1, created: Moment().subtract(1, 'month')});
+      const q3 = new Quest({...q.basic, id: 'q3', ratingavg: 5.0, ratingcount: 3, created: Moment().subtract(1, 'month')});
+      const q4 = new Quest({...q.basic, id: 'q4', ratingavg: 4.5, ratingcount: 1, created: Moment()});
 
-      testingDBWithState([q1, q2, q3])
+      testingDBWithState([q1, q2, q3, q4])
         .then((db) => searchQuests(db, '', {order: '+ratingavg'}))
         .then((results: QuestInstance[]) => {
-          expect(results.map((r) => r.get('id'))).toEqual(['q3', 'q2', 'q1']);
+          expect(results.map((r) => r.get('id'))).toEqual(['q4', 'q3', 'q2', 'q1']);
           done();
         })
         .catch(done.fail);

--- a/services/api/src/models/Quests.ts
+++ b/services/api/src/models/Quests.ts
@@ -95,8 +95,8 @@ export function searchQuests(db: Database, userId: string, params: QuestSearchPa
   const order = [];
   if (params.order) {
     if (params.order === '+ratingavg') {
-      // Default search - also show very new quests on top
-      order.push(Sequelize.literal(`NOW() - created <= interval '24 hours' DESC`));
+      // Default sort - also show very new quests on top
+      order.push(Sequelize.literal(`created > current_date - 1 DESC`));
       order.push(['ratingavg', 'DESC']);
       order.push(['ratingcount', 'DESC']);
     } else {

--- a/services/api/src/models/Quests.ts
+++ b/services/api/src/models/Quests.ts
@@ -10,6 +10,8 @@ import {getFeedbackByQuestId} from './Feedback';
 import {prepare} from './Schema';
 import {getUser} from './Users';
 
+const Moment = require('moment');
+
 export const MAX_SEARCH_LIMIT = 100;
 
 export interface QuestSearchParams {
@@ -96,7 +98,7 @@ export function searchQuests(db: Database, userId: string, params: QuestSearchPa
   if (params.order) {
     if (params.order === '+ratingavg') {
       // Default sort - also show very new quests on top
-      order.push(Sequelize.literal(`created > current_date - 1 DESC`));
+      order.push(Sequelize.literal(`created >= '${Moment().subtract(1, 'day').format('YYYY-MM-DD HH:mm:ss')}' DESC`));
       order.push(['ratingavg', 'DESC']);
       order.push(['ratingcount', 'DESC']);
     } else {
@@ -109,14 +111,15 @@ export function searchQuests(db: Database, userId: string, params: QuestSearchPa
   if (!params.id) {
     if (!params.expansions || (params.expansions.indexOf('horror') === -1 && params.expansions.indexOf('future') === -1)) {
       // No expansions
-      where.expansionhorror =  {$not: true};
-      where.expansionfuture =  {$not: true};
+      where.expansionhorror = {$not: true};
+      where.expansionfuture = {$not: true};
     } else if (params.expansions.indexOf('future') === -1) {
-      // The Future
-      order.push(['expansionfuture', 'DESC']);
-    } else {
-      // The Horror
+      // Only the Horror
+      where.expansionfuture = {$not: true};
       order.push(['expansionhorror', 'DESC']);
+    } else {
+      // All
+      order.push(['expansionfuture', 'DESC']);
     }
   }
 

--- a/services/api/src/models/Quests.ts
+++ b/services/api/src/models/Quests.ts
@@ -95,6 +95,8 @@ export function searchQuests(db: Database, userId: string, params: QuestSearchPa
   const order = [];
   if (params.order) {
     if (params.order === '+ratingavg') {
+      // Default search - also show very new quests on top
+      order.push(Sequelize.literal(`NOW() - created <= interval '24 hours' DESC`));
       order.push(['ratingavg', 'DESC']);
       order.push(['ratingcount', 'DESC']);
     } else {
@@ -129,7 +131,7 @@ function mailNewQuestToAdmin(mail: MailService, quest: Quest) {
   const to = ['team+newquest@fabricate.io'];
   const subject = `Please review! New quest published: ${quest.title} (${quest.partition}, ${quest.language})`;
   const message = `Summary: ${quest.summary}.\n
-    By ${quest.author},
+    By ${quest.author} (${quest.email}),
     for ${quest.minplayers} - ${quest.maxplayers} players
     over ${quest.mintimeminutes} - ${quest.maxtimeminutes} minutes.
     ${quest.genre}.

--- a/services/app/src/Style.scss
+++ b/services/app/src/Style.scss
@@ -1239,11 +1239,18 @@ body.android .dialog .textfield:focus-within {
         width: auto;
         .inline_icon {
           padding-right: 0;
-          padding-left: size(base);
-        }
-        svg {
+          padding-left: size(small);
+          margin-top: size(tiny);
+          margin-bottom: -2 * size(tiny);
           height: fontsize(flavor) !important;
           width: fontsize(flavor) !important;
+        }
+        .badge {
+          background: $font_color_primary;
+          color: $bg_primary;
+          padding: 4px 6px 1px 6px;
+          border-radius: 4px;
+          display: inline-block;
         }
       }
     }

--- a/services/app/src/actions/User.tsx
+++ b/services/app/src/actions/User.tsx
@@ -54,23 +54,29 @@ function registerUserAndIdToken(user: {name: string, image: string, email: strin
   })
   .then(handleFetchErrors)
   .then((response: Response) => response.text())
-  .then((userResult: string) => {
-    let id = '';
+  .then((response: string) => {
+    let userResult = {} as any;
     try {
-      id = JSON.parse(userResult).id || userResult;
+      userResult = {
+        id: response,
+        ...JSON.parse(response),
+      };
     } catch (err) {
-      id = userResult;
+      userResult.id = response;
     }
+
     if (getGA()) {
-      getGA().set({ userId: id });
+      getGA().set({ userId: userResult.id });
     }
-    Raven.setUserContext({id});
+    Raven.setUserContext({id: userResult.id});
     return {
       email: user.email,
-      id,
+      id: userResult.id,
       image: user.image,
       loggedIn: true,
       name: user.name,
+      lastLogin: new Date(userResult.lastLogin),
+      loginCount: userResult.loginCount,
     };
   }).catch((error: Error) => {
     console.log('Request failed', error);

--- a/services/app/src/components/views/Search.test.tsx
+++ b/services/app/src/components/views/Search.test.tsx
@@ -96,12 +96,17 @@ describe('Search', () => {
     });
 
     test('displays NEW if quest created since last login', () => {
-      const {wrapper} = setup('Learning to Adventure', {lastLogin: new Date('2010-01-01')});
+      const {wrapper} = setup('Learning to Adventure', {lastLogin: new Date('2010')}, {created: new Date('2020')});
+      expect(wrapper.html()).toContain('NEW');
+    });
+
+    test('displays NEW if quest created in past 24 hours', () => {
+      const {wrapper} = setup('Learning to Adventure', {lastLogin: new Date('2010-01-01 22:00:00')}, {created: new Date('2010-01-01 2:00:00')});
       expect(wrapper.html()).toContain('NEW');
     });
 
     test('does not display NEW if quest created before last login', () => {
-      const {wrapper} = setup('Learning to Adventure', {lastLogin: new Date('2020-01-01')});
+      const {wrapper} = setup('Learning to Adventure', {lastLogin: new Date('2020')}, {created: new Date('2010')});
       expect(wrapper.html()).not.toContain('NEW');
     });
 

--- a/services/app/src/components/views/Search.test.tsx
+++ b/services/app/src/components/views/Search.test.tsx
@@ -95,6 +95,16 @@ describe('Search', () => {
       expect(wrapper.html()).not.toContain('book');
     });
 
+    test('displays NEW if quest created since last login', () => {
+      const {wrapper} = setup('Learning to Adventure', {lastLogin: new Date('2010-01-01')});
+      expect(wrapper.html()).toContain('NEW');
+    });
+
+    test('does not display NEW if quest created before last login', () => {
+      const {wrapper} = setup('Learning to Adventure', {lastLogin: new Date('2020-01-01')});
+      expect(wrapper.html()).not.toContain('NEW');
+    });
+
     test('does not display last played date if quest has not been played', () => {
       const {wrapper} = setup('Learning to Adventure');
       expect(wrapper.html()).not.toContain('questPlayedIcon');

--- a/services/app/src/components/views/Search.test.tsx
+++ b/services/app/src/components/views/Search.test.tsx
@@ -10,6 +10,8 @@ import {
 } from './Search';
 configure({ adapter: new Adapter() });
 
+const Moment = require('moment');
+
 const TEST_SEARCH: SearchSettings = {
   age: 31536000,
   contentrating: 'Teen',
@@ -95,18 +97,23 @@ describe('Search', () => {
       expect(wrapper.html()).not.toContain('book');
     });
 
-    test('displays NEW if quest created since last login', () => {
-      const {wrapper} = setup('Learning to Adventure', {lastLogin: new Date('2010')}, {created: new Date('2020')});
+    test('displays NEW if quest created in past 24 hours', () => {
+      const {wrapper} = setup('Learning to Adventure', {lastLogin: Moment()}, {created: Moment().subtract(23, 'hours')});
       expect(wrapper.html()).toContain('NEW');
     });
 
-    test('displays NEW if quest created in past 24 hours', () => {
-      const {wrapper} = setup('Learning to Adventure', {lastLogin: new Date('2010-01-01 22:00:00')}, {created: new Date('2010-01-01 2:00:00')});
+    test('displays NEW if quest created since last login', () => {
+      const {wrapper} = setup('Learning to Adventure', {lastLogin: Moment().subtract(30, 'days')}, {created: Moment().subtract(20, 'days')});
       expect(wrapper.html()).toContain('NEW');
     });
 
     test('does not display NEW if quest created before last login', () => {
-      const {wrapper} = setup('Learning to Adventure', {lastLogin: new Date('2020')}, {created: new Date('2010')});
+      const {wrapper} = setup('Learning to Adventure', {lastLogin: Moment()}, {created: Moment().subtract(30, 'days')});
+      expect(wrapper.html()).not.toContain('NEW');
+    });
+
+    test('does not display NEW if quest has been played', () => {
+      const {wrapper} = setup('Learning to Adventure', {lastLogin: Moment().subtract(30, 'days'), lastPlayed: Moment()}, {created: Moment()});
       expect(wrapper.html()).not.toContain('NEW');
     });
 
@@ -116,7 +123,7 @@ describe('Search', () => {
     });
 
     test('displayed last played date if quest has been played before', () => {
-      const {wrapper} = setup('Learning to Adventure', {lastPlayed: new Date()});
+      const {wrapper} = setup('Learning to Adventure', {lastPlayed: Moment()});
       expect(wrapper.html()).toContain('questPlayedIcon');
     });
 

--- a/services/app/src/components/views/Search.tsx
+++ b/services/app/src/components/views/Search.tsx
@@ -218,6 +218,7 @@ function renderSettings(props: Props): JSX.Element {
 
 export interface SearchResultProps {
   index: number;
+  lastLogin: Date;
   lastPlayed: Date | null;
   onQuest: (quest: Quest) => void;
   quest: Quest;
@@ -256,6 +257,7 @@ export function renderResult(props: SearchResultProps): JSX.Element {
                 </Truncate>
               </th>
               <th className="rightcell">
+                {props.lastLogin < quest.created && !props.lastPlayed && <div className="badge">NEW</div>}
                 {props.lastPlayed && <DoneIcon className="inline_icon questPlayedIcon" />}
                 {quest.official && <span className="indicator_spacer"><img className="inline_icon questOfficialIcon" src="images/compass_small.svg"/></span>}
                 {quest.awarded && <StarsIcon className="inline_icon questAwardedIcon" />}
@@ -309,7 +311,15 @@ export function renderResults(props: Props, hideHeader?: boolean): JSX.Element {
     );
   } else {
     content = (props.results || []).map((quest: Quest, index: number) => {
-      return renderResult({index, quest, search: props.search, onQuest: props.onQuest, lastPlayed: (props.questHistory.list[quest.id] || {}).lastPlayed, offlineQuests: props.offlineQuests});
+      return renderResult({
+        index,
+        quest,
+        search: props.search,
+        onQuest: props.onQuest,
+        lastLogin: props.user.lastLogin,
+        lastPlayed: (props.questHistory.list[quest.id] || {}).lastPlayed,
+        offlineQuests: props.offlineQuests,
+      });
     });
   }
 

--- a/services/app/src/components/views/Search.tsx
+++ b/services/app/src/components/views/Search.tsx
@@ -257,7 +257,8 @@ export function renderResult(props: SearchResultProps): JSX.Element {
                 </Truncate>
               </th>
               <th className="rightcell">
-                {props.lastLogin < quest.created && !props.lastPlayed && <div className="badge">NEW</div>}
+                {(props.lastLogin < quest.created || Moment().diff(quest.created, 'days') <= 1) && !props.lastPlayed &&
+                  <div className="badge">NEW</div>}
                 {props.lastPlayed && <DoneIcon className="inline_icon questPlayedIcon" />}
                 {quest.official && <span className="indicator_spacer"><img className="inline_icon questOfficialIcon" src="images/compass_small.svg"/></span>}
                 {quest.awarded && <StarsIcon className="inline_icon questAwardedIcon" />}

--- a/services/app/src/reducers/StateTypes.tsx
+++ b/services/app/src/reducers/StateTypes.tsx
@@ -171,6 +171,8 @@ export interface UserState {
   name: string;
   image: string;
   email: string;
+  lastLogin: Date;
+  loginCount: number;
 }
 
 export interface UserQuestHistory {

--- a/services/app/src/reducers/User.tsx
+++ b/services/app/src/reducers/User.tsx
@@ -8,6 +8,8 @@ export const loggedOutUser: UserState = {
   image: '',
   loggedIn: false,
   name: '',
+  lastLogin: new Date(),
+  loginCount: 0,
 };
 
 export function user(state: UserState = loggedOutUser, action: Redux.Action): UserState {


### PR DESCRIPTION
Closes https://github.com/ExpeditionRPG/expedition/issues/342

Note that it uses created instead of published (since published is actually "last updated") - this will be more conservative and may occasionally result in a false negative, ie if an author accidentally publishes then unpublishes a quest early in writing, and then re-publishes it months later, anyone who's logged in in the last few months won't see it as "new". The alternative would be to show "NEW" any time it's been updated more recently than the most recent login, but that seems like it would be uselessly noisy. 

<img width="269" alt="screen shot 2018-09-23 at 14 20 04" src="https://user-images.githubusercontent.com/775657/45931423-0e14fe80-bf3c-11e8-9bbb-8df767314fcc.png">
<img width="1150" alt="screen shot 2018-09-23 at 14 19 54" src="https://user-images.githubusercontent.com/775657/45931424-0e14fe80-bf3c-11e8-99af-22702738574f.png">
