### PR TITLE
Fix return behavior when just after splash screen

### DIFF
--- a/services/app/src/reducers/CombinedReducers.test.tsx
+++ b/services/app/src/reducers/CombinedReducers.test.tsx
@@ -30,5 +30,12 @@ describe('CombinedReducers', () => {
           card: {name: 'QUEST_CARD'} // Does not persist
         }));
     });
+    test('does nothing when no history', () => {
+      const result = setup({_history: []}).execute({type: 'RETURN'});
+      expect(result).toEqual(jasmine.objectContaining({
+          commitID: 6,
+          card: {name: 'SPLASH_CARD'}
+        }));
+    })
   });
 });

--- a/services/app/src/reducers/CombinedReducers.tsx
+++ b/services/app/src/reducers/CombinedReducers.tsx
@@ -67,6 +67,7 @@ export default function combinedReducerWithHistory(state: AppStateWithHistory, a
         } else if (navigator.device) {
             navigator.device.exitApp();
         }
+        return state;
       }
 
       let pastStateIdx: number = state._history.length - 1;


### PR DESCRIPTION
Sometimes users can cause a RETURN action to be dispatched on the splash page by rapidly tapping the flyout menu, resulting in an exception of "Cannot read property 'name' of undefined".

#561