### PR TITLE
Proper multiplayer behavior on reviewing end of quest

### DIFF
--- a/services/api/src/models/migrations/2018_12_01 feedback stats.sql
+++ b/services/api/src/models/migrations/2018_12_01 feedback stats.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feedback ADD COLUMN "stats" TEXT DEFAULT '';

--- a/services/api/src/multiplayer/Sessions.test.ts
+++ b/services/api/src/multiplayer/Sessions.test.ts
@@ -1,0 +1,58 @@
+import {resetSessions, getSession, initSessionClient, setClientStatus, rmSessionClient} from './Sessions';
+import {newMockWebsocket} from './TestData';
+import {toClientKey} from 'shared/multiplayer/Session';
+
+const CLI = "asdf";
+const INST = "ghjk";
+const KEY = toClientKey(CLI, INST);
+
+describe('Multiplayer Sessions', () => {
+  afterEach(resetSessions);
+
+  describe('getSession', () => {
+    test('gets a session', () => {
+      initSessionClient(123, CLI, INST, null);
+      expect(getSession(123)).not.toEqual(null);
+    });
+    test('returns null if no match', () => {
+      expect(getSession(123)).toEqual(null);
+    });
+  });
+
+  describe('initSessionClient', () => {
+    test('initializes a client within a session', () => {
+      const socket = newMockWebsocket();
+      initSessionClient(123, CLI, INST, socket);
+      expect(getSession(123)[KEY]).toEqual(jasmine.objectContaining({socket}));
+    });
+  });
+
+  describe('setClientStatus', () => {
+    test('sets the status for a client', () => {
+      const status = {type: 'STATUS', name: 'test'};
+      initSessionClient(123, CLI, INST, null);
+      setClientStatus(123, CLI, INST, null, status);
+      expect(getSession(123)[KEY]).toEqual(jasmine.objectContaining({status}));
+    });
+
+    test('inits client if not present in session map', () => {
+      const status = {type: 'STATUS', name: 'test'};
+      setClientStatus(123, CLI, INST, null, status);
+      expect(getSession(123)[KEY]).toEqual(jasmine.objectContaining({status}));
+    });
+  });
+
+  describe('rmSessionClient', () => {
+    test('removes a client from a session', () => {
+      initSessionClient(123, CLI, INST, null);
+      rmSessionClient(123, CLI, INST);
+      expect(getSession(123)[KEY]).not.toBeDefined();
+    });
+    test('does nothing if client does not exist in session', () => {
+      initSessionClient(123, CLI, 'differentinstance', null);
+      rmSessionClient(123, CLI, INST);
+      expect(getSession(123)[KEY]).not.toBeDefined();
+    });
+  });
+
+});

--- a/services/api/src/multiplayer/Sessions.ts
+++ b/services/api/src/multiplayer/Sessions.ts
@@ -2,9 +2,16 @@ import {StatusEvent} from 'shared/multiplayer/Events';
 import {toClientKey} from 'shared/multiplayer/Session';
 import * as WebSocket from 'ws';
 
-export interface SessionClient {socket: WebSocket, status: StatusEvent|null, client: string, instance: string}
+export interface SessionClient {
+  socket: WebSocket;
+  status: StatusEvent|null;
+  client: string;
+  instance: string;
+}
 
-export interface InMemorySession {[clientAndInstance: string]: SessionClient}
+export interface InMemorySession {
+  [clientAndInstance: string]: SessionClient;
+}
 
 let inMemorySessions: {[session: number]: InMemorySession} = {};
 

--- a/services/api/src/multiplayer/Sessions.ts
+++ b/services/api/src/multiplayer/Sessions.ts
@@ -1,0 +1,50 @@
+import {StatusEvent} from 'shared/multiplayer/Events';
+import {toClientKey} from 'shared/multiplayer/Session';
+import * as WebSocket from 'ws';
+
+export interface SessionClient {socket: WebSocket, status: StatusEvent|null, client: string, instance: string}
+
+export interface InMemorySession {[clientAndInstance: string]: SessionClient}
+
+let inMemorySessions: {[session: number]: InMemorySession} = {};
+
+export function getSession(session: number): InMemorySession|null {
+  return inMemorySessions[session] || null;
+}
+
+export function initSessionClient(session: number, client: string, instance: string, socket: WebSocket): SessionClient {
+  if (!inMemorySessions[session]) {
+    inMemorySessions[session] = {};
+  }
+  inMemorySessions[session][toClientKey(client, instance)] = {
+    client,
+    instance,
+    socket,
+    status: null,
+  };
+  return inMemorySessions[session][toClientKey(client, instance)];
+}
+
+export function setClientStatus(session: number, client: string, instance: string, socket: WebSocket, status: StatusEvent): SessionClient {
+  if (!inMemorySessions[session]) {
+    inMemorySessions[session] = {};
+  }
+  const s = getSession(session);
+  if (!s || !s[toClientKey(client, instance)]) {
+    initSessionClient(session, client, instance, socket);
+  }
+  const cli = (s || {})[toClientKey(client, instance)];
+  cli.status = status;
+  return cli;
+}
+
+export function rmSessionClient(session: number, client: string, instance: string) {
+  if (!(getSession(session) || {})[toClientKey(client, instance)]) {
+    return;
+  }
+  delete inMemorySessions[session][toClientKey(client, instance)];
+}
+
+export function resetSessions() {
+  inMemorySessions = {};
+}

--- a/services/api/src/multiplayer/TestData.ts
+++ b/services/api/src/multiplayer/TestData.ts
@@ -1,0 +1,7 @@
+
+export function newMockWebsocket() {
+  return {
+    readyState: WebSocket.OPEN,
+    send: jasmine.createSpy('send'),
+  };
+}

--- a/services/api/src/multiplayer/WaitingOn.test.ts
+++ b/services/api/src/multiplayer/WaitingOn.test.ts
@@ -1,0 +1,96 @@
+import {resetSessions, setClientStatus} from './Sessions';
+import {newMockWebsocket} from './TestData';
+import {handleWaitingOnTimer, handleWaitingOnReview} from './WaitingOn';
+
+const CLI1 = "asdf";
+const INST1 = "ghjk";
+const CLI2 = "zxcv";
+const INST2 = "bnm";
+const SESSION = 123;
+
+describe('Multiplayer WaitingOn', () => {
+
+  afterEach(resetSessions);
+
+  describe('handleWaitingOnTimer', () => {
+    test('triggers handleCombatTimerStop when all waiting on TIMER', (done) => {
+      setClientStatus(SESSION, CLI1, INST1, null, {type: 'STATUS', waitingOn: {elapsedMillis: 500, type: 'TIMER'}});
+      setClientStatus(SESSION, CLI2, INST2, null, {type: 'STATUS', waitingOn: {elapsedMillis: 800, type: 'TIMER'}});
+      const commitAndBroadcast = jasmine.createSpy('commitAndBroadcast').and.returnValue(Promise.resolve());
+
+      handleWaitingOnTimer(null, SESSION, CLI2, INST2, commitAndBroadcast).then(() => {
+        expect(commitAndBroadcast).toHaveBeenCalledWith(null, SESSION, CLI2, INST2, jasmine.objectContaining({name: 'handleCombatTimerStop'}));
+        done();
+      }).catch(done.fail);
+    });
+
+    test('does nothing when not all waiting on TIMER', (done) => {
+      setClientStatus(SESSION, CLI1, INST1, null, {type: 'STATUS', waitingOn: {elapsedMillis: 500, type: 'TIMER'}});
+      setClientStatus(SESSION, CLI2, INST2, null, {type: 'STATUS', waitingOn: undefined});
+      const commitAndBroadcast = jasmine.createSpy('commitAndBroadcast').and.returnValue(Promise.resolve());
+
+      handleWaitingOnTimer(null, SESSION, CLI2, INST2, commitAndBroadcast).then(() => {
+        expect(commitAndBroadcast).not.toHaveBeenCalled();
+        done();
+      }).catch(done.fail);
+    });
+
+    test('broadcasts error on commit fail', (done) => {
+      const ws1 = newMockWebsocket();
+      setClientStatus(SESSION, CLI1, INST1, ws1, {type: 'STATUS', waitingOn: {elapsedMillis: 500, type: 'TIMER'}});
+      const ws2 = newMockWebsocket();
+      setClientStatus(SESSION, CLI2, INST2, ws2, {type: 'STATUS', waitingOn: {elapsedMillis: 800, type: 'TIMER'}});
+      const commitAndBroadcast = () => {
+        return new Promise((a, b) => throw new Error('test error'));
+      }
+
+      handleWaitingOnTimer(null, SESSION, CLI2, INST2, commitAndBroadcast).then(() => {
+        expect(ws1.send).toHaveBeenCalled();
+        expect(ws1.send.calls.first().args[0]).toContain('test error');
+        done();
+      }).catch(done.fail);
+    });
+  });
+
+  describe('handleWaitingOnReview', () => {
+    test('exits quest when all waiting on REVIEW', (done) => {
+      setClientStatus(SESSION, CLI1, INST1, null, {type: 'STATUS', waitingOn: {elapsedMillis: 500, type: 'REVIEW'}});
+      setClientStatus(SESSION, CLI2, INST2, null, {type: 'STATUS', waitingOn: {elapsedMillis: 800, type: 'REVIEW'}});
+      const commitAndBroadcast = jasmine.createSpy('commitAndBroadcast').and.returnValue(Promise.resolve());
+
+      handleWaitingOnReview(null, SESSION, CLI2, INST2, commitAndBroadcast).then(() => {
+        for (const name of ['exitQuest', 'toPrevious']) {
+          expect(commitAndBroadcast).toHaveBeenCalledWith(null, SESSION, CLI2, INST2, jasmine.objectContaining({name}));
+        }
+        done();
+      }).catch(done.fail);
+    });
+
+    test('does nothing when not all waiting on REVIEW', (done) => {
+      setClientStatus(SESSION, CLI1, INST1, null, {type: 'STATUS', waitingOn: {elapsedMillis: 500, type: 'REVIEW'}});
+      setClientStatus(SESSION, CLI2, INST2, null, {type: 'STATUS', waitingOn: undefined});
+      const commitAndBroadcast = jasmine.createSpy('commitAndBroadcast').and.returnValue(Promise.resolve());
+
+      handleWaitingOnReview(null, SESSION, CLI2, INST2, commitAndBroadcast).then(() => {
+        expect(commitAndBroadcast).not.toHaveBeenCalled();
+        done();
+      }).catch(done.fail);
+    });
+
+    test('broadcasts error on commit fail', (done) => {
+      const ws1 = newMockWebsocket();
+      setClientStatus(SESSION, CLI1, INST1, ws1, {type: 'STATUS', waitingOn: {elapsedMillis: 500, type: 'REVIEW'}});
+      const ws2 = newMockWebsocket();
+      setClientStatus(SESSION, CLI2, INST2, ws2, {type: 'STATUS', waitingOn: {elapsedMillis: 800, type: 'REVIEW'}});
+      const commitAndBroadcast = () => {
+        return new Promise((a, b) => throw new Error('test error'));
+      }
+
+      handleWaitingOnReview(null, SESSION, CLI2, INST2, commitAndBroadcast).then(() => {
+        expect(ws1.send).toHaveBeenCalled();
+        expect(ws1.send.calls.first().args[0]).toContain('test error');
+        done();
+      }).catch(done.fail);
+    });
+  });
+});

--- a/services/api/src/multiplayer/WaitingOn.ts
+++ b/services/api/src/multiplayer/WaitingOn.ts
@@ -1,0 +1,66 @@
+import * as Promise from 'bluebird';
+import {ActionEvent, ClientID, TimerWait, WaitType} from 'shared/multiplayer/Events';
+import {Database} from '../models/Database';
+import {commitAndBroadcastAction} from '../models/multiplayer/Events';
+import {getSession} from './Sessions';
+import {broadcastError} from './Websockets';
+
+function allWaitingOn(session: number, type: string, map?: (w: WaitType) => any): boolean {
+  let waitCount: number = 0;
+  const s = getSession(session) || {};
+  for (const c of Object.keys(s)) {
+    const sc = s[c];
+    if (!sc || sc.status === null) {
+      continue;
+    }
+
+    const wo: WaitType|undefined = sc.status.waitingOn;
+    if (!wo || wo.type !== type) {
+      continue;
+    }
+
+    waitCount += 1;
+    if (map) {
+      map(wo);
+    }
+  }
+  return waitCount === Object.keys(s).length;
+}
+
+export function handleWaitingOnTimer(db: Database, session: number, client: ClientID, instance: string, commitAndBroadcast= commitAndBroadcastAction): Promise<void> {
+  let maxElapsedMillis = 0;
+  const allWaiting = allWaitingOn(session, 'TIMER', (w) => {
+    maxElapsedMillis = Math.max(maxElapsedMillis, (w as TimerWait).elapsedMillis);
+  });
+
+  // Do nothing if not everyone is waiting for timer resolution
+  if (!allWaiting) {
+    return Promise.resolve();
+  }
+
+  return commitAndBroadcast(db, session, client, instance, {
+      args: JSON.stringify({elapsedMillis: maxElapsedMillis, seed: Date.now()}),
+      name: 'handleCombatTimerStop',
+      type: 'ACTION',
+    } as ActionEvent)
+    .catch((error: Error) => broadcastError(session, error));
+}
+
+export function handleWaitingOnReview(db: Database, session: number, client: ClientID, instance: string, commitAndBroadcast= commitAndBroadcastAction): Promise<void> {
+  // Do nothing if not everyone is waiting for review resolution
+  if (!allWaitingOn(session, 'REVIEW')) {
+    return Promise.resolve();
+  }
+
+  return commitAndBroadcast(db, session, client, instance, {
+      args: JSON.stringify({skip: [{name: 'QUEST_CARD'}, {name: 'QUEST_SETUP'}]}),
+      name: 'toPrevious',
+      type: 'ACTION',
+    } as ActionEvent)
+    .then(() => commitAndBroadcast(db, session, client, instance, {
+      args: JSON.stringify({}),
+      name: 'exitQuest',
+      type: 'ACTION',
+    } as ActionEvent))
+    .catch((error: Error) => broadcastError(session, error));
+}

--- a/services/api/src/multiplayer/Websockets.test.ts
+++ b/services/api/src/multiplayer/Websockets.test.ts
@@ -1,3 +1,38 @@
+import {resetSessions, initSessionClient} from './Sessions';
+import {broadcast, broadcastError} from './Websockets';
+import {newMockWebsocket} from './TestData';
+
 describe('Websockets', () => {
-  test.skip('Sets up websocket handler on new connection', () => { /* TODO */ });
+
+  afterEach(resetSessions);
+
+  describe('setupWebsockets', () => {
+    test.skip('Sets up websocket handler on new connection', () => { /* TODO */ });
+  });
+
+  describe('broadcast', () => {
+    test('sends to all connected peers within a session', () => {
+      const ws1 = newMockWebsocket();
+      initSessionClient(123, 'abc', 'def', ws1);
+      const ws2 = newMockWebsocket();
+      initSessionClient(123, 'zxc', 'vbn', ws2);
+      broadcast(123, 'testing');
+      for (const ws of [ws1, ws2]) {
+        expect(ws.send).toHaveBeenCalledWith('testing', jasmine.any(Function));
+      }
+    });
+  });
+
+  describe('broadcastError', () => {
+    test('sends to all connected peers within a session', () => {
+      const ws1 = newMockWebsocket();
+      initSessionClient(123, 'abc', 'def', ws1);
+      const ws2 = newMockWebsocket();
+      initSessionClient(123, 'zxc', 'vbn', ws2);
+      broadcastError(123, new Error('test error'));
+      for (const ws of [ws1, ws2]) {
+        expect(ws.send.calls.mostRecent().args[0]).toContain('test error');
+      }
+    });
+  })
 });

--- a/services/app/src/Testing.tsx
+++ b/services/app/src/Testing.tsx
@@ -21,8 +21,7 @@ interface MockStore extends Redux.Store {
   getActions: any;
 }
 
-export function newMockStore(state: object): MockStore {
-  const client = new Connection();
+export function newMockStore(state: object, client= new Connection()): MockStore {
   // Since this is a testing function, we play it a bit loose with the state type.
   const store = configureStore<AppStateWithHistory>([createMiddleware(client)])(state as any as AppStateWithHistory);
   (store as any).multiplayerClient = client;
@@ -79,8 +78,7 @@ export function Reducer<A extends Redux.Action>(reducer: (state: object|undefine
   };
 }
 
-export function Action<A>(action: (...a: any[]) => Redux.Action, baseState?: object) {
-  const client = new Connection();
+export function Action<A>(action: (...a: any[]) => Redux.Action, baseState?: object, client= new Connection()) {
   client.sendEvent = jasmine.createSpy('sendEvent');
   setMultiplayerConnection(client);
   let store = configureStore<AppStateWithHistory>([createMiddleware(client)])((baseState as any as AppStateWithHistory) ||  defaultGlobalState);

--- a/services/app/src/actions/Multiplayer.test.tsx
+++ b/services/app/src/actions/Multiplayer.test.tsx
@@ -17,6 +17,7 @@ import {
 import {MULTIPLAYER_SETTINGS} from '../Constants';
 import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {defaultContext} from '../components/views/quest/cardtemplates/Template';
+import {fakeConnection} from '../multiplayer/Testing';
 
 var cheerio = require('cheerio');
 
@@ -35,22 +36,6 @@ const mockResponse = (status, statusText, response) => {
   };
 };
 
-function fakeConnection() {
-  return {
-    registerEventRouter: jasmine.createSpy('registerEventRouter'),
-    getClientKey: jasmine.createSpy('getClientKey'),
-    sendEvent: jasmine.createSpy('sendEvent'),
-    hasInFlight: jasmine.createSpy('hasInFlight'),
-    getClientAndInstance: jasmine.createSpy('getClientAndInstance').and.returnValue([123,456]),
-    committedEvent: jasmine.createSpy('committedEvent'),
-    rejectedEvent: jasmine.createSpy('rejectedEvent'),
-    publish: jasmine.createSpy('publish'),
-    sync: jasmine.createSpy('sync'),
-    subscribe: jasmine.createSpy('subscribe'),
-    unsubscribe: jasmine.createSpy('unsubscribe'),
-  };
-}
-
 // Fake "connected" multiplayer state
 const multiplayer = {
   ...initialMultiplayer,
@@ -58,8 +43,6 @@ const multiplayer = {
   client: "abc",
   instance: "def",
 };
-
-
 
 describe('Multiplayer actions', () => {
   let oldFetch: any;

--- a/services/app/src/actions/Multiplayer.tsx
+++ b/services/app/src/actions/Multiplayer.tsx
@@ -121,6 +121,9 @@ export function loadMultiplayer(user: UserState, fetch: any = window.fetch) {
 export function setMultiplayerStatus(ev: StatusEvent, c= getMultiplayerConnection()) {
   return (dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory): any => {
     const {multiplayer} = getState();
+    if (!multiplayer) {
+      return;
+    }
     dispatch(sendStatus(undefined, undefined, ev, c));
     dispatch({
       client: multiplayer.client,

--- a/services/app/src/actions/Quest.test.tsx
+++ b/services/app/src/actions/Quest.test.tsx
@@ -4,10 +4,14 @@ import {initialQuestState} from '../reducers/Quest';
 import {initialSettings} from '../reducers/Settings';
 import {loggedOutUser} from '../reducers/User';
 import {Action} from '../Testing';
-import {endQuest, initQuest} from './Quest';
+import {exitQuest, endQuest, initQuest} from './Quest';
+import {fakeConnection} from '../multiplayer/Testing';
+import {initialMultiplayer} from '../reducers/Multiplayer';
 
 const cheerio = require('cheerio') as CheerioAPI;
 const fetchMock = require('fetch-mock');
+
+
 
 describe('Quest actions', () => {
   describe('initQuest', () => {
@@ -48,6 +52,21 @@ describe('Quest actions', () => {
         quest: {details: initialQuestState},
       }).execute({});
       expect(fetchMock.called(matcher)).toEqual(true);
+    });
+  });
+
+  describe('exitQuest', () => {
+    test('clears waitingOn', () => {
+      const c = fakeConnection();
+      const a = Action(exitQuest, {
+        multiplayer: {
+          ...initialMultiplayer,
+          connected: true,
+          client: "abc",
+          instance: "def",
+        },
+      }, c).execute();
+      expect(c.sendEvent).toHaveBeenCalledWith(jasmine.objectContaining({type: 'STATUS', waitingOn: undefined}), undefined);
     });
   });
 });

--- a/services/app/src/actions/Quest.tsx
+++ b/services/app/src/actions/Quest.tsx
@@ -11,6 +11,7 @@ import {
   QuestNodeAction,
 } from './ActionTypes';
 import {toCard} from './Card';
+import {setMultiplayerStatus} from './Multiplayer';
 import {logQuestPlay} from './Web';
 
 export function initQuestNode(questNode: Cheerio, ctx: TemplateContext): ParserNode {
@@ -27,6 +28,12 @@ export function initQuest(details: Quest, questNode: Cheerio, ctx: TemplateConte
 }
 
 export const exitQuest = remoteify(function exitQuest(a: any, dispatch: Redux.Dispatch<any>) {
+  // In case we're playing multiplayer, clear waitingOn state to indicate we're no longer
+  // waiting e.g. for reviews from other players.
+  dispatch(setMultiplayerStatus({
+    type: 'STATUS',
+    waitingOn: undefined,
+  }));
   dispatch({type: 'QUEST_EXIT'} as QuestExitAction);
 });
 

--- a/services/app/src/multiplayer/Testing.test.tsx
+++ b/services/app/src/multiplayer/Testing.test.tsx
@@ -1,0 +1,3 @@
+describe('Counters', () => {
+  test('None', () => { /* nothing to do here, yet */ });
+});

--- a/services/app/src/multiplayer/Testing.tsx
+++ b/services/app/src/multiplayer/Testing.tsx
@@ -1,0 +1,17 @@
+
+export function fakeConnection() {
+  return {
+    getMaxBufferID: jasmine.createSpy('getMaxBufferID').and.returnValue(null),
+    registerEventRouter: jasmine.createSpy('registerEventRouter'),
+    getClientKey: jasmine.createSpy('getClientKey'),
+    sendEvent: jasmine.createSpy('sendEvent'),
+    hasInFlight: jasmine.createSpy('hasInFlight'),
+    getClientAndInstance: jasmine.createSpy('getClientAndInstance').and.returnValue([123, 456]),
+    committedEvent: jasmine.createSpy('committedEvent'),
+    rejectedEvent: jasmine.createSpy('rejectedEvent'),
+    publish: jasmine.createSpy('publish'),
+    sync: jasmine.createSpy('sync'),
+    subscribe: jasmine.createSpy('subscribe'),
+    unsubscribe: jasmine.createSpy('unsubscribe'),
+  };
+}

--- a/shared/multiplayer/Events.tsx
+++ b/shared/multiplayer/Events.tsx
@@ -15,7 +15,14 @@ export interface TouchList {[id: string]: number[]; }
 // ------ Events (Passed Client-to-Client) --------
 
 // StatusEvent is published by a client to indicate some change in state.
-export interface WaitType {type: 'TIMER'; elapsedMillis: number; }
+export interface TimerWait {
+  type: 'TIMER';
+  elapsedMillis: number;
+}
+export interface ReviewWait {
+  type: 'REVIEW';
+}
+export type WaitType = TimerWait|ReviewWait;
 export interface StatusEvent {
   type: 'STATUS';
 


### PR DESCRIPTION
Fixes #557

- Includes a refactor of API multiplayer code so it could be tested. 
  - The original multiplayer Handlers file was partially split off into a Sessions file (containing inmemory websocket sessions) and WaitingOn, which handles synchronizing between devices and acting when all devices are at the same state.
  - Common `broadcast` and `broadcastError` methods are upstreamed to the Websockets file.
- In the app, testing functions like `Action` now allow passing of a multiplayer connection into the test rig, to make it easier to check if connection actions were applied.
- Updated `<QuestEnd/>` to wait until all devices have acted on the end state before moving forward. This adds a new "ReviewWait" waitingOn type, behavior in the API to fire actions when all clients have acted, and additional behavior when finally navigating away from the quest end card to clear the waitingOn state.