### PR TITLE
Fix onReturn after decision timer, timer selection code

### DIFF
--- a/services/app/src/components/views/quest/cardtemplates/Template.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.tsx
@@ -70,6 +70,7 @@ export function renderCardTemplate(card: CardState, node: ParserNode): JSX.Eleme
     case 'MID_COMBAT_ROLEPLAY':
       return <MidCombatRoleplayContainer node={node}/>;
     case 'MID_COMBAT_DECISION':
+    case 'MID_COMBAT_DECISION_TIMER':
       const combat = node.ctx.templates.combat;
       return renderCardTemplate({...card, phase: ((combat) ? combat.decisionPhase : 'PREPARE_DECISION')}, node);
     default:
@@ -90,6 +91,7 @@ export function getCardTemplateTheme(card: CardState): CardThemeType {
     case 'NO_TIMER':
     case 'MID_COMBAT_ROLEPLAY':
     case 'MID_COMBAT_DECISION':
+    case 'MID_COMBAT_DECISION_TIMER':
       return 'dark';
     case 'ROLEPLAY':
     case 'PREPARE_DECISION':

--- a/services/app/src/components/views/quest/cardtemplates/combat/Types.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Types.tsx
@@ -45,7 +45,8 @@ export type CombatPhase = 'DRAW_ENEMIES'
   | 'DEFEAT'
   | 'NO_TIMER'
   | 'MID_COMBAT_ROLEPLAY'
-  | 'MID_COMBAT_DECISION';
+  | 'MID_COMBAT_DECISION'
+  | 'MID_COMBAT_DECISION_TIMER'; // Timer must be separate to allow skip of timer during onReturn.
 
 export interface StateProps {
   node: ParserNode;

--- a/services/app/src/components/views/quest/cardtemplates/decision/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Actions.tsx
@@ -253,7 +253,8 @@ interface ToDecisionCardArgs extends Partial<ToCardArgs> {
 }
 export const toDecisionCard = remoteify(function toDecisionCard(a: ToDecisionCardArgs, dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory): ToDecisionCardArgs {
   const phase = a.phase || 'PREPARE_DECISION';
-  if (getState().card.phase !== 'MID_COMBAT_DECISION' && a.name !== undefined) {
+  const statePhase = getState().card.phase;
+  if (statePhase !== 'MID_COMBAT_DECISION' && statePhase !== 'MID_COMBAT_DECISION_TIMER' && a.name !== undefined) {
     const a2: ToCardArgs = {
       keySuffix: a.keySuffix,
       name: a.name || 'MID_COMBAT_DECISION',
@@ -268,7 +269,12 @@ export const toDecisionCard = remoteify(function toDecisionCard(a: ToDecisionCar
   combat.decisionPhase = phase;
   dispatch({type: 'PUSH_HISTORY'});
   dispatch({type: 'QUEST_NODE', node} as QuestNodeAction);
-  dispatch(toCard({name: 'QUEST_CARD', phase: 'MID_COMBAT_DECISION', keySuffix: a.phase + (decision.rolls || '').toString(), noHistory: true}));
+  dispatch(toCard({
+    name: 'QUEST_CARD',
+    phase: (a.phase === 'DECISION_TIMER') ? 'MID_COMBAT_DECISION_TIMER' : 'MID_COMBAT_DECISION',
+    keySuffix: a.phase + (decision.rolls || '').toString(),
+    noHistory: true,
+  }));
   return {
   phase: a.phase,
 };

--- a/services/app/src/components/views/quest/cardtemplates/decision/DecisionTimer.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/DecisionTimer.test.tsx
@@ -53,12 +53,12 @@ describe('DecisionTimer', () => {
   test('Either shows persona or difficulty, not both', () => {
     const {e} = setup({});
     const result = e.find('.secondary').childAt(0).text();
-    expect(result).toMatch(/^2 \w+ charisma$/);
+    expect(result).toMatch(/^\d \w+ (charisma|athletics|knowledge)$/);
   });
   test('triggers onSelect when a decision is selected', () => {
     const {props, e} = setup({});
     e.find('button').at(0).simulate('click');
-    expect(props.onSelect).toHaveBeenCalledWith(props.node, TEST_LEVELED_CHECKS[1], jasmine.any(Number));
+    expect(props.onSelect).toHaveBeenCalledWith(props.node, TEST_LEVELED_CHECKS[0], jasmine.any(Number));
   });
   test('picks unique leveled checks', () => {
     const node = TEST_NODE.clone();

--- a/services/app/src/components/views/quest/cardtemplates/decision/DecisionTimer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/DecisionTimer.tsx
@@ -81,8 +81,12 @@ export default class DecisionTimer extends React.Component<Props, {}> {
       }
       mapped[k].push(c);
     }
-    return getRandomSubarray(Object.keys(mapped), 3, this.props.rng)
-      .map((k) => {
+
+    const keys = Object.keys(mapped);
+    if (keys.length > 3) {
+      getRandomSubarray(Object.keys(mapped), 3, this.props.rng);
+    }
+    return keys.map((k) => {
         return mapped[k][Math.floor(this.props.rng() * mapped[k].length)];
       });
   }

--- a/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecision.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecision.test.tsx
@@ -22,6 +22,7 @@ function setup(overrides: Partial<Props>) {
     rng: () => 0,
     onCombatDecisionEnd: jasmine.createSpy('onEnd'),
     onRoll: jasmine.createSpy('onRoll'),
+    onReturn: jasmine.createSpy('onReturn'),
     ...overrides,
   };
   const e = mount(<ResolveDecision {...props} />);

--- a/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecision.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecision.tsx
@@ -14,6 +14,7 @@ const pluralize = require('pluralize');
 export interface DispatchProps {
   onRoll: (node: ParserNode, roll: number) => void;
   onCombatDecisionEnd: () => void;
+  onReturn: () => void;
 }
 
 export interface Props extends StateProps, DispatchProps {}
@@ -75,7 +76,11 @@ export default function resolveDecision(props: Props): JSX.Element {
   const numLeft = selected.requiredSuccesses - successes;
   const roll = <img className="inline_icon" src={'images/' + formatImg('roll', props.theme) + '.svg'}></img>;
   return (
-    <Card title={[capitalizeFirstLetter(selected.persona), capitalizeFirstLetter(selected.skill), 'Check'].filter((s) => s).join(' ')} inQuest={true} theme={props.theme}>
+    <Card
+      title={[capitalizeFirstLetter(selected.persona), capitalizeFirstLetter(selected.skill), 'Check'].filter((s) => s).join(' ')}
+      inQuest={true}
+      theme={props.theme}
+      onReturn={() => props.onReturn()}>
       {helpText}
       {inst}
       <h2 className="center">

--- a/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecisionContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecisionContainer.tsx
@@ -1,4 +1,5 @@
 import {toCard} from 'app/actions/Card';
+import {toPrevious} from 'app/actions/Card';
 import {connect} from 'react-redux';
 import Redux from 'redux';
 import {ParserNode} from '../TemplateTypes';
@@ -8,6 +9,13 @@ import {mapStateToProps} from './Types';
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
+    onReturn: () => {
+      // Return to the Prepare Decision card instead of going back to the timer.
+      dispatch(toPrevious({before: false, skip: [
+        {name: 'QUEST_CARD', phase: 'DECISION_TIMER'},
+        {name: 'QUEST_CARD', phase: 'MID_COMBAT_DECISION_TIMER'},
+      ]}));
+    },
     onRoll: (node: ParserNode, roll: number) => {
       dispatch(handleDecisionRoll({node, roll}));
     },


### PR DESCRIPTION
- Fixed where decision resolve card would go back into the timer when the back button was pressed.
- Tweaked decision timer logic for selecting decisions (hopefully we see fewer single-choice timer cards)
- Made decision timer tests slightly more RNG-resilient.