### PR TITLE
Added checkbox for filtering private quests

### DIFF
--- a/services/api/src/models/Quests.ts
+++ b/services/api/src/models/Quests.ts
@@ -1,47 +1,71 @@
 import * as Bluebird from 'bluebird';
 import Sequelize from 'sequelize';
-import {PUBLIC_PARTITION} from 'shared/schema/Constants';
-import {Quest} from 'shared/schema/Quests';
-import {RenderedQuest} from 'shared/schema/RenderedQuests';
-import {User} from 'shared/schema/Users';
-import {MailService} from '../Mail';
-import {Database, FeedbackInstance, QuestInstance} from './Database';
-import {getFeedbackByQuestId} from './Feedback';
-import {prepare} from './Schema';
-import {getUser} from './Users';
+import { PRIVATE_PARTITION, PUBLIC_PARTITION } from 'shared/schema/Constants';
+import { Quest } from 'shared/schema/Quests';
+import { RenderedQuest } from 'shared/schema/RenderedQuests';
+import { User } from 'shared/schema/Users';
+import { MailService } from '../Mail';
+import { Database, FeedbackInstance, QuestInstance } from './Database';
+import { getFeedbackByQuestId } from './Feedback';
+import { prepare } from './Schema';
+import { getUser } from './Users';
+
+const { Op } = Sequelize;
 
 const Moment = require('moment');
 
 export const MAX_SEARCH_LIMIT = 100;
 
 export interface QuestSearchParams {
-  age?: number|null;
-  contentrating?: string|null;
-  expansions?: string[]|null;
-  genre?: string|null;
-  id?: string|null;
-  language?: string|null;
-  limit?: number|null;
-  maxtimeminutes?: number|null;
-  mintimeminutes?: number|null;
-  order?: string|null;
-  owner?: string|null;
-  partition?: string|null;
-  players?: number|null;
-  requirespenpaper?: boolean|null;
-  text?: string|null;
+  age?: number | null;
+  contentrating?: string | null;
+  expansions?: string[] | null;
+  genre?: string | null;
+  id?: string | null;
+  language?: string | null;
+  limit?: number | null;
+  maxtimeminutes?: number | null;
+  mintimeminutes?: number | null;
+  order?: string | null;
+  owner?: string | null;
+  partition?: string | null;
+  players?: number | null;
+  requirespenpaper?: boolean | null;
+  text?: string | null;
+  showPrivate?: boolean | null;
 }
 
-export function getQuest(db: Database, partition: string, id: string): Bluebird<Quest> {
-  return db.quests.findOne({where: {partition, id}})
-    .then((result: QuestInstance|null) =>  new Quest((result) ? result.dataValues : {}));
+export function getQuest(
+  db: Database,
+  partition: string,
+  id: string,
+): Bluebird<Quest> {
+  return db.quests
+    .findOne({ where: { partition, id } })
+    .then(
+      (result: QuestInstance | null) =>
+        new Quest(result ? result.dataValues : {}),
+    );
 }
 
-export function searchQuests(db: Database, userId: string, params: QuestSearchParams): Bluebird<QuestInstance[]> {
+export function searchQuests(
+  db: Database,
+  userId: string,
+  params: QuestSearchParams,
+): Bluebird<QuestInstance[]> {
   // TODO: Validate search params
-  const where: Sequelize.WhereOptions<Partial<Quest>> = {published: {$ne: null} as any, tombstone: null};
+  const where: Sequelize.WhereOptions<Partial<Quest>> = {
+    published: { $ne: null } as any,
+    tombstone: null,
+  };
 
-  where.partition = params.partition || PUBLIC_PARTITION;
+  if (params.showPrivate === true) {
+    where.partition = {
+      [Op.or]: [PUBLIC_PARTITION, PRIVATE_PARTITION],
+    };
+  } else {
+    where.partition = params.partition || PUBLIC_PARTITION;
+  }
 
   if (params.id) {
     where.id = params.id;
@@ -53,29 +77,37 @@ export function searchQuests(db: Database, userId: string, params: QuestSearchPa
   }
 
   if (params.players) {
-    where.minplayers = {$lte: params.players};
-    where.maxplayers = {$gte: params.players};
+    where.minplayers = { $lte: params.players };
+    where.maxplayers = { $gte: params.players };
   }
 
   // DEPRECATED from app 6/10/17 (also in schemas.js)
   if (params.text && params.text !== '') {
     const text = '%' + params.text.toLowerCase() + '%';
     (where as Sequelize.AnyWhereOptions).$or = [
-      Sequelize.where(Sequelize.fn('LOWER', Sequelize.col('title')), {$like: text}),
-      Sequelize.where(Sequelize.fn('LOWER', Sequelize.col('author')), {$like: text}),
+      Sequelize.where(Sequelize.fn('LOWER', Sequelize.col('title')), {
+        $like: text,
+      }),
+      Sequelize.where(Sequelize.fn('LOWER', Sequelize.col('author')), {
+        $like: text,
+      }),
     ];
   }
 
   if (params.age) {
-    where.published = {$gt: Moment().subtract(params.age, 'seconds').format('YYYY-MM-DD HH:mm:ss')};
+    where.published = {
+      $gt: Moment()
+        .subtract(params.age, 'seconds')
+        .format('YYYY-MM-DD HH:mm:ss'),
+    };
   }
 
   if (params.mintimeminutes) {
-    where.mintimeminutes = {$gte: params.mintimeminutes};
+    where.mintimeminutes = { $gte: params.mintimeminutes };
   }
 
   if (params.maxtimeminutes) {
-    where.maxtimeminutes = {$lte: params.maxtimeminutes};
+    where.maxtimeminutes = { $lte: params.maxtimeminutes };
   }
 
   if (params.contentrating) {
@@ -98,24 +130,37 @@ export function searchQuests(db: Database, userId: string, params: QuestSearchPa
   if (params.order) {
     if (params.order === '+ratingavg') {
       // Default sort - also show very new quests on top
-      order.push(Sequelize.literal(`created >= '${Moment().subtract(7, 'day').format('YYYY-MM-DD HH:mm:ss')}' DESC`));
+      order.push(
+        Sequelize.literal(
+          `created >= '${Moment()
+            .subtract(7, 'day')
+            .format('YYYY-MM-DD HH:mm:ss')}' DESC`,
+        ),
+      );
       order.push(['ratingavg', 'DESC']);
       order.push(['ratingcount', 'DESC']);
     } else {
-      order.push([params.order.substr(1), (params.order[0] === '+') ? 'ASC' : 'DESC']);
+      order.push([
+        params.order.substr(1),
+        params.order[0] === '+' ? 'ASC' : 'DESC',
+      ]);
     }
   }
 
   // Hide expansion if searching & not specified, otherwise prioritize results
   // that have the expansion as a secondary sort
   if (!params.id) {
-    if (!params.expansions || (params.expansions.indexOf('horror') === -1 && params.expansions.indexOf('future') === -1)) {
+    if (
+      !params.expansions ||
+      (params.expansions.indexOf('horror') === -1 &&
+        params.expansions.indexOf('future') === -1)
+    ) {
       // No expansions
-      where.expansionhorror = {$not: true};
-      where.expansionfuture = {$not: true};
+      where.expansionhorror = { $not: true };
+      where.expansionfuture = { $not: true };
     } else if (params.expansions.indexOf('future') === -1) {
       // Only the Horror
-      where.expansionfuture = {$not: true};
+      where.expansionfuture = { $not: true };
       order.push(['expansionhorror', 'DESC']);
     } else {
       // All
@@ -123,22 +168,31 @@ export function searchQuests(db: Database, userId: string, params: QuestSearchPa
     }
   }
 
-  const limit = Math.min(Math.max(params.limit || MAX_SEARCH_LIMIT, 0), MAX_SEARCH_LIMIT);
+  const limit = Math.min(
+    Math.max(params.limit || MAX_SEARCH_LIMIT, 0),
+    MAX_SEARCH_LIMIT,
+  );
 
-  return db.quests.findAll({where, order, limit});
+  return db.quests.findAll({ where, order, limit });
 }
 
 function mailNewQuestToAdmin(mail: MailService, quest: Quest) {
   // If this is a newly published quest, email us!
   // We don't care if this fails.
   const to = ['team+newquest@fabricate.io'];
-  const subject = `Please review! New quest published: ${quest.title} (${quest.partition}, ${quest.language})`;
+  const subject = `Please review! New quest published: ${quest.title} (${
+    quest.partition
+  }, ${quest.language})`;
   const message = `Summary: ${quest.summary}.\n
     By ${quest.author} (${quest.email}),
     for ${quest.minplayers} - ${quest.maxplayers} players
     over ${quest.mintimeminutes} - ${quest.maxtimeminutes} minutes.
     ${quest.genre}.
-    ${quest.requirespenpaper ? 'Requires pen and paper.' : 'No pen or paper required.'}
+    ${
+      quest.requirespenpaper
+        ? 'Requires pen and paper.'
+        : 'No pen or paper required.'
+    }
     Horror: ${quest.expansionhorror ? 'Required' : 'no'}.
     Future: ${quest.expansionfuture ? 'Required' : 'no'}.`;
   return mail.send(to, subject, message);
@@ -159,7 +213,14 @@ function mailFirstQuestPublish(mail: MailService, quest: Quest) {
   mail.send(to, subject, message);
 }
 
-export function publishQuest(db: Database, mail: MailService, userid: string, majorRelease: boolean, quest: Quest, xml: string): Bluebird<QuestInstance> {
+export function publishQuest(
+  db: Database,
+  mail: MailService,
+  userid: string,
+  majorRelease: boolean,
+  quest: Quest,
+  xml: string,
+): Bluebird<QuestInstance> {
   // TODO: Validate XML via crawler
   if (!userid) {
     return Bluebird.reject(new Error('Could not publish - no user id.'));
@@ -170,34 +231,36 @@ export function publishQuest(db: Database, mail: MailService, userid: string, ma
 
   let instance: QuestInstance;
   let isNew: boolean = false;
-  return db.quests.findOne({where: {id: quest.id, partition: quest.partition}})
-    .then((i: QuestInstance|null) => {
+  return db.quests
+    .findOne({ where: { id: quest.id, partition: quest.partition } })
+    .then((i: QuestInstance | null) => {
       isNew = !Boolean(i);
       instance = i || db.quests.build(prepare(quest));
       if (isNew && quest.partition === PUBLIC_PARTITION) {
         mailNewQuestToAdmin(mail, quest);
 
         // New publish on public = 100 loot point award
-        getUser(db, userid)
-          .then((u: User) => {
-            u.lootPoints = (u.lootPoints || 0) + 100;
-            db.users.upsert(prepare(u));
-          });
+        getUser(db, userid).then((u: User) => {
+          u.lootPoints = (u.lootPoints || 0) + 100;
+          db.users.upsert(prepare(u));
+        });
 
         // If this is the author's first published quest, email them a congratulations
-        db.quests.findOne({where: {userid}})
-          .then((qi: QuestInstance) => {
-            if (!Boolean(qi)) {
-              mailFirstQuestPublish(mail, quest);
-            }
-          });
+        db.quests.findOne({ where: { userid } }).then((qi: QuestInstance) => {
+          if (!Boolean(qi)) {
+            mailFirstQuestPublish(mail, quest);
+          }
+        });
       }
 
       const updateValues: Partial<Quest> = {
         ...quest,
         published: new Date(),
-        publishedurl: `http://quests.expeditiongame.com/raw/${quest.partition}/${quest.id}/${quest.questversion}`,
-        questversion: (instance.get('questversion') || quest.questversion || 0) + 1,
+        publishedurl: `http://quests.expeditiongame.com/raw/${
+          quest.partition
+        }/${quest.id}/${quest.questversion}`,
+        questversion:
+          (instance.get('questversion') || quest.questversion || 0) + 1,
         tombstone: null as any, // Remove tombstone; need null instead of undefined to trigger Sequelize update override
         userid, // Not included in the request - pull from auth
       };
@@ -209,61 +272,82 @@ export function publishQuest(db: Database, mail: MailService, userid: string, ma
       console.log(quest);
 
       // Publish to RenderedQuests
-      db.renderedQuests.create(new RenderedQuest({
-        id: quest.id,
-        partition: quest.partition,
-        questversion: updateValues.questversion,
-        xml,
-      }))
-      .then(() => {
-        console.log(`Stored XML for quest ${quest.id} in RenderedQuests`);
-      });
+      db.renderedQuests
+        .create(
+          new RenderedQuest({
+            id: quest.id,
+            partition: quest.partition,
+            questversion: updateValues.questversion,
+            xml,
+          }),
+        )
+        .then(() => {
+          console.log(`Stored XML for quest ${quest.id} in RenderedQuests`);
+        });
 
       return instance.update(updateValues);
     });
 }
 
 export function unpublishQuest(db: Database, partition: string, id: string) {
-  return db.quests.update({tombstone: new Date()}, {where: {partition, id}, limit: 1});
+  return db.quests.update(
+    { tombstone: new Date() },
+    { where: { partition, id }, limit: 1 },
+  );
 }
 
 export function republishQuest(db: Database, partition: string, id: string) {
-  return db.quests.update({tombstone: null} as any, {where: {partition, id}, limit: 1});
+  return db.quests.update({ tombstone: null } as any, {
+    where: { partition, id },
+    limit: 1,
+  });
 }
 
-export function updateQuestRatings(db: Database, partition: string, id: string): Bluebird<QuestInstance> {
+export function updateQuestRatings(
+  db: Database,
+  partition: string,
+  id: string,
+): Bluebird<QuestInstance> {
   let quest: QuestInstance;
-  return db.quests.findOne({where: {partition, id}})
+  return db.quests
+    .findOne({ where: { partition, id } })
     .then((q: QuestInstance) => {
       quest = q;
       return getFeedbackByQuestId(db, partition, quest.get('id'));
     })
     .then((feedback: FeedbackInstance[]) => {
-      const ratings: number[] = feedback.filter((f: FeedbackInstance) => {
-        if (f.get('tombstone')) {
-          return false;
-        }
-        if (!quest.get('questversionlastmajor')) {
-          return true;
-        }
-        if (!f.get('questversion') || !f.get('rating')) {
-          return false;
-        }
-        return (f.get('questversion') >= quest.get('questversionlastmajor'));
-      }).map((f: FeedbackInstance) => {
-        if (f.get('rating') === undefined || f.get('rating') === null || f.get('rating') === 0) {
-          // typescript isn't quite smart enough to realize we already filtered
-          // out any null/zero ratings. We add this here to appease it.
-          throw Error('Failed to filter out null ratings');
-        }
-        return f.get('rating');
-      });
+      const ratings: number[] = feedback
+        .filter((f: FeedbackInstance) => {
+          if (f.get('tombstone')) {
+            return false;
+          }
+          if (!quest.get('questversionlastmajor')) {
+            return true;
+          }
+          if (!f.get('questversion') || !f.get('rating')) {
+            return false;
+          }
+          return f.get('questversion') >= quest.get('questversionlastmajor');
+        })
+        .map((f: FeedbackInstance) => {
+          if (
+            f.get('rating') === undefined ||
+            f.get('rating') === null ||
+            f.get('rating') === 0
+          ) {
+            // typescript isn't quite smart enough to realize we already filtered
+            // out any null/zero ratings. We add this here to appease it.
+            throw Error('Failed to filter out null ratings');
+          }
+          return f.get('rating');
+        });
       const ratingcount = ratings.length;
       if (ratingcount === 0) {
-        return quest.update({ratingcount: null, ratingavg: null});
+        return quest.update({ ratingcount: null, ratingavg: null });
       }
 
-      const ratingavg = ratings.reduce((a: number, b: number) => a + b) / ratings.length;
-      return quest.update({ratingcount, ratingavg});
+      const ratingavg =
+        ratings.reduce((a: number, b: number) => a + b) / ratings.length;
+      return quest.update({ ratingcount, ratingavg });
     });
 }

--- a/services/app/src/actions/Search.tsx
+++ b/services/app/src/actions/Search.tsx
@@ -1,112 +1,120 @@
-import {QuestSearchResponse} from 'api/Handlers';
+import { QuestSearchResponse } from 'api/Handlers';
 import * as Redux from 'redux';
-import {Quest} from 'shared/schema/Quests';
-import {openSnackbar} from '../actions/Snackbar';
-import {AUTH_SETTINGS, TUTORIAL_QUESTS} from '../Constants';
-import {remoteify} from '../multiplayer/Remoteify';
-import {SearchParams, SettingsType} from '../reducers/StateTypes';
-import {SearchChangeParamsAction, SearchResponseAction} from './ActionTypes';
+import { handleFetchErrors } from 'shared/requests';
+import { Quest } from 'shared/schema/Quests';
+import { openSnackbar } from '../actions/Snackbar';
+import { AUTH_SETTINGS, TUTORIAL_QUESTS } from '../Constants';
+import { remoteify } from '../multiplayer/Remoteify';
+import { SearchParams, SettingsType } from '../reducers/StateTypes';
+import { SearchChangeParamsAction, SearchResponseAction } from './ActionTypes';
 import {} from './ActionTypes';
-import {toCard} from './Card';
-import {previewQuest} from './Quest';
+import { toCard } from './Card';
+import { previewQuest } from './Quest';
 
 export function changeSearchParams(params: any): SearchChangeParamsAction {
-  return {type: 'SEARCH_CHANGE_PARAMS', params};
+  return { type: 'SEARCH_CHANGE_PARAMS', params };
 }
 
 // TODO: Make search options propagate to other clients
-export const search = remoteify(function search(a: {params: SearchParams, players: number, settings: SettingsType}, dispatch: Redux.Dispatch<any>) {
-  const params = {...a.params};
+export const search = remoteify(function search(
+  a: { params: SearchParams; players: number; settings: SettingsType },
+  dispatch: Redux.Dispatch<any>
+) {
+  const params = { ...a.params };
   Object.keys(params).forEach((key: string) => {
     if ((params as any)[key] === null) {
       delete (params as any)[key];
     }
   });
   params.players = a.players;
-  dispatch(getSearchResults(params, (response: QuestSearchResponse) => {
-    dispatch({
-      quests: response.quests,
-      error: response.error,
-      params,
-      type: 'SEARCH_RESPONSE',
-    } as SearchResponseAction);
-  }));
+  dispatch(
+    getSearchResults(params, (response: QuestSearchResponse) => {
+      dispatch({
+        quests: response.quests,
+        error: response.error,
+        params,
+        type: 'SEARCH_RESPONSE',
+      } as SearchResponseAction);
+    })
+  );
 
   return a;
 });
 
-export const searchAndPlay = remoteify(function searchAndPlay(id: string, dispatch: Redux.Dispatch<any>) {
+export const searchAndPlay = remoteify(function searchAndPlay(
+  id: string,
+  dispatch: Redux.Dispatch<any>
+) {
   const params = {
     id,
     partition: 'expedition-public',
   } as SearchParams;
   const featuredQuest = TUTORIAL_QUESTS.filter((q) => q.id === id);
   if (featuredQuest.length === 1) {
-    dispatch(previewQuest({quest: featuredQuest[0]}));
+    dispatch(previewQuest({ quest: featuredQuest[0] }));
   } else {
-    dispatch(getSearchResults(params, (response: QuestSearchResponse) => {
-      dispatch({
-        quests: response.quests,
-        error: response.error,
-        params: {}, // Don't specify search params because this one's weird and uses ID
-        type: 'SEARCH_RESPONSE',
-      } as SearchResponseAction);
-      if (response.quests.length === 0) {
-        // TODO better alert / failure UI (dialog)
-        // https://github.com/ExpeditionRPG/expedition-app/issues/625
-        alert('Quest not found, returning to home screen.');
-        dispatch(toCard({name: 'SPLASH_CARD'}));
-      } else {
-        dispatch(previewQuest({quest: response.quests[0]}));
-      }
-    }));
+    dispatch(
+      getSearchResults(params, (response: QuestSearchResponse) => {
+        dispatch({
+          quests: response.quests,
+          error: response.error,
+          params: {}, // Don't specify search params because this one's weird and uses ID
+          type: 'SEARCH_RESPONSE',
+        } as SearchResponseAction);
+        if (response.quests.length === 0) {
+          // TODO better alert / failure UI (dialog)
+          // https://github.com/ExpeditionRPG/expedition-app/issues/625
+          alert('Quest not found, returning to home screen.');
+          dispatch(toCard({ name: 'SPLASH_CARD' }));
+        } else {
+          dispatch(previewQuest({ quest: response.quests[0] }));
+        }
+      })
+    );
   }
   return params;
 });
 
 // TODO switch to fetch since this never loads local files
-function getSearchResults(params: SearchParams, callback: (response: QuestSearchResponse) => void) {
+function getSearchResults(
+  params: SearchParams,
+  callback: (response: QuestSearchResponse) => void
+) {
   return (dispatch: Redux.Dispatch<any>) => {
     // Clear previous results
-    dispatch({type: 'SEARCH_REQUEST'});
+    dispatch({ type: 'SEARCH_REQUEST' });
 
-    const xhr = new XMLHttpRequest();
-    // TODO: Pagination / infinite scrolling
-    xhr.open('POST', AUTH_SETTINGS.URL_BASE + '/quests', true);
-    xhr.setRequestHeader('Content-Type', 'text/plain');
-    xhr.onload = () => {
-      let response: QuestSearchResponse;
-      try {
-        response = JSON.parse(xhr.responseText);
-      } catch (e) {
-        response = {error: e.toString(), hasMore: false, quests: []};
-      }
-
-      // Log silently to console, so we can see if users file feedback
-      // with recurrent search problems.
-      if (response.error) {
-        console.error(response.error);
-      }
-
-      // Simple validation of response quests
-      const quests: Quest[] = [];
-      if (response.quests) {
-        for (const q of response.quests) {
-          const i = Quest.create(q);
-          if (i instanceof Error) {
-            console.error('Parsed invalid quest: ' + JSON.stringify(q));
-          } else {
-            quests.push(i);
+    fetch(AUTH_SETTINGS.URL_BASE + '/quests', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+      body: JSON.stringify(params),
+    })
+      .then(handleFetchErrors)
+      .then((response: Response) => response.json())
+      .then((data: QuestSearchResponse) => {
+        // Simple validation of response quests
+        const quests: Quest[] = [];
+        if (data.quests) {
+          for (const q of data.quests) {
+            const i = Quest.create(q);
+            if (i instanceof Error) {
+              console.error('Parsed invalid quest: ' + JSON.stringify(q));
+            } else {
+              quests.push(i);
+            }
           }
         }
-      }
-      response.quests = quests;
-      callback(response);
-    };
-    xhr.onerror = () => {
-      dispatch(openSnackbar(Error('Network error: Please check your connection.')));
-    };
-    xhr.withCredentials = true;
-    xhr.send(JSON.stringify(params));
+
+        data.quests = quests;
+        callback(data);
+      })
+      .catch((error: Error) => {
+        // Don't alert user - it's not important to them if this fails
+        dispatch(
+          openSnackbar(Error('Network error: Please check your connection.'))
+        );
+      });
   };
 }

--- a/services/app/src/components/views/Search.test.tsx
+++ b/services/app/src/components/views/Search.test.tsx
@@ -21,6 +21,7 @@ export const TEST_SEARCH: SearchParams = {
   order: '+title',
   text: 'Test Text',
   expansions: [],
+  showPrivate: true,
 };
 
 describe('Search', () => {
@@ -29,7 +30,7 @@ describe('Search', () => {
 
   function setup(overrides?: Partial<Props>) {
     const props: Props = {
-      params: TEST_SEARCH
+      params: TEST_SEARCH,
       settings: initialSettings,
       user: loggedOutUser,
       results: [],

--- a/services/app/src/components/views/SearchSettings.test.tsx
+++ b/services/app/src/components/views/SearchSettings.test.tsx
@@ -1,11 +1,11 @@
-import {mount} from 'app/Testing';
+import { mount } from 'app/Testing';
 import * as React from 'react';
-import {initialSearch} from '../../reducers/Search';
-import {initialSettings} from '../../reducers/Settings';
-import {loggedOutUser} from '../../reducers/User';
-import SearchSettings, {Props} from './SearchSettings';
-import {Quest} from 'shared/schema/Quests';
-import {TEST_SEARCH} from './Search.test';
+import { initialSearch } from '../../reducers/Search';
+import { initialSettings } from '../../reducers/Settings';
+import { loggedOutUser } from '../../reducers/User';
+import SearchSettings, { Props } from './SearchSettings';
+import { Quest } from 'shared/schema/Quests';
+import { TEST_SEARCH } from './Search.test';
 
 describe('SearchSettings', () => {
   function setup() {
@@ -16,7 +16,7 @@ describe('SearchSettings', () => {
       onSearch: jasmine.createSpy('onSearch'),
     };
     const e = mount(<SearchSettings {...props} />);
-    return {props, e};
+    return { props, e };
   }
 
   function getNode(k) {
@@ -26,14 +26,22 @@ describe('SearchSettings', () => {
     if (k === 'expansions') {
       return 'ExpansionCheckbox';
     }
+
+    if(k === 'showPrivate') {
+      return `Checkbox#${k}`;
+    }
+
     return `NativeSelect#${k}`;
   }
 
   test('propagates user selections when Search is pressed', () => {
-    const {props, e} = setup();
+    const { props, e } = setup();
     for (const k of Object.keys(TEST_SEARCH)) {
       const node = getNode(k);
-      const onChange = k === 'expansions' ? TEST_SEARCH[k] : { target: { value: TEST_SEARCH[k] } };
+      const onChange =
+        k === 'expansions'
+          ? TEST_SEARCH[k]
+          : { target: { value: TEST_SEARCH[k] } };
       e.find(node).prop('onChange')(onChange);
     }
     e.find('ExpeditionButton#search').prop('onClick')();
@@ -41,10 +49,13 @@ describe('SearchSettings', () => {
   });
 
   test('propagates user selections when form is submitted', () => {
-    const {props, e} = setup();
+    const { props, e } = setup();
     for (const k of Object.keys(TEST_SEARCH)) {
       const node = getNode(k);
-      const onChange = k === 'expansions' ? TEST_SEARCH[k] : { target: { value: TEST_SEARCH[k] } };
+      const onChange =
+        k === 'expansions'
+          ? TEST_SEARCH[k]
+          : { target: { value: TEST_SEARCH[k] } };
       e.find(node).prop('onChange')(onChange);
     }
     e.find('form').prop('onSubmit')();
@@ -52,15 +63,19 @@ describe('SearchSettings', () => {
   });
 
   test('params default to initial search params when submitted', () => {
-    const {props, e} = setup();
+    const { props, e } = setup();
     e.find('form').prop('onSubmit')();
     expect(props.onSearch).toHaveBeenCalledWith(initialSearch.params);
   });
 
   test('changing a value then clearing it results in no value being sent as expected', () => {
-    const {props, e} = setup();
-    e.find('NativeSelect#contentrating').prop('onChange')({ target: { value: 'Teen' } });
-    e.find('NativeSelect#contentrating').prop('onChange')({ target: { value: undefined } });
+    const { props, e } = setup();
+    e.find('NativeSelect#contentrating').prop('onChange')({
+      target: { value: 'Teen' },
+    });
+    e.find('NativeSelect#contentrating').prop('onChange')({
+      target: { value: undefined },
+    });
     e.find('form').prop('onSubmit')();
     expect(props.onSearch).toHaveBeenCalledWith(initialSearch.params);
   });

--- a/services/app/src/components/views/SearchSettings.tsx
+++ b/services/app/src/components/views/SearchSettings.tsx
@@ -13,6 +13,7 @@ import Card from '../base/Card';
 import ExpansionCheckbox from './ExpansionCheckbox';
 
 const pluralize = require('pluralize');
+import Checkbox from '../base/Checkbox';
 
 export interface StateProps {
   params: SearchParams;
@@ -42,6 +43,14 @@ export class SearchSettings extends React.Component<Props, {}> {
       this.setState({[attrib]: undefined});
     } else {
       this.setState({[attrib]: value});
+    }
+  }
+
+  public handleCheckbox(v: boolean) {
+    if (v === false) {
+      this.onChange('showPrivate', false);
+    } else {
+      this.onChange('showPrivate', true);
     }
   }
 
@@ -180,6 +189,8 @@ export class SearchSettings extends React.Component<Props, {}> {
               <option value="false">No</option>
             </NativeSelect>
           </FormControl>
+          <Checkbox id="showPrivate" label="Also show my private quests" value={this.state.showPrivate === true ? true : false} onChange={(v: boolean) => { this.handleCheckbox(v); }}>
+          </Checkbox>
           {rating && <div className="ratingDescription">
             <span>"{this.state.contentrating}" rating means: {rating.summary}</span>
           </div>}

--- a/services/app/src/reducers/Search.tsx
+++ b/services/app/src/reducers/Search.tsx
@@ -11,6 +11,7 @@ export const initialSearch: SearchState = {
   params: {
     language: getStorageString(LANGUAGE_KEY, 'English') as LanguageType,
     order: '+ratingavg',
+    showPrivate: true,
     text: '',
     expansions: [],
   },

--- a/services/app/src/reducers/StateTypes.tsx
+++ b/services/app/src/reducers/StateTypes.tsx
@@ -79,6 +79,7 @@ export interface SearchParams {
   partition?: 'expedition-public' | 'expedition-private';
   expansions?: ExpansionsType[];
   language?: LanguageType;
+  showPrivate: boolean;
 }
 
 export type DifficultyType = 'EASY' | 'NORMAL' | 'HARD' | 'IMPOSSIBLE';


### PR DESCRIPTION
### [Issue #450](https://github.com/expeditionRPG/expedition/issues/450) 

* **What kind of change does this PR introduce?**
Feature request

* **What is the current behavior?**
Earlier, there wasn’t an option for the user to configure the settings for viewing private/public quests.

* **What I did?**
Added a checkbox for the user to enable Private quests and displayed them on the top.
This checkbox is added on the "Filter & Sort" page ie SearchSettings component!
