### PR TITLE
search: fix bug with re-searching, preserve language

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-hot-loader": "~4.3.0",
     "react-redux": "^5.0.7",
     "react-split-pane": "0.1.77",
-    "react-transition-group": "^2.3.1",
+    "react-transition-group": "^2.5.0",
     "react-truncate": "^2.3.0",
     "redux": "^4.0.0",
     "redux-devtools-extension": "^2.13.4",
@@ -281,6 +281,6 @@
       "schedule:monthly",
       "docker:disable"
     ],
-    "prConcurrentLimit": 2
+    "prConcurrentLimit": 3
   }
 }

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -57,3 +57,21 @@ npm run test
 ## Deployment
 
 Set up your Heroku remotes and then rename them to api-beta and api-prod: https://devcenter.heroku.com/articles/git#creating-a-heroku-remote
+
+## Database
+
+Uses Postgres SQL. You can test functionality and scripts against a locally-hosted version of Postgres. To access the official databases, you'll need to be a regular contributor to the codebase and receive special permission from the creators.
+
+If you are going to access prod, especially to edit data, make sure to make a backup [here](https://data.heroku.com/datastores/af009eae-3a7e-467b-9822-b368e0d4ed3a) first. Backups are automatically created daily, but this will allow zero-consequence rollbacks in case your query fails.
+
+For database querying, make sure you have psql installed and can do `which psql`, then run `heroku pg:psql --app expedition-api-beta DATABASE` to connect.
+
+On Mac, you may need to add `PATH=/Applications/Postgres.app/Contents/Versions/latest/bin:$PATH` to your `.bash_profile` for your terminal to recognize the `psql` command.
+
+The production database is backed up daily. See the [playbook](docs/playbook.md) on how to interact with these backups.
+
+If you need fresher data in dev, you can restore a prod backup into dev:
+
+```shell
+heroku pg:backups:restore expedition-api-prod:: DATABASE_URL -a expedition-api-beta
+```

--- a/services/app/src/actions/ActionTypes.tsx
+++ b/services/app/src/actions/ActionTypes.tsx
@@ -92,13 +92,18 @@ export interface QuestNodeAction extends Redux.Action {
 
 export interface ChangeSettingsAction extends Redux.Action {
   type: 'CHANGE_SETTINGS';
-  settings: any;
+  settings: Partial<SettingsType>;
 }
 
 export interface CombatTimerStopAction extends Redux.Action {
   type: 'COMBAT_TIMER_STOP';
   elapsedMillis: number;
   settings: SettingsType;
+}
+
+export interface SearchChangeParamsAction extends Redux.Action {
+  type: 'SEARCH_CHANGE_PARAMS';
+  params: Partial<SearchParams>;
 }
 
 export interface SearchRequestAction extends Redux.Action {

--- a/services/app/src/actions/Card.tsx
+++ b/services/app/src/actions/Card.tsx
@@ -2,11 +2,9 @@ import * as Redux from 'redux';
 import {NAV_CARD_STORAGE_KEY, VIBRATION_LONG_MS, VIBRATION_SHORT_MS} from '../Constants';
 import {getNavigator} from '../Globals';
 import {getStorageString} from '../LocalStorage';
-import {initialSearch} from '../reducers/Search';
-import {AppStateWithHistory, CardName, CardPhase, SettingsType} from '../reducers/StateTypes';
+import {AppStateWithHistory, CardName, CardPhase} from '../reducers/StateTypes';
 import {getStore} from '../Store';
 import {NavigateAction, remoteify} from './ActionTypes';
-import {search} from './Search';
 
 export interface ToCardArgs {
   keySuffix?: string;
@@ -70,18 +68,9 @@ export const toPrevious = remoteify(function toPrevious(a: ToPreviousArgs, dispa
 
 interface ToNavCardArgs {
   name?: CardName;
-  settings?: SettingsType;
 }
 export const toNavCard = remoteify(function toNavCard(a: ToNavCardArgs, dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory): ToNavCardArgs {
-  const settings = a.settings || getState().settings;
   const name = a.name || getStorageString(NAV_CARD_STORAGE_KEY, 'TUTORIAL_QUESTS') as CardName;
-  if (name === 'SEARCH_CARD') {
-    // Fire off a search if we don't have any search results already.
-    dispatch(search({
-      params: initialSearch.params,
-      settings,
-    }));
-  }
   dispatch(toCard({name}));
   return {name};
 });

--- a/services/app/src/actions/Search.tsx
+++ b/services/app/src/actions/Search.tsx
@@ -4,13 +4,17 @@ import {Quest} from 'shared/schema/Quests';
 import {openSnackbar} from '../actions/Snackbar';
 import {AUTH_SETTINGS, TUTORIAL_QUESTS} from '../Constants';
 import {ExpansionsType, SearchParams, SettingsType} from '../reducers/StateTypes';
-import {SearchResponseAction} from './ActionTypes';
-import {remoteify} from './ActionTypes';
+import {remoteify, SearchChangeParamsAction, SearchResponseAction} from './ActionTypes';
+import {} from './ActionTypes';
 import {toCard} from './Card';
 import {previewQuest} from './Quest';
 
+export function changeSearchParams(params: any): SearchChangeParamsAction {
+  return {type: 'SEARCH_CHANGE_PARAMS', params};
+}
+
 // TODO: Make search options propagate to other clients
-export const search = remoteify(function search(a: {params: SearchParams, settings: SettingsType}, dispatch: Redux.Dispatch<any>) {
+export const search = remoteify(function searchAndView(a: {params: SearchParams, settings: SettingsType}, dispatch: Redux.Dispatch<any>) {
   const params = {...a.params};
   Object.keys(params).forEach((key: string) => {
     if ((params as any)[key] === null) {
@@ -19,7 +23,6 @@ export const search = remoteify(function search(a: {params: SearchParams, settin
   });
   params.players = a.settings.numPlayers;
   params.expansions = Object.keys(a.settings.contentSets).filter( (key) => a.settings.contentSets[key] ) as ExpansionsType[],
-  dispatch(toCard({name: 'SEARCH_CARD'}));
   dispatch(getSearchResults(params, (response: QuestSearchResponse) => {
     dispatch({
       quests: response.quests,

--- a/services/app/src/components/base/NavigationContainer.tsx
+++ b/services/app/src/components/base/NavigationContainer.tsx
@@ -1,33 +1,24 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
 import {toCard} from '../../actions/Card';
-import {search} from '../../actions/Search';
 import {NAV_CARD_STORAGE_KEY} from '../../Constants';
 import {setStorageKeyValue} from '../../LocalStorage';
-import {initialSearch} from '../../reducers/Search';
-import {AppState, CardName, SettingsType} from '../../reducers/StateTypes';
+import {AppState, CardName} from '../../reducers/StateTypes';
 import Navigation, {DispatchProps, Props, StateProps} from './Navigation';
 
 const mapStateToProps = (state: AppState, ownProps: Partial<Props>): StateProps => {
   return {
     card: state.card,
     cardTheme: ownProps.cardTheme || 'light',
+    hasSearchResults: (state.search.results || false) && state.search.results.length > 0,
     questTheme: state.quest.details.theme || 'base',
-    hasSearchResults: state.search.results.length > 0,
     settings: state.settings,
   };
 };
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
-    toCard: (name: CardName, hasSearchResults: boolean, settings: SettingsType) => {
-      if (name === 'SEARCH_CARD' && !hasSearchResults) {
-        // Fire off a search if we don't have any search results already.
-        dispatch(search({
-          params: initialSearch.params,
-          settings,
-        }));
-      }
+    toCard: (name: CardName) => {
       dispatch(toCard({name, noHistory: true}));
 
       // Save nav state in local storage so we can persist the user's

--- a/services/app/src/components/views/Search.tsx
+++ b/services/app/src/components/views/Search.tsx
@@ -14,11 +14,12 @@ export interface StateProps {
   params: SearchParams;
   settings: SettingsType;
   user: UserState;
-  results: Quest[];
+  results: Quest[]|null;
   searching: boolean;
 }
 
 export interface DispatchProps {
+  search: (params: SearchParams, settings: SettingsType) => void;
   toCard: (name: CardName) => void;
   onReturn: () => void;
   onQuest: (quest: Quest) => void;
@@ -98,43 +99,72 @@ function renderNoQuests(props: Props): JSX.Element {
   </Card>);
 }
 
-export function search(props: Props): JSX.Element {
-  if (!props.user.loggedIn) {
-    return renderStoredQuests(props);
+export class Search extends React.Component<Props, {}> {
+
+  public componentDidMount() {
+    if (!this.props.results) {
+      // 10/14/18 Timeout prevents bug with CSSTransition when dispatching
+      // DOM change as part of componentDidMount
+      setTimeout(() => {
+        this.props.search(this.props.params, this.props.settings);
+      }, 1);
+    }
   }
 
-  if (props.searching) {
-    return renderLoading(props);
+  public render() {
+    if (!this.props.user.loggedIn) {
+      return renderStoredQuests(this.props);
+    }
+
+    if (!this.props.results || this.props.searching) {
+      return renderLoading(this.props);
+    }
+
+    if (this.props.results.length === 0) {
+      return renderNoQuests(this.props);
+    }
+
+    const quests = this.props.results.map((quest: Quest, i: number) => {
+      return (<QuestButtonContainer
+        id={`quest-${i}`}
+        key={i}
+        quest={quest}
+        onClick={() => this.props.onQuest(quest)}>
+          {renderDetails(quest, this.props.params.order)}
+      </QuestButtonContainer>);
+    });
+
+    const horror = this.props.settings.contentSets.horror;
+    const future = this.props.settings.contentSets.future;
+
+    return (
+      <Card
+        title="Quests"
+        className="search_card"
+        icon="logo_outline"
+        onReturn={this.props.onReturn}
+        header={<div className="searchHeader">
+          <Button
+            className="searchResultInfo"
+            disabled={true}>
+              {this.props.results.length} quests for {this.props.settings.numPlayers}
+              <img className="inline_icon" src="images/adventurer_small.svg"/>
+              {(horror || future) && <span> with </span>}
+              {horror && <img className="inline_icon" src="images/horror_small.svg"/>}
+              {future && <img className="inline_icon" src="images/future_small.svg"/>}
+          </Button>
+          <Button
+            className="filter_button"
+            onClick={() => this.props.toCard('SEARCH_SETTINGS')}
+            id="filter">
+              Filter &amp; Sort >
+          </Button>
+        </div>}
+      >
+        {quests}
+      </Card>
+    );
   }
-
-  if (props.results.length === 0) {
-    return renderNoQuests(props);
-  }
-
-  const quests = props.results.map((quest: Quest, i: number) => {
-    return (<QuestButtonContainer
-      id={`quest-${i}`}
-      key={i}
-      quest={quest}
-      onClick={() => props.onQuest(quest)}>
-        {renderDetails(quest, props.params.order)}
-    </QuestButtonContainer>);
-  });
-
-  return (
-    <Card
-      title="Quests"
-      className="search_card"
-      icon="logo_outline"
-      onReturn={props.onReturn}
-      header={<div className="searchHeader">
-        <Button className="searchResultInfo" disabled={true}>{props.results.length} quests for {props.settings.numPlayers} <img className="inline_icon" src="images/adventurer_small.svg"/></Button>
-        <Button className="filter_button" onClick={() => props.toCard('SEARCH_SETTINGS')} id="filter">Filter &amp; Sort ></Button>
-      </div>}
-    >
-      {quests}
-    </Card>
-  );
 }
 
-export default search;
+export default Search;

--- a/services/app/src/components/views/SearchContainer.tsx
+++ b/services/app/src/components/views/SearchContainer.tsx
@@ -3,13 +3,13 @@ import Redux from 'redux';
 import {Quest} from 'shared/schema/Quests';
 import {toCard, toPrevious} from '../../actions/Card';
 import {previewQuest} from '../../actions/Quest';
+import {search} from '../../actions/Search';
 import {NAV_CARDS} from '../../Constants';
-import {AppStateWithHistory, CardName} from '../../reducers/StateTypes';
+import {AppStateWithHistory, CardName, SearchParams, SettingsType} from '../../reducers/StateTypes';
 import Search, {DispatchProps, StateProps} from './Search';
 
 const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProps>): StateProps => {
   return {
-    results: [], // Default in case search results are not defined
     ...state.search,
     settings: state.settings,
     user: state.user,
@@ -18,6 +18,9 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
+    search: (params: SearchParams, settings: SettingsType) => {
+      dispatch(search({params, settings}));
+    },
     toCard: (name: CardName) => {
       dispatch(toCard({name}));
     },

--- a/services/app/src/components/views/SearchSettings.tsx
+++ b/services/app/src/components/views/SearchSettings.tsx
@@ -16,7 +16,7 @@ export interface StateProps {
 }
 
 export interface DispatchProps {
-  onSearch: (search: SearchParams, settings: SettingsType) => void;
+  onSearch: (search: SearchParams) => void;
 }
 
 export interface Props extends StateProps, DispatchProps {}
@@ -37,7 +37,7 @@ export class SearchSettings extends React.Component<Props, {}> {
     if (e) {
       e.preventDefault();
     }
-    this.props.onSearch(this.state, this.props.settings);
+    this.props.onSearch(this.state);
   }
 
   // TODO remove the clutter here / move to Theme.tsx
@@ -46,13 +46,22 @@ export class SearchSettings extends React.Component<Props, {}> {
     const timeBuckets = PLAYTIME_MINUTES_BUCKETS.map((minutes: number, index: number) => {
       return <option key={index} value={minutes}>{`${minutes} min`}</option>;
     });
-    // TODO Once we have 3 romance quests, change code to just display genre list
+    // TODO Once we have 3 romance & SciFi quests, change code to just display genre list
     const visibleGenres: GenreType[] = ['Comedy', 'Drama', 'Horror', 'Mystery'];
+    const horror = this.props.settings.contentSets.horror;
+    const future = this.props.settings.contentSets.future;
+    let content = 'the base game';
+    if (future && horror) {
+      content = 'The Future & The Horror';
+    } else if (horror) {
+      content = 'The Horror';
+    }
     return (
       <Card title="Quest Search">
         <form className="searchForm" autoComplete="off" onSubmit={(e: React.FormEvent) => {this.submit(e); }}>
           <div className="searchDescription">
-            For {this.props.settings.numPlayers} adventurer{this.props.settings.numPlayers > 1 ? 's' : ''} with {this.props.settings.contentSets.horror ? 'The Horror' : 'the base game'} (based on settings)
+            For {this.props.settings.numPlayers} adventurer{this.props.settings.numPlayers > 1 ? 's ' : ' '}
+            with {content} (based on settings)
           </div>
           <FormControl fullWidth={true}>
             <TextField

--- a/services/app/src/components/views/SearchSettingsContainer.tsx
+++ b/services/app/src/components/views/SearchSettingsContainer.tsx
@@ -1,7 +1,8 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
-import {search} from '../../actions/Search';
-import {AppStateWithHistory, SearchParams, SettingsType} from '../../reducers/StateTypes';
+import {toCard} from '../../actions/Card';
+import {changeSearchParams} from '../../actions/Search';
+import {AppStateWithHistory, SearchParams} from '../../reducers/StateTypes';
 import SearchSettings, {DispatchProps, StateProps} from './SearchSettings';
 
 const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProps>): StateProps => {
@@ -14,8 +15,9 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
-    onSearch: (params: SearchParams, settings: SettingsType) => {
-      dispatch(search({params, settings}));
+    onSearch: (params: SearchParams) => {
+      dispatch(changeSearchParams(params));
+      dispatch(toCard({name: 'SEARCH_CARD'}));
     },
   };
 };

--- a/services/app/src/reducers/CombinedReducers.tsx
+++ b/services/app/src/reducers/CombinedReducers.tsx
@@ -108,13 +108,14 @@ export default function combinedReducerWithHistory(state: AppStateWithHistory, a
         _history: state._history.slice(0, pastStateIdx),
         _return: true,
         // things that should persist / not be rewound:
+        audioData: state.audioData,
         commitID: state.commitID,
         multiplayer: state.multiplayer,
         saved: state.saved,
-        userQuests: state.userQuests,
+        search: state.search,
         settings: state.settings,
         user: state.user,
-        audioData: state.audioData,
+        userQuests: state.userQuests,
       } as AppStateWithHistory;
     }
 
@@ -128,12 +129,13 @@ export default function combinedReducerWithHistory(state: AppStateWithHistory, a
         _committed: undefined,
         _history: undefined,
         _return: undefined,
+        audioData: undefined,
         multiplayer: undefined,
         saved: undefined,
-        userQuests: undefined,
+        search: undefined,
         settings: undefined,
         user: undefined,
-        audioData: undefined,
+        userQuests: undefined,
       } as AppStateBase);
     }
   }

--- a/services/app/src/reducers/Search.tsx
+++ b/services/app/src/reducers/Search.tsx
@@ -1,9 +1,10 @@
 import Redux from 'redux';
-import {SearchResponseAction} from '../actions/ActionTypes';
+import {SearchChangeParamsAction, SearchResponseAction} from '../actions/ActionTypes';
+import {setStorageKeyValue} from '../LocalStorage';
 import {SearchState} from './StateTypes';
 
 export const initialSearch: SearchState = {
-  results: [],
+  results: null, // null = need to search; [] = no results
   params: {
     language: 'English',
     order: '+ratingavg',
@@ -14,11 +15,21 @@ export const initialSearch: SearchState = {
 
 export function search(state: SearchState = initialSearch, action: Redux.Action): SearchState {
   switch (action.type) {
+    case 'CHANGE_SETTINGS':
+      // Clear results when invalidated.
+      return {...state, results: null};
+    case 'SEARCH_CHANGE_PARAMS':
+      // Update params and clear results
+      const changes = (action as SearchChangeParamsAction).params || {};
+      Object.keys(changes).forEach((key: string) => {
+        setStorageKeyValue(`search-${key}`, changes[key]);
+      });
+      return {...state, params: {...state.params, ...changes}, results: null};
     case 'SEARCH_REQUEST':
       // Clear the searched quests if we're starting a new search.
-      return {...state, results: [], searching: true};
+      return {...state, results: null, searching: true};
     case 'SEARCH_ERROR':
-      return {...state, searching: false};
+      return {...state, results: [], searching: false};
     case 'SEARCH_RESPONSE':
       return {...state,
         results: (action as SearchResponseAction).quests,

--- a/services/app/src/reducers/Search.tsx
+++ b/services/app/src/reducers/Search.tsx
@@ -1,12 +1,13 @@
 import Redux from 'redux';
+import {LanguageType} from 'shared/schema/Constants';
 import {SearchChangeParamsAction, SearchResponseAction} from '../actions/ActionTypes';
-import {setStorageKeyValue} from '../LocalStorage';
+import {getStorageString, setStorageKeyValue} from '../LocalStorage';
 import {SearchState} from './StateTypes';
 
 export const initialSearch: SearchState = {
   results: null, // null = need to search; [] = no results
   params: {
-    language: 'English',
+    language: getStorageString('search-language', 'English') as LanguageType,
     order: '+ratingavg',
     text: '',
   },

--- a/services/app/src/reducers/StateTypes.tsx
+++ b/services/app/src/reducers/StateTypes.tsx
@@ -76,6 +76,7 @@ export interface ContentSetsType {
 }
 
 export interface SettingsType {
+  [index: string]: any;
   audioEnabled: boolean;
   autoRoll: boolean;
   contentSets: ContentSetsType;
@@ -152,7 +153,7 @@ export interface SavedQuestState {
 
 export interface SearchState {
   params: SearchParams;
-  results: Quest[];
+  results: Quest[]|null;
   searching: boolean;
 }
 
@@ -195,10 +196,10 @@ export interface MultiplayerSessionMeta {
 }
 
 export interface MultiplayerState {
-  session: MultiplayerSessionType|null;
-  history: MultiplayerSessionMeta[];
-  syncing: boolean;
   clientStatus: {[client: string]: StatusEvent};
+  history: MultiplayerSessionMeta[];
+  session: MultiplayerSessionType|null;
+  syncing: boolean;
 }
 
 // AppStateBase is what's stored in AppState._history.
@@ -211,20 +212,20 @@ export interface AppStateBase {
   audio: AudioState;
   card: CardState;
   checkout: CheckoutState;
+  commitID: number;
   dialog: DialogState;
   quest: QuestState;
-  search: SearchState;
   snackbar: SnackbarState;
-  commitID: number;
 }
 
 export interface AppState extends AppStateBase {
-  settings: SettingsType;
-  multiplayer: MultiplayerState;
-  userQuests: UserQuestsState;
-  saved: SavedQuestState;
   audioData: AudioDataState;
+  multiplayer: MultiplayerState;
+  saved: SavedQuestState;
+  search: SearchState;
+  settings: SettingsType;
   user: UserState;
+  userQuests: UserQuestsState;
 }
 
 export interface AppStateWithHistory extends AppState {

--- a/services/quests/README.md
+++ b/services/quests/README.md
@@ -1,10 +1,8 @@
 # Expedition Quest Creator
 
-[![Build Status](https://travis-ci.org/ExpeditionRPG/expedition-quest-creator.svg)](https://travis-ci.org/ExpeditionRPG/expedition-quest-creator)
-
 Write and publish quests for [Expedition: The RPG Card Game](http://expeditiongame.com).
 
-This is the companion to the [Expedition App](https://github.com/ExpeditionRPG/expedition-app).
+This is the companion to the [Expedition App](http://app.expeditiongame.com).
 
 ## Installation
 
@@ -38,34 +36,3 @@ The Quest Creator is then available at http://localhost:8080 by default. Note th
 
 When running on Windows, must be run within a Unix-like shell (such as Git Bash).
 
-#### Testing
-
-```sh
-npm test
-```
-
-### Deploying
-
-The Quest Creator uses Continuous Integration (via Travis CI) and Heroku hosting to make deployment super easy.
-
-If tests pass, that code is automatically deployed to AWS S3 at [http://betaquests.expeditiongame.com](http://betaquests.expeditiongame.com).
-
-Once master has been thoroughly tested on dev, you can deploy to prod with `./prod.sh` - if you run into any deploy issues, make sure to read the notes in that file!
-
-### Database
-
-The Quest Creator uses Postgres SQL. You can test functionality and scripts against a locally-hosted version of Postgres. To access the official databases, you'll need to be a regular contributor to the codebase and receive special permission from the creators.
-
-If you are going to access prod, especially to edit data, make sure to make a backup [here](https://data.heroku.com/datastores/af009eae-3a7e-467b-9822-b368e0d4ed3a) first. Backups are automatically created daily, but this will allow zero-consequence rollbacks in case your query fails.
-
-For database querying, make sure you have psql installed and can do `which psql`, then run `heroku pg:psql --app expedition-api-beta DATABASE` to connect.
-
-On Mac, you may need to add `PATH=/Applications/Postgres.app/Contents/Versions/latest/bin:$PATH` to your `.bash_profile` for your terminal to recognize the `psql` command.
-
-The production database is backed up daily. See the [playbook](docs/playbook.md) on how to interact with these backups.
-
-If you need fresher data in devel, you can restore a prod backup into dev:
-
-```shell
-heroku pg:backups:restore expedition-quest-creator:: DATABASE_URL -a expedition-quest-creator-dev
-```

--- a/yarn.lock
+++ b/yarn.lock
@@ -6616,6 +6616,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.10.0, js-yaml@^3.7.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
@@ -7306,6 +7310,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0, loud-rejection@^1.6.0:
   version "1.6.0"
@@ -9299,12 +9309,21 @@ react-test-renderer@^16.0.0-0:
     prop-types "^15.6.0"
     react-is "^16.4.1"
 
-react-transition-group@^2.2.1, react-transition-group@^2.3.1:
+react-transition-group@^2.2.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.4.0.tgz#1d9391fabfd82e016f26fabd1eec329dbd922b5a"
   dependencies:
     dom-helpers "^3.3.1"
     loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
+
+react-transition-group@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.0.tgz#70bca0e3546102c4dc5cf3f5f57f73447cce6874"
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 


### PR DESCRIPTION
Bug was that going back from settings was not trigger a new search.

Streamlined the search code to use an onMount trigger rather than trying to catch every single place where a goToSearch is called; that, along with clearing the search state each time a setting or search param is changed should make it much more robust (ie now you can go home, change player count and go back, and it will definitely re-search).

Also now stores and uses search language; decided not to also restore other search params, since those are more likely to change / break, and also more likely to change across search requests.

<img width="263" alt="screen shot 2018-10-14 at 12 00 13" src="https://user-images.githubusercontent.com/775657/46919908-4c8a6000-cfb4-11e8-8370-cf0d72a78ba0.png">
