### PR TITLE
Better multiplayer bug reporting

### DIFF
--- a/services/api/src/Handlers.ts
+++ b/services/api/src/Handlers.ts
@@ -353,6 +353,7 @@ export function feedback(db: Database, mail: MailService, req: express.Request, 
     text: body.text,
     userid: body.userid,
     version: body.version,
+    stats: body.stats,
   });
   if (data instanceof Error) {
     console.error(data);

--- a/services/api/src/models/Database.ts
+++ b/services/api/src/models/Database.ts
@@ -103,7 +103,6 @@ export class Database {
       ...standardOptions,
       timestamps: false, // TODO: eventually switch to sequelize timestamps
     });
-    this.questData.sync();
 
     const feedbackSpec = toSequelize(new Feedback({partition: PUBLIC_PARTITION, questid: '', userid: ''}));
     this.feedback = this.sequelize.define('feedback', feedbackSpec, {

--- a/services/api/src/models/Feedback.ts
+++ b/services/api/src/models/Feedback.ts
@@ -47,6 +47,7 @@ function mailFeedbackToAdmin(mail: MailService, type: FeedbackType, quest: Quest
     <p>User settings: ${feedback.players} adventurers on ${feedback.difficulty} difficulty.</p>
     <p>Raw platform string: ${platformDump}</p>
     <p>User email that reported it: <a href="mailto:${feedback.email}">${feedback.email}</a></p>
+    <p>Multiplayer stats: ${feedback.stats}</p>
   `;
 
   if (consoleDump.length > 0) {

--- a/services/app/src/actions/Web.tsx
+++ b/services/app/src/actions/Web.tsx
@@ -8,7 +8,7 @@ import {MIN_FEEDBACK_LENGTH} from '../Constants';
 import {getDevicePlatform, getPlatformDump} from '../Globals';
 import {getLogBuffer} from '../Logging';
 import {logEvent} from '../Logging';
-import {getCounters, MultiplayerCounters} from '../multiplayer/Counters';
+import {getCounters} from '../multiplayer/Counters';
 import {remoteify} from '../multiplayer/Remoteify';
 import {AppState, FeedbackType, QuestState, SettingsType, UserQuestsType, UserState} from '../reducers/StateTypes';
 import {UserQuestsAction} from './ActionTypes';
@@ -148,10 +148,6 @@ export function subscribe(a: {email: string}) {
 
 export function submitUserFeedback(a: {quest: QuestState, settings: SettingsType, user: UserState, type: FeedbackType, anonymous: boolean, text: string, rating: number|null}) {
   return (dispatch: Redux.Dispatch<any>, getState: () => AppState) => {
-    const stats = getCounters();
-    if (stats) {
-      logMultiplayerStats(a.user, a.quest.details, stats);
-    }
     if (a.rating && a.rating < 3 && (!a.text || a.text.length < MIN_FEEDBACK_LENGTH)) {
       return alert('Sounds like the quest needs work! Please provide feedback of at least ' + MIN_FEEDBACK_LENGTH + ' characters to help the author improve.');
     } else if (a.rating && a.text.length > 0 && a.text.length < MIN_FEEDBACK_LENGTH) {
@@ -172,6 +168,7 @@ export function submitUserFeedback(a: {quest: QuestState, settings: SettingsType
       text: a.text,
       userid: a.user.id,
       version: VERSION,
+      stats: JSON.stringify(getCounters()),
     };
 
     // If we're not rating, we're providing other feedback.
@@ -214,31 +211,4 @@ function postUserFeedback(type: string, data: any) {
       dispatch(openSnackbar(Error('Error submitting review: ' + error.toString())));
     });
   };
-}
-
-export function logMultiplayerStats(user: UserState, quest: Quest, stats: MultiplayerCounters) {
-  try {
-    const data = {
-      console: getLogBuffer(),
-      data: stats,
-      email: user.email,
-      name: user.name,
-      platform: getDevicePlatform(),
-      questid: quest.id,
-      questversion: quest.questversion,
-      userid: user.id,
-      version: VERSION,
-    };
-
-    return fetch(AUTH_SETTINGS.URL_BASE + '/analytics/multiplayer/stats', {
-      body: JSON.stringify(data),
-      method: 'POST',
-    })
-    .then(handleFetchErrors)
-    .catch((error: Error) => {
-      logEvent('error', 'analytics_quest_err', { label: error });
-    });
-  } catch (e) {
-    console.error('Failed to log multiplayer stats', e);
-  }
 }

--- a/services/app/src/components/base/Dialogs.test.tsx
+++ b/services/app/src/components/base/Dialogs.test.tsx
@@ -126,11 +126,6 @@ describe('Dialogs', () => {
       const {e} = setup({receivedEvents: 500});
       expect(e.find('DialogContent').render().text()).toContain("receivedEvents: 500");
     });
-    test('sends report', () => {
-      const {props, e} = setup();
-      e.find('#sendReportButton').hostNodes().prop('onClick')();
-      expect(props.onSendReport).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('MultiplayerPeersDialog', () => {

--- a/services/app/src/components/base/Dialogs.tsx
+++ b/services/app/src/components/base/Dialogs.tsx
@@ -85,7 +85,6 @@ export class DeleteSavedQuestDialog extends ConfirmationDialog<DeleteSavedQuestD
 
 interface MultiplayerStatusDialogProps extends React.Props<any> {
   onClose: () => void;
-  onSendReport: (user: UserState, quest: Quest, stats: MultiplayerCounters) => void;
   open: boolean;
   questDetails: Quest;
   stats: MultiplayerCounters;
@@ -112,14 +111,9 @@ export class MultiplayerStatusDialog extends React.Component<MultiplayerStatusDi
           </p>
           <p>Here's some multiplayer debugging information:</p>
           {stats}
-          <p>
-            If you're experiencing problems with multiplayer, please
-            tap "Send Report" below to send a log to the Expedition team. Thanks!
-          </p>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => this.props.onClose()}>Cancel</Button>,
-          <Button id="sendReportButton" className="primary" onClick={() => this.props.onSendReport(this.props.user, this.props.questDetails, this.props.stats)}>Send Report</Button>
         </DialogActions>
       </Dialog>
     );
@@ -380,7 +374,6 @@ export interface DispatchProps {
   onFeedbackSubmit: (type: FeedbackType, quest: QuestState, settings: SettingsType, user: UserState, text: string) => void;
   onMultitouchChange: (v: boolean) => void;
   onPlayerDelta: (numLocalPlayers: number, delta: number) => void;
-  onSendMultiplayerReport: (user: UserState, quest: Quest, stats: MultiplayerCounters) => void;
   playQuest: (quest: Quest) => void;
 }
 
@@ -418,7 +411,6 @@ const Dialogs = (props: Props): JSX.Element => {
         user={props.user}
         multiplayer={props.multiplayer}
         questDetails={props.quest.details}
-        onSendReport={props.onSendMultiplayerReport}
         onClose={props.onClose}
       />
       <MultiplayerPeersDialog

--- a/services/app/src/components/base/DialogsContainer.tsx
+++ b/services/app/src/components/base/DialogsContainer.tsx
@@ -9,9 +9,9 @@ import {exitQuest} from '../../actions/Quest';
 import {deleteSavedQuest} from '../../actions/SavedQuests';
 import {changeSettings} from '../../actions/Settings';
 import {openSnackbar} from '../../actions/Snackbar';
-import {fetchQuestXML, logMultiplayerStats, submitUserFeedback} from '../../actions/Web';
+import {fetchQuestXML, submitUserFeedback} from '../../actions/Web';
 import {MIN_FEEDBACK_LENGTH} from '../../Constants';
-import {getCounters, MultiplayerCounters} from '../../multiplayer/Counters';
+import {getCounters} from '../../multiplayer/Counters';
 import {AppState, ContentSetsType, FeedbackType, QuestState, SavedQuestMeta, SettingsType, UserState} from '../../reducers/StateTypes';
 import Dialogs, {DispatchProps, StateProps} from './Dialogs';
 
@@ -82,13 +82,6 @@ export const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps
         return;
       }
       dispatch(changeSettings({numLocalPlayers}));
-    },
-    onSendMultiplayerReport: (user: UserState, quest: Quest, stats: MultiplayerCounters) => {
-      logMultiplayerStats(user, quest, stats)
-        .then((r: Response) => {
-          dispatch(openSnackbar('Stats submitted. Thank you!'));
-          dispatch(setDialog(null));
-        });
     },
     playQuest: (details: Quest) => {
       dispatch(setDialog(null));

--- a/shared/schema/Feedback.tsx
+++ b/shared/schema/Feedback.tsx
@@ -56,6 +56,10 @@ export class Feedback extends SchemaBase {
   }) public email: string;
 
   @field({
+    default: '',
+  }) public stats: string;
+
+  @field({
     default: false,
   }) public anonymous: boolean;
 


### PR DESCRIPTION
Remove feedback sending from MP connection icon in favor of regular Submit Feedback flow - also send MP counters whenever they exist as part of feedback.

Part of #237