### PR TITLE
Multiplayer: distinguish local alive adventurer counts during combat

### DIFF
--- a/services/app/src/actions/Multiplayer.test.tsx
+++ b/services/app/src/actions/Multiplayer.test.tsx
@@ -221,6 +221,10 @@ describe('Multiplayer actions', () => {
       const {c, actions} = doTest("nnn", "mmm");
       expect(c.sendEvent).not.toHaveBeenCalled();
     });
+    test('persists waitingOn', () => {
+      // This has failed multiple times for various reasons, so figued it's worthwhile to test it here.
+      // TODO
+    });
   });
 
   describe('sendEvent', () => {

--- a/services/app/src/actions/Multiplayer.tsx
+++ b/services/app/src/actions/Multiplayer.tsx
@@ -1,5 +1,6 @@
 import Redux from 'redux';
 import {MultiplayerEvent, MultiplayerEventBody, StatusEvent} from 'shared/multiplayer/Events';
+import {toClientKey} from 'shared/multiplayer/Session';
 import {handleFetchErrors} from 'shared/requests';
 import {openSnackbar} from '../actions/Snackbar';
 import {MULTIPLAYER_SETTINGS} from '../Constants';
@@ -149,12 +150,14 @@ export function sendStatus(client?: string, instance?: string, partialStatus?: S
   return (dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory): Promise<void> => {
     const {multiplayer, settings, commitID, quest, user} = getState();
     const elem = (quest && quest.node && quest.node.elem);
-    const selfStatus = (multiplayer && multiplayer.clientStatus && multiplayer.clientStatus[multiplayer.client]);
+    const combat = (quest && quest.node && quest.node.ctx && quest.node.ctx.templates && quest.node.ctx.templates.combat);
+    const selfStatus = (multiplayer && multiplayer.clientStatus && multiplayer.clientStatus[toClientKey(multiplayer.client, multiplayer.instance)]);
     let event: StatusEvent = {
       connected: true,
       lastEventID: commitID,
       line: (elem && parseInt(elem.attr('data-line'), 10)),
       numLocalPlayers: (settings && settings.numLocalPlayers) || 1,
+      aliveAdventurers: (combat && combat.numAliveAdventurers),
       type: 'STATUS',
       waitingOn: (selfStatus && selfStatus.waitingOn),
       name: user && user.email,

--- a/services/app/src/actions/Multiplayer.tsx
+++ b/services/app/src/actions/Multiplayer.tsx
@@ -152,6 +152,8 @@ export function sendStatus(client?: string, instance?: string, partialStatus?: S
     const elem = (quest && quest.node && quest.node.elem);
     const combat = (quest && quest.node && quest.node.ctx && quest.node.ctx.templates && quest.node.ctx.templates.combat);
     const selfStatus = (multiplayer && multiplayer.clientStatus && multiplayer.clientStatus[toClientKey(multiplayer.client, multiplayer.instance)]);
+    const storeClient = multiplayer && multiplayer.client;
+    const storeInstance = multiplayer && multiplayer.instance;
     let event: StatusEvent = {
       connected: true,
       lastEventID: commitID,
@@ -161,16 +163,16 @@ export function sendStatus(client?: string, instance?: string, partialStatus?: S
       type: 'STATUS',
       waitingOn: (selfStatus && selfStatus.waitingOn),
       name: user && user.email,
-      contentSets: settings && Object.keys(settings.contentSets).filter((k) => settings.contentSets[k]),
+      contentSets: settings && Object.keys(settings.contentSets || {}).filter((k) => settings.contentSets[k]),
     };
     if (partialStatus) {
       event = {...event, ...partialStatus};
     }
-    client = client || multiplayer.client || '';
-    instance = instance || multiplayer.instance || '';
+    client = client || storeClient || '';
+    instance = instance || storeInstance || '';
 
     // Send remote if we're the origin
-    if (client === multiplayer.client && instance === multiplayer.instance) {
+    if (client === storeClient && instance === storeInstance) {
       c.sendEvent(event, commitID);
     }
 

--- a/services/app/src/actions/Settings.test.tsx
+++ b/services/app/src/actions/Settings.test.tsx
@@ -1,7 +1,12 @@
 import {initialMultiplayer} from 'app/reducers/Multiplayer';
 import {initialSettings} from 'app/reducers/Settings';
 import {MultiplayerState} from 'app/reducers/StateTypes';
-import {numAdventurers, numPlayers, playerOrder} from './Settings';
+import {numAdventurers, numPlayers, playerOrder, numAliveAdventurers} from './Settings';
+import {defaultContext} from '../components/views/quest/cardtemplates/Template';
+import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
+
+
+const cheerio = require('cheerio') as CheerioAPI;
 
 describe('Settings action', () => {
   describe('changeSettings', () => {
@@ -10,11 +15,13 @@ describe('Settings action', () => {
 
   describe('PlayerCount', () => {
     const s = {...initialSettings, numLocalPlayers: 1};
+    const n = new ParserNode(cheerio.load('<quest/>')('quest'), {...defaultContext(), templates: {combat: {numAliveAdventurers: 1}}});
+    const n0 = new ParserNode(cheerio.load('<quest/>')('quest'), {...defaultContext(), templates: {combat: null}});
     const m4: MultiplayerState = {...initialMultiplayer, clientStatus: {
-      a: {type: 'STATUS', connected: false},
-      b: {type: 'STATUS', connected: true, numLocalPlayers: 1},
-      c: {type: 'STATUS', connected: true, numLocalPlayers: 2},
-      d: {type: 'STATUS', connected: true, numLocalPlayers: 1},
+      a: {type: 'STATUS', connected: false, aliveAdventurers: 10},
+      b: {type: 'STATUS', connected: true, numLocalPlayers: 1, aliveAdventurers: 1},
+      c: {type: 'STATUS', connected: true, numLocalPlayers: 2, aliveAdventurers: 0},
+      d: {type: 'STATUS', connected: true, numLocalPlayers: 1, aliveAdventurers: 1},
     }};
 
     describe('numAdventurers', () => {
@@ -29,9 +36,20 @@ describe('Settings action', () => {
       test('returns 1 for single-player mode', () => {
         expect(numPlayers(s, initialMultiplayer)).toEqual(1);
       });
-      test('sums up players across all connected sessions', () => {
+      test('sums up players across all connected devices', () => {
         expect(numPlayers(s, m4)).toEqual(4);
       });
+    });
+    describe('numAliveAdventurers', () => {
+      test('returns node value from single player mode', () => {
+        expect(numAliveAdventurers(s, n, initialMultiplayer)).toEqual(1);
+      });
+      test('sums up across all connected devices', () => {
+        expect(numAliveAdventurers(s, n, m4)).toEqual(2);
+      });
+      test('returns total adventurer count when invalid node', () => {
+        expect(numAliveAdventurers(s, n0, initialMultiplayer)).toEqual(2);
+      })
     });
     describe('playerOrder', () => {
       test('returns order from 1-6', () => {

--- a/services/app/src/actions/Settings.test.tsx
+++ b/services/app/src/actions/Settings.test.tsx
@@ -1,7 +1,7 @@
 import {initialMultiplayer} from 'app/reducers/Multiplayer';
 import {initialSettings} from 'app/reducers/Settings';
 import {MultiplayerState} from 'app/reducers/StateTypes';
-import {numAdventurers, numPlayers, playerOrder, numAliveAdventurers} from './Settings';
+import {numAdventurers, numPlayers, playerOrder, numAliveAdventurers, numLocalAdventurers} from './Settings';
 import {defaultContext} from '../components/views/quest/cardtemplates/Template';
 import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
 
@@ -30,6 +30,17 @@ describe('Settings action', () => {
       });
       test('sums up adventurers across all connected sessions', () => {
         expect(numAdventurers(s, m4)).toEqual(4);
+      });
+    });
+    describe('numLocalAdventurers', () => {
+      test('returns local adventurers', () => {
+        expect(numLocalAdventurers({...s, numLocalPlayers: 3}, m4)).toEqual(3);
+      });
+      test('returns 2 adventurers for singler-player mode', () => {
+        expect(numLocalAdventurers(s, initialMultiplayer)).toEqual(2);
+      });
+      test('returns 1 for multiplayer with single player on device', () => {
+        expect(numLocalAdventurers(s, m4)).toEqual(1);
       });
     });
     describe('numPlayers', () => {

--- a/services/app/src/actions/Settings.tsx
+++ b/services/app/src/actions/Settings.tsx
@@ -13,7 +13,6 @@ export function changeSettings(settings: any) {
 }
 
 export function numAliveAdventurers(settings: SettingsType, node: ParserNode, mp: MultiplayerState): number {
-  console.log(Boolean(mp.clientStatus));
   if (!mp || !mp.clientStatus || Object.keys(mp.clientStatus).length < 2) {
     const combat = node.ctx.templates.combat;
     if (!combat) {
@@ -33,16 +32,20 @@ export function numAliveAdventurers(settings: SettingsType, node: ParserNode, mp
   return count;
 }
 
-export function numAdventurers(settings: SettingsType, mp: MultiplayerState): number {
+export function numAdventurers(settings: SettingsType, mp?: MultiplayerState): number {
   if (!mp || !mp.clientStatus || Object.keys(mp.clientStatus).length < 2) {
     return numLocalAdventurers(settings);
   }
   return countAllPlayers(mp);
 }
 
-export function numLocalAdventurers(settings: SettingsType) {
-  // Since single player still has two adventurers, the minimum possible is two.
-  return Math.max(2, settings.numLocalPlayers);
+export function numLocalAdventurers(settings: SettingsType, mp?: MultiplayerState) {
+  if (!mp || !mp.clientStatus || Object.keys(mp.clientStatus).length < 2) {
+    // Since single player still has two adventurers, the minimum possible is two.
+    return Math.max(2, settings.numLocalPlayers);
+  }
+  // Multiplayer always has at least one other player, so there could be just one adventurer locally.
+  return settings.numLocalPlayers;
 }
 
 export function numPlayers(settings: SettingsType, mp?: MultiplayerState): number {

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
@@ -169,6 +169,12 @@ describe('Combat actions', () => {
     });
   });
 
+  describe('handleCombatTimerStart', () => {
+    test.skip('starts timer in pause state when 0 local alive adventurers in multiplayer', () => {
+      // TODO
+    });
+  });
+
   describe('handleCombatTimerStop', () => {
     const newStore = (overrides: any) => {
       const store = newMockStore({multiplayer: initialMultiplayer});

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
@@ -35,7 +35,7 @@ const TEST_SETTINGS = {
   vibration: true,
 };
 
-const TEST_RP = {
+const TEST_MP = {
   ...initialMultiplayer,
   clientStatus: {
     1: {
@@ -176,7 +176,7 @@ describe('Combat actions', () => {
   });
 
   describe('handleCombatTimerStop', () => {
-    const newStore = (overrides: any) => {
+    const runTest = (overrides: any) => {
       const store = newMockStore({multiplayer: initialMultiplayer});
       store.dispatch(handleCombatTimerStop({
         elapsedMillis: 1000,
@@ -190,19 +190,19 @@ describe('Combat actions', () => {
     };
 
     test('randomly assigns damage', () => {
-      const {actions} = newStore({});
+      const {actions} = runTest({});
       expect(actions[2].node.ctx.templates.combat.mostRecentAttack.damage).toBeDefined();
     });
     test('generates rolls according to player count', () => {
-      const {actions} = newStore({});
+      const {actions} = runTest({});
       expect(actions[2].node.ctx.templates.combat.mostRecentRolls.length).toEqual(3);
     });
     test('increments the round counter', () => {
-      const {actions} = newStore({});
+      const {actions} = runTest({});
       expect(actions[2].node.ctx.templates.combat.roundCount).toEqual(1);
     });
     test('only generates rolls for local, not remote, players', () => {
-      const {actions} = newStore({ rp: TEST_RP });
+      const {actions} = runTest({ multiplayer: TEST_MP });
       expect(actions[2].node.ctx.templates.combat.mostRecentRolls.length).toEqual(3);
     });
   });
@@ -244,11 +244,10 @@ describe('Combat actions', () => {
     });
 
     test('does not level up if multiplayer count exceeds tier sum', () => {
-      const store = newMockStore({settings: TEST_SETTINGS});
+      const store = newMockStore({settings: TEST_SETTINGS, multiplayer: TEST_MP});
       store.dispatch(handleCombatEnd({
         maxTier: 4,
         node: newCombatNode(),
-        rp: TEST_RP,
         seed: '',
         settings: TEST_SETTINGS,
         victory: true,
@@ -270,11 +269,10 @@ describe('Combat actions', () => {
       // Replace combat node elem with the roleplay node
       node.elem = node.elem.find('#start');
 
-      const store = newMockStore({settings: TEST_SETTINGS});
+      const store = newMockStore({settings: TEST_SETTINGS, multiplayer: TEST_MP});
       store.dispatch(handleCombatEnd({
         maxTier: 4,
         node,
-        rp: TEST_RP,
         seed: '',
         settings: TEST_SETTINGS,
         victory: true,
@@ -319,10 +317,6 @@ describe('Combat actions', () => {
     test('does not go below 0', () => {
       const node = Action(adventurerDelta).execute({node: newCombatNode(), settings: TEST_SETTINGS, current: 3, delta: -1000})[0].node;
       expect(node.ctx.templates.combat.numAliveAdventurers).toEqual(0);
-    });
-    test('does not go above the player count', () => {
-      const node = Action(adventurerDelta).execute({node: newCombatNode(), settings: TEST_SETTINGS, current: 2, delta: 1000})[0].node;
-      expect(node.ctx.templates.combat.numAliveAdventurers).toEqual(3);
     });
   });
 

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
@@ -32,8 +32,8 @@ export function findCombatParent(node: ParserNode): Cheerio|null {
   return elem;
 }
 
-export function roundTimeMillis(settings: SettingsType, rp?: MultiplayerState) {
-  const totalPlayerCount = numPlayers(settings, rp);
+export function roundTimeMillis(settings: SettingsType, mp?: MultiplayerState) {
+  const totalPlayerCount = numPlayers(settings, mp);
   return settings.timerSeconds * 1000 * PLAYER_TIME_MULT[totalPlayerCount];
 }
 
@@ -49,14 +49,14 @@ export function getEnemiesAndTier(node?: ParserNode): {enemies: Enemy[], tier: n
   return {enemies, tier};
 }
 
-export function generateCombatTemplate(settings: SettingsType, custom: boolean, node?: ParserNode): CombatState {
+export function generateCombatTemplate(settings: SettingsType, custom: boolean, node?: ParserNode, mp?: MultiplayerState): CombatState {
   const {enemies, tier} = getEnemiesAndTier(node);
 
   return {
     custom,
     decisionPhase: 'PREPARE_DECISION',
     enemies,
-    numAliveAdventurers: numLocalAdventurers(settings),
+    numAliveAdventurers: numLocalAdventurers(settings, mp),
     roundCount: 0,
     tier,
     ...getDifficultySettings(settings.difficulty),
@@ -68,9 +68,10 @@ interface InitCombatArgs {
   custom?: boolean;
 }
 export const initCombat = remoteify(function initCombat(a: InitCombatArgs, dispatch: Redux.Dispatch<any>,  getState: () => AppStateWithHistory) {
+  const mp = getState().multiplayer;
   a.node = a.node.clone();
   const settings = getState().settings;
-  a.node.ctx.templates.combat = generateCombatTemplate(settings, a.custom || false, a.node);
+  a.node.ctx.templates.combat = generateCombatTemplate(settings, a.custom || false, a.node, mp);
   const tierSum = a.node.ctx.templates.combat.tier;
   dispatch({type: 'PUSH_HISTORY'});
   dispatch({type: 'QUEST_NODE', node: a.node} as QuestNodeAction);
@@ -80,13 +81,9 @@ export const initCombat = remoteify(function initCombat(a: InitCombatArgs, dispa
 });
 
 interface InitCustomCombatArgs {
-  rp?: MultiplayerState;
   seed?: string;
 }
 export const initCustomCombat = remoteify(function initCustomCombat(a: InitCustomCombatArgs, dispatch: Redux.Dispatch<any>,  getState: () => AppStateWithHistory): InitCustomCombatArgs {
-  if (!a.rp) {
-    a.rp = getState().multiplayer;
-  }
   // Set seed if we got one from multiplayer
   const node = new ParserNode(cheerio.load('<combat></combat>')('combat'), defaultContext(), undefined, a.seed);
   dispatch(initCombat({custom: true, node}));
@@ -130,8 +127,8 @@ function getEnemies(node: ParserNode): Enemy[] {
   return enemies;
 }
 
-function generateCombatAttack(node: ParserNode, settings: SettingsType, rp: MultiplayerState, elapsedMillis: number, rng: () => number): CombatAttack {
-  const totalPlayerCount = numPlayers(settings, rp);
+function generateCombatAttack(node: ParserNode, settings: SettingsType, mp: MultiplayerState, elapsedMillis: number, rng: () => number): CombatAttack {
+  const totalPlayerCount = numPlayers(settings, mp);
   const playerMultiplier = PLAYER_DAMAGE_MULT[totalPlayerCount] || 1;
   const combat = node.ctx.templates.combat;
   if (!combat) {
@@ -141,7 +138,7 @@ function generateCombatAttack(node: ParserNode, settings: SettingsType, rp: Mult
 
   // enemies each get to hit once - 1.5x if the party took too long
   let attackCount = combat.tier;
-  const roundTime = roundTimeMillis(settings, rp);
+  const roundTime = roundTimeMillis(settings, mp);
   if (roundTime - elapsedMillis < 0) {
     attackCount = attackCount * 1.5;
   }
@@ -168,7 +165,7 @@ function generateCombatAttack(node: ParserNode, settings: SettingsType, rp: Mult
   // 4: 2
   // 5: 2.5
   // 6: 3
-  const aliveAdventurers = numAliveAdventurers(settings, node, rp);
+  const aliveAdventurers = numAliveAdventurers(settings, node, mp);
   if (aliveAdventurers === 1 && totalPlayerCount > 1 && combat.roundCount > 6) {
     attackCount = attackCount * Math.pow(1.2, combat.roundCount - 6);
   }
@@ -347,7 +344,6 @@ export const handleCombatTimerHold = remoteify(function handleCombatTimerHold(a:
 interface HandleCombatTimerStopArgs {
   elapsedMillis: number;
   node?: ParserNode;
-  rp?: MultiplayerState;
   seed: string;
   settings?: SettingsType;
 }
@@ -356,9 +352,7 @@ export const handleCombatTimerStop = remoteify(function handleCombatTimerStop(a:
     a.node = getState().quest.node;
     a.settings = getState().settings;
   }
-  if (!a.rp) {
-    a.rp = getState().multiplayer;
-  }
+  const mp = getState().multiplayer;
 
   dispatch(audioSet({peakIntensity: 0}));
 
@@ -366,10 +360,10 @@ export const handleCombatTimerStop = remoteify(function handleCombatTimerStop(a:
   const arng = seedrandom.alea(a.seed);
   let combat = a.node.ctx.templates.combat;
   if (!combat) {
-    combat = generateCombatTemplate(a.settings, false, a.node);
+    combat = generateCombatTemplate(a.settings, false, a.node, mp);
     a.node.ctx.templates.combat = combat;
   }
-  combat.mostRecentAttack = generateCombatAttack(a.node, a.settings, a.rp, a.elapsedMillis, arng);
+  combat.mostRecentAttack = generateCombatAttack(a.node, a.settings, mp, a.elapsedMillis, arng);
   combat.mostRecentRolls = generateRolls(numLocalAdventurers(a.settings), arng);
   combat.roundCount++;
 
@@ -399,7 +393,6 @@ export const handleCombatTimerStop = remoteify(function handleCombatTimerStop(a:
 interface HandleCombatEndArgs {
   maxTier: number;
   node?: ParserNode;
-  rp?: MultiplayerState;
   seed: string;
   settings: SettingsType;
   victory: boolean;
@@ -409,9 +402,7 @@ export const handleCombatEnd = remoteify(function handleCombatEnd(a: HandleComba
     a.node = getState().quest.node;
     a.settings = getState().settings;
   }
-  if (!a.rp) {
-    a.rp = getState().multiplayer;
-  }
+  const mp = getState().multiplayer;
 
   // If we were given a non-combat node due to some bug in previous code,
   // find its parent combat container and use it.
@@ -425,7 +416,7 @@ export const handleCombatEnd = remoteify(function handleCombatEnd(a: HandleComba
 
   let combat = a.node.ctx.templates.combat;
   if (!combat) {
-    combat = generateCombatTemplate(a.settings, false, a.node);
+    combat = generateCombatTemplate(a.settings, false, a.node, mp);
     a.node.ctx.templates.combat = combat;
   }
 
@@ -436,7 +427,7 @@ export const handleCombatEnd = remoteify(function handleCombatEnd(a: HandleComba
     combat.numAliveAdventurers = 0;
   }
   a.node = a.node.clone();
-  const adventurers = numAdventurers(a.settings, a.rp);
+  const adventurers = numAdventurers(a.settings, mp);
   combat.levelUp = (a.victory) ? (adventurers <= a.maxTier) : false;
 
   const arng = seedrandom.alea(a.seed);
@@ -459,11 +450,11 @@ export const tierSumDelta = remoteify(function tierSumDelta(a: TierSumDeltaArgs,
   if (!a.node) {
     a.node = getState().quest.node;
   }
-
+  const mp = getState().multiplayer;
   a.node = a.node.clone();
   let combat = a.node.ctx.templates.combat;
   if (!combat) {
-    combat = generateCombatTemplate(getState().settings, false, a.node);
+    combat = generateCombatTemplate(getState().settings, false, a.node, mp);
     a.node.ctx.templates.combat = combat;
   }
   combat.tier = Math.max(a.current + a.delta, 0);
@@ -481,18 +472,14 @@ interface AdventurerDeltaArgs {
   delta: number;
   node: ParserNode;
   settings: SettingsType;
-  rp?: MultiplayerState;
 }
 export const adventurerDelta = remoteify(function adventurerDelta(a: AdventurerDeltaArgs, dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory) {
-  if (!a.rp) {
-    a.rp = getState().multiplayer;
-  }
-
-  const newAdventurerCount = Math.min(Math.max(0, a.current + a.delta), numAdventurers(a.settings, a.rp));
+  const mp = getState().multiplayer;
+  const newAdventurerCount = Math.min(Math.max(0, a.current + a.delta), numLocalAdventurers(a.settings, mp));
   a.node = a.node.clone();
   let combat = a.node.ctx.templates.combat;
   if (!combat) {
-    combat = generateCombatTemplate(getState().settings, false, a.node);
+    combat = generateCombatTemplate(getState().settings, false, a.node, mp);
     a.node.ctx.templates.combat = combat;
   }
   combat.numAliveAdventurers = newAdventurerCount;
@@ -514,11 +501,11 @@ interface SetupCombatDecisionArgs {
 export const setupCombatDecision = remoteify(function setupCombatDecision(a: SetupCombatDecisionArgs, dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory): SetupCombatDecisionArgs {
   const {node, combat} = resolveParams(a.node, getState);
   const settings = getState().settings;
-  const rp = getState().multiplayer;
+  const mp = getState().multiplayer;
   combat.decisionPhase = 'PREPARE_DECISION';
   const arng = seedrandom.alea(a.seed);
   node.ctx.templates.decision = {
-    leveledChecks: generateLeveledChecks(numAdventurers(settings, rp), arng),
+    leveledChecks: generateLeveledChecks(numAdventurers(settings, mp), arng),
     selected: null,
     rolls: [],
   };

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.test.tsx
@@ -1,4 +1,43 @@
+import {mount, unmountAll} from 'app/Testing';
+import * as React from 'react';
+import PlayerTier, { Props } from './PlayerTier';
+import {initialSettings} from 'app/reducers/Settings';
+
+describe('PlayerTier', () => {
+  afterEach(unmountAll);
+
+  function setup(overrides?: Props) {
+    const props: Props = {
+      settings: initialSettings,
+      adventurers: 3,
+      combat: {
+        mostRecentAttack: {damage: 3},
+        roundCount: 2,
+      },
+      maxTier: 0,
+      numAliveAdventurers: 3,
+      localAliveAdventurers: 2,
+      seed: 'asdf',
+      tier: 0,
+      onAdventurerDelta: jasmine.createSpy('onAdventurerDelta'),
+      onDecisionSetup: jasmine.createSpy('onDecisionSetup'),
+      onDefeat: jasmine.createSpy('onDefeat'),
+      onNext: jasmine.createSpy('onNext'),
+      onTierSumDelta: jasmine.createSpy('onTierSumDelta'),
+      onVictory: jasmine.createSpy('onVictory'),
+      ...overrides,
+    };
+    const e = mount(<PlayerTier {...props} />);
+    return {e, props};
+  }
+
+
 describe('Combat PlayerTier', () => {
   test.skip('starts at current player and tier count', () => { /* TODO */ });
-  test.skip('shows total alive player count along with local alive player count', () => { /* TODO */ });
+  test('shows total alive player count along with local alive player count', () => {
+    const {e} = setup();
+    const text = e.find("Picker#adventurers").text();
+    expect(text).toContain('Adventurers: 2');
+    expect(text).toContain('3 across all devices');
+  });
 });

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.test.tsx
@@ -1,3 +1,4 @@
 describe('Combat PlayerTier', () => {
   test.skip('starts at current player and tier count', () => { /* TODO */ });
+  test.skip('shows total alive player count along with local alive player count', () => { /* TODO */ });
 });

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.tsx
@@ -14,6 +14,7 @@ export interface StateProps extends StatePropsBase {
   combat: CombatState;
   maxTier: number;
   numAliveAdventurers: number;
+  localAliveAdventurers: number;
   seed: string;
   tier: number;
 }
@@ -40,7 +41,7 @@ export default function playerTier(props: Props): JSX.Element {
   let helpText: JSX.Element = (<span></span>);
   const damage = (props.combat.mostRecentAttack) ? props.combat.mostRecentAttack.damage : -1;
   const theHorror = (props.settings.contentSets.horror === true);
-  const injured = props.numAliveAdventurers < props.adventurers;
+  const injured = props.localAliveAdventurers < props.adventurers;
 
   if (props.settings.showHelp) {
     helpText = (
@@ -68,9 +69,12 @@ export default function playerTier(props: Props): JSX.Element {
       <Picker
         label="Adventurers"
         id="adventurers"
-        onDelta={(i: number) => props.onAdventurerDelta(props.node, props.settings, props.numAliveAdventurers, i)}
-        value={props.numAliveAdventurers}>
-        {props.settings.showHelp && <span>The number of adventurers &gt; 0 health.</span>}
+        onDelta={(i: number) => props.onAdventurerDelta(props.node, props.settings, props.localAliveAdventurers, i)}
+        value={props.localAliveAdventurers}>
+        {props.settings.showHelp && (props.numAliveAdventurers === props.localAliveAdventurers)
+          ? <span>The number of adventurers &gt; 0 health.</span>
+          : <span>Local adventurers &gt; 0 health.<br/>({props.numAliveAdventurers} across all devices)</span>
+        }
       </Picker>
       {helpText}
       <Button

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
@@ -1,5 +1,5 @@
 import {toCard} from 'app/actions/Card';
-import {numAdventurers, numPlayers} from 'app/actions/Settings';
+import {numAdventurers, numAliveAdventurers, numPlayers} from 'app/actions/Settings';
 import {logEvent} from 'app/Logging';
 import {AppStateWithHistory, SettingsType} from 'app/reducers/StateTypes';
 import {connect} from 'react-redux';
@@ -47,7 +47,8 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
     adventurers: numAdventurers(state.settings, state.multiplayer),
     combat: resolveCombat(node),
     maxTier,
-    numAliveAdventurers: stateCombat.numAliveAdventurers,
+    numAliveAdventurers: numAliveAdventurers(state.settings, node, state.multiplayer),
+    localAliveAdventurers: stateCombat.numAliveAdventurers,
     tier: stateCombat.tier,
   };
 };

--- a/shared/multiplayer/Events.tsx
+++ b/shared/multiplayer/Events.tsx
@@ -33,6 +33,10 @@ export interface StatusEvent {
   // Count of players playing on this client - used for e.g. damage calculation
   numLocalPlayers?: number;
 
+  // The number of alive adventurers - used for updating UI and calculating
+  // actions based on living adventurer count.
+  aliveAdventurers?: number;
+
   // The last seen event ID from the client. This is used to keep
   // the client in sync.
   lastEventID?: number;


### PR DESCRIPTION
Fixes #560 by adding `aliveAdventurers` to the multiplayer status event and changing the UI so that:
- Incrementing or decrementing alive adventurers locally doesn't affect the local counts on other devices, but does affect the global count.
- Starting the timer (from any device) causes all devices with zero alive local adventurers to start in "paused" mode, waiting for devices that still have living adventurers.

The added status field is a prereq for #559.

Additional fixes: 

- Renamed `rp` to `mp` in tests and elsewhere where discovered
- Switched combat actions to not require passing in multiplayer state - it's just always fetched from the store directly.

![combat_mp_advcount](https://user-images.githubusercontent.com/607666/49194188-1f212800-f350-11e8-9131-67951fdc382e.gif)
