### PR TITLE
decision RNG fix + multiplayer disable fix

### DIFF
--- a/services/app/src/Globals.test.tsx
+++ b/services/app/src/Globals.test.tsx
@@ -1,26 +1,26 @@
-import {getDevicePlatform, setDevice} from './Globals';
+import {getDevicePlatform, setDeviceForTest} from './Globals';
 
 describe('Globals', () => {
 
   describe('getDevicePlatform', () => {
     // Disabled for now because of unexpected behavior with Phantom
-    // it('reports web if no device inititialized', () => {
-    //   // No initialization at all
-    //   expect(getDevicePlatform()).toEqual('web');
-    // });
+    test('reports web if no device inititialized', () => {
+      // No initialization at all
+      expect(getDevicePlatform()).toEqual('web');
+    });
 
     test('defaults to web on unexpected device', () => {
-      setDevice({platform: 'zune'});
+      setDeviceForTest({platform: 'zune'});
       expect(getDevicePlatform()).toEqual('web');
     });
 
     test('reports ios if ios device initialized', () => {
-      setDevice({platform: 'ios'});
+      setDeviceForTest({platform: 'ios'});
       expect(getDevicePlatform()).toEqual('ios');
     });
 
     test('reports android if android device initialized', () => {
-      setDevice({platform: 'android'});
+      setDeviceForTest({platform: 'android'});
       expect(getDevicePlatform()).toEqual('android');
     });
   });

--- a/services/app/src/Globals.tsx
+++ b/services/app/src/Globals.tsx
@@ -54,7 +54,9 @@ const refs = {
 export function getDevicePlatform(): 'android' | 'ios' | 'web' {
   const p = (getDevice() || {}).platform;
   const platform = (p || window.navigator.appVersion || '').toLowerCase();
-  if (/android/.test(platform)) {
+  if (!window.cordova) {
+    return 'web';
+  } else if (/android/.test(platform)) {
     return 'android';
   } else if (/iphone|ipad|ipod|ios/.test(platform)) {
     return 'ios';
@@ -74,7 +76,8 @@ export function setDocument(d: ReactDocument) {
   refs.document = d;
 }
 
-export function setDevice(d: any) {
+export function setDeviceForTest(d: any) {
+  window.cordova = window.cordova || (true as any);
   refs.device = d;
 }
 

--- a/services/app/src/actions/ServerStatus.test.tsx
+++ b/services/app/src/actions/ServerStatus.test.tsx
@@ -29,7 +29,7 @@ describe('Fetch ServerStatus', () => {
         }),
       }));
       done();
-    });
+    }).catch(done.fail);
   });
 
   test('Shows update version prompt with platform-specific link if outdated version', (done) => {
@@ -49,19 +49,25 @@ describe('Fetch ServerStatus', () => {
         }),
       }));
       done();
-    });
+    }).catch(done.fail);
   });
 
-  test('Does nothing if latest version and no announcement', (done) => {
+  test('Updates version status if latest version and no announcement', (done) => {
     fetchMock.get('*', {
       link: '',
       message: '',
       versions: {android: '0.0.0', ios: '0.0.0', web: '0.0.0'},
     });
     Action(fetchServerStatus, {}).execute().then((actions) => {
-      expect(actions.length).toEqual(0);
+      expect(actions.length).toEqual(1);
+      expect(actions[0]).toEqual(jasmine.objectContaining({
+        type: 'SERVER_STATUS_SET',
+        delta: jasmine.objectContaining({
+          isLatestAppVersion: true,
+        }),
+      }));
       done();
-    });
+    }).catch(done.fail);
   });
 
   test('Silently logs error events', (done) => {
@@ -71,6 +77,6 @@ describe('Fetch ServerStatus', () => {
       expect(actions.length).toEqual(0);
       expect(log).toHaveBeenCalled();
       done();
-    });
+    }).catch(done.fail);
   });
 });

--- a/services/app/src/actions/ServerStatus.tsx
+++ b/services/app/src/actions/ServerStatus.tsx
@@ -26,7 +26,6 @@ function handleServerStatus(data: FetchServerStatusResponse) {
     const newVersion = data.versions[getDevicePlatform()];
     const oldVersion = VERSION;
     const isLatestAppVersion = semver.valid(newVersion) && semver.valid(oldVersion) && semver.lte(newVersion, oldVersion) || false;
-
     if (data.message !== null && data.message !== '') {
       dispatch(setServerStatus({
         announcement: {
@@ -45,6 +44,8 @@ function handleServerStatus(data: FetchServerStatusResponse) {
         },
         isLatestAppVersion,
       }));
+    } else {
+      dispatch(setServerStatus({isLatestAppVersion}));
     }
   };
 }

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
@@ -108,17 +108,26 @@ describe('Combat actions', () => {
   });
 
   describe('initCustomCombat', () => {
-    const actions = Action(initCustomCombat, {settings: TEST_SETTINGS}).execute({});
-
     test('has custom=true', () => {
+      const actions = Action(initCustomCombat, {settings: TEST_SETTINGS}).execute({});
       expect(actions[1].node.ctx.templates.combat).toEqual(jasmine.objectContaining({
         custom: true,
       }));
     });
 
     test('identifies as a combat element', () => {
+      const actions = Action(initCustomCombat, {settings: TEST_SETTINGS}).execute({});
       expect(actions[1].node.getTag()).toEqual('combat');
     });
+
+    test('passes seed to multiplayer', () => {
+      Action(initCustomCombat, {settings: TEST_SETTINGS}).expect({seed: 'testseed'}).toSendMultiplayer({seed: 'testseed'});
+    });
+
+    test('uses passed seed', () => {
+      const actions = Action(initCustomCombat, {settings: TEST_SETTINGS}).execute({seed: 'testseed'});
+      expect(actions[1].node.ctx.seed).toEqual('testseed');
+    })
   });
 
   describe('isSurgeNextRound', () => {

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
@@ -82,16 +82,19 @@ export const initCombat = remoteify(function initCombat(a: InitCombatArgs, dispa
 
 interface InitCustomCombatArgs {
   rp?: MultiplayerState;
+  seed?: string;
 }
 export const initCustomCombat = remoteify(function initCustomCombat(a: InitCustomCombatArgs, dispatch: Redux.Dispatch<any>,  getState: () => AppStateWithHistory): InitCustomCombatArgs {
   if (!a.rp) {
     a.rp = getState().multiplayer;
   }
-  dispatch(initCombat({
-    custom: true,
-    node: new ParserNode(cheerio.load('<combat></combat>')('combat'), defaultContext()),
-  }));
-  return {};
+  // Set seed if we got one from multiplayer
+  const node = new ParserNode(cheerio.load('<combat></combat>')('combat'), defaultContext(), undefined, a.seed);
+  dispatch(initCombat({custom: true, node}));
+  if (!a.seed) {
+    a.seed = node.ctx.seed;
+  }
+  return {seed: a.seed};
 });
 
 function calculateAudioIntensity(currentTier: number, maxTier: number, deadAdventurers: number, roundCount: number): number {
@@ -304,7 +307,6 @@ interface HandleCombatTimerStartArgs {
   settings?: SettingsType;
 }
 export const handleCombatTimerStart = remoteify(function handleCombatTimerStart(a: HandleCombatTimerStartArgs, dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory) {
-  console.log('handling combat timer start');
   if (!a.settings) {
     a.settings = getState().settings;
   }

--- a/services/app/src/components/views/quest/cardtemplates/combat/Types.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Types.tsx
@@ -58,11 +58,12 @@ export interface StateProps {
 }
 
 export function mapStateToProps(state: AppStateWithHistory, ownProps: Partial<StateProps>): StateProps {
+  const node = ownProps.node || state.quest.node;
   return {
-    node: ownProps.node || state.quest.node,
+    node,
     players: numPlayers(state.settings, state.multiplayer),
     settings: state.settings,
-    seed: state.quest.seed,
+    seed: (node && node.ctx.seed) || '',
     theme: getCardTemplateTheme(state.card),
   };
 }

--- a/services/app/src/components/views/quest/cardtemplates/decision/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Actions.test.tsx
@@ -7,10 +7,11 @@ import {
   skillTimeMillis,
   handleDecisionRoll,
   toDecisionCard,
+  selectChecks,
 } from './Actions';
 import {defaultContext} from '../Template';
 import {ParserNode} from '../TemplateTypes';
-import {EMPTY_DECISION_STATE} from './Types';
+import {EMPTY_DECISION_STATE, LeveledSkillCheck} from './Types';
 import {Action, newMockStore} from 'app/Testing';
 import {Multiplayer as m, Settings as s} from 'app/reducers/TestData';
 import {Outcome} from 'shared/schema/templates/Decision';
@@ -82,6 +83,17 @@ describe('Decision actions', () => {
     });
     test('respects difficulty', () => {
       expect(computeSuccesses([16, 15, 10, 14], {difficulty: 'hard'})).toEqual(0);
+    });
+  });
+  describe('selectChecks', () => {
+    test.only('selects a subset if there are more than 3 decisions', () => {
+      const cs: LeveldSkillCheck[] = [];
+      for (const skill of ['athletics', 'knowledge', 'charisma']) {
+        for (const persona of ['light', 'dark']) {
+          cs.push({difficulty: 'hard', persona, requiredSuccesses: 1, skill});
+        }
+      }
+      expect(selectChecks(cs, seedrandom.alea('1234')).length).toEqual(3);
     });
   });
   describe('computeOutcome', () => {

--- a/services/app/src/components/views/quest/cardtemplates/decision/DecisionTimer.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/DecisionTimer.test.tsx
@@ -43,14 +43,14 @@ function setup(overrides: Partial<Props>) {
 describe('DecisionTimer', () => {
   afterEach(unmountAll);
 
-  test('Shows the skill and num successes needed', () => {
+  test('shows the skill and num successes needed', () => {
     const {e} = setup({});
     const result = e.find('.secondary').text();
     expect(result).toMatch(/1 \w+ athletics/);
     expect(result).toMatch(/2 \w+ charisma/);
     expect(result).toMatch(/3 \w+ knowledge/);
   });
-  test('Either shows persona or difficulty, not both', () => {
+  test('either shows persona or difficulty, not both', () => {
     const {e} = setup({});
     const result = e.find('.secondary').childAt(0).text();
     expect(result).toMatch(/^\d \w+ (charisma|athletics|knowledge)$/);

--- a/services/app/src/components/views/quest/cardtemplates/decision/DecisionTimer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/DecisionTimer.tsx
@@ -2,7 +2,7 @@ import Button from 'app/components/base/Button';
 import {getStore} from 'app/Store';
 import * as React from 'react';
 import {ParserNode} from '../TemplateTypes';
-import {extractDecision} from './Actions';
+import {extractDecision, selectChecks} from './Actions';
 import {LeveledSkillCheck, StateProps as StatePropsBase} from './Types';
 
 export interface StateProps extends StatePropsBase {
@@ -14,20 +14,6 @@ export interface DispatchProps {
 }
 
 export interface Props extends StateProps, DispatchProps {}
-
-// Credit: https://stackoverflow.com/questions/11935175/sampling-a-random-subset-from-an-array
-function getRandomSubarray<T>(arr: T[], size: number, rng: () => number) {
-    const shuffled = arr.slice(0);
-    let i = arr.length;
-    const min = i - size;
-    while (i-- > min) {
-        const index = Math.floor((i + 1) * rng());
-        const temp = shuffled[index];
-        shuffled[index] = shuffled[i];
-        shuffled[i] = temp;
-    }
-    return shuffled.slice(min);
-}
 
 export default class DecisionTimer extends React.Component<Props, {}> {
   public interval: any;
@@ -44,7 +30,8 @@ export default class DecisionTimer extends React.Component<Props, {}> {
 
     // Set on single evaluation
     this.showPersona = this.props.rng() > 0.5;
-    this.checks = this.selectChecks();
+    const decision = extractDecision(this.props.node);
+    this.checks = selectChecks(decision.leveledChecks, this.props.rng);
   }
 
   public onSelect(c: LeveledSkillCheck) {
@@ -63,32 +50,6 @@ export default class DecisionTimer extends React.Component<Props, {}> {
     if (this.interval) {
       clearInterval(this.interval);
     }
-  }
-
-  public selectChecks(): LeveledSkillCheck[] {
-    const decision = extractDecision(this.props.node);
-    const cs = decision.leveledChecks;
-    if (cs.length === 0) {
-      console.error('Could not resolve any checks, using generated checks');
-      return [];
-    }
-
-    const mapped: {[k: string]: LeveledSkillCheck[]} = {};
-    for (const c of cs) {
-      const k = `${c.persona} ${c.skill}`;
-      if (!mapped[k]) {
-        mapped[k] = [];
-      }
-      mapped[k].push(c);
-    }
-
-    const keys = Object.keys(mapped);
-    if (keys.length > 3) {
-      getRandomSubarray(Object.keys(mapped), 3, this.props.rng);
-    }
-    return keys.map((k) => {
-        return mapped[k][Math.floor(this.props.rng() * mapped[k].length)];
-      });
   }
 
   private formattedTimer(): string {

--- a/services/app/src/components/views/quest/cardtemplates/decision/Types.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Types.tsx
@@ -57,11 +57,12 @@ export interface StateProps {
 }
 
 export function mapStateToProps(state: AppStateWithHistory, ownProps: Partial<StateProps>): StateProps {
+  const node = ownProps.node || state.quest.node;
   return {
     multiplayerState: state.multiplayer,
-    node: ownProps.node || state.quest.node,
+    node,
     settings: state.settings,
-    rng: seedrandom.alea(state.quest.seed),
+    rng: seedrandom.alea((node && node.ctx.seed) || ''),
     theme: getCardTemplateTheme(state.card),
   };
 }

--- a/services/app/src/reducers/Quest.tsx
+++ b/services/app/src/reducers/Quest.tsx
@@ -5,16 +5,6 @@ import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes'
 import {QuestState} from './StateTypes';
 
 const cheerio = require('cheerio') as CheerioAPI;
-const seedrandom = require('seedrandom');
-
-function autoseed(): string {
-  let seed = '';
-  seedrandom(undefined, { pass(p: seedrandom.prng, s: string): seedrandom.prng {
-    seed = s;
-    return p;
-  }});
-  return seed;
-}
 
 export const initialQuestState: QuestState = {
   details: new Quest({
@@ -34,7 +24,6 @@ export const initialQuestState: QuestState = {
   }),
   lastPlayed: null,
   savedTS: null,
-  seed: autoseed(),
 };
 
 export function quest(state: QuestState = initialQuestState, action: Redux.Action): QuestState {
@@ -47,7 +36,6 @@ export function quest(state: QuestState = initialQuestState, action: Redux.Actio
       return {...state,
         details: (action as QuestNodeAction).details || state.details,
         node: (action as QuestNodeAction).node,
-        seed: autoseed(),
       };
     case 'PREVIEW_QUEST':
       const pqa = action as PreviewQuestAction;
@@ -56,7 +44,6 @@ export function quest(state: QuestState = initialQuestState, action: Redux.Actio
         details: pqa.quest,
         lastPlayed: pqa.lastPlayed || null,
         savedTS: pqa.savedTS || null,
-        seed: autoseed(),
       };
     default:
       return state;

--- a/services/app/src/reducers/StateTypes.tsx
+++ b/services/app/src/reducers/StateTypes.tsx
@@ -154,7 +154,6 @@ export type TransitionClassType = 'next' | 'prev' | 'instant' | 'nav';
 export interface QuestState {
   details: Quest;
   node: ParserNode;
-  seed: string;
   // Additional details populated depending on from where
   // the user approaches the quest
   lastPlayed: Date|null;


### PR DESCRIPTION
- Device settings now properly says "web" when using a web browser (i.e. cordova not present)
- Added `done.fail` catchers to ServerStatus tests to fail early if they do fail
- Changed ServerStatus to still set `isLatestAppVersion` if there are no announcements so multiplayer is still allowed
- Edited custom combat init function to synchronize seed values across multiplayer so decisions were in sync
- Changed combat & decision seed usage to use the ParserNode seed instead of `state.quest.seed`, and removed `state.quest.seed` since it's totally redundant and never synced with multiplayer
- Fixed decision check selection to actually limit the number of decisions to at most 3
- Added tests for all the modified stuff

#234 #237