### PR TITLE
Add crawler check for invalid transition between two combats

### DIFF
--- a/scripts/meta.test.js
+++ b/scripts/meta.test.js
@@ -154,4 +154,15 @@ describe('Typescript files', () => {
     }
     expect(violations).toEqual([]);
   });
+
+  test('never contain test.only', () => {
+    let violations = [];
+    for (let f of FILES) {
+      const body = fs.readFileSync(f);
+      if (body.indexOf('test.only') !== -1) {
+        violations.push(f);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
 });

--- a/services/api/src/Handlers.test.ts
+++ b/services/api/src/Handlers.test.ts
@@ -282,7 +282,7 @@ describe('handlers', () => {
         .then((db) => loadQuestData(db, mockReq({params: {quest: qd.basic.id, edittime: qd.basic.edittime}}), res))
         .then(() => {
           expect(res.status.getCall(0).args[0]).toEqual(200);
-          expect(JSON.parse(res.end.getCall(0).args[0])).toEqual({data: qd.basic.data, notes: qd.basic.notes, metadata: JSON.parse(qd.basic.metadata), edittime: qd.basic.edittime});
+          expect(JSON.parse(res.end.getCall(0).args[0])).toEqual({data: qd.basic.data, notes: qd.basic.notes, metadata: JSON.parse(qd.basic.metadata)});
           done();
         })
         .catch(done.fail);
@@ -301,7 +301,7 @@ describe('handlers', () => {
   });
 
   describe('saveQuestData', () => {
-    test.only('notifies when other client is editing quest', (done) => {
+    test('notifies when other client is editing quest', (done) => {
       const res = mockRes();
       res.locals.id = qd.basic.userid;
       testingDBWithState([qd.basic])

--- a/services/api/src/models/QuestData.test.ts
+++ b/services/api/src/models/QuestData.test.ts
@@ -124,5 +124,15 @@ describe('quest', () => {
       })
       .catch(done.fail);
     });
+    test('returns null if no quest data', (done) => {
+      testingDBWithState([]).then((tdb) => {
+        return claimNewestQuestData(tdb, qd.basic.id, qd.basic.userid, new Date());
+      })
+      .then((result) => {
+        expect(result).toEqual(null);
+        done();
+      })
+      .catch(done.fail);
+    });
   });
 });

--- a/services/api/src/models/QuestData.ts
+++ b/services/api/src/models/QuestData.ts
@@ -37,14 +37,14 @@ export function saveQuestData(db: Database, data: QuestData, now: number = Date.
 
 }
 
-export function claimNewestQuestData(db: Database, id: string, userid: string, edittime: Date): Bluebird<QuestData> {
-  let result: QuestData;
+export function claimNewestQuestData(db: Database, id: string, userid: string, edittime: Date): Bluebird<QuestData|null> {
+  let result: QuestData|null = null;
   return db.questData.findOne({
     where: {id, userid, tombstone: null},
     order: [['created', 'DESC']],
   }).then((i: QuestDataInstance|null) => {
     if (i === null) {
-      throw new Error('No quest data found');
+      return Promise.resolve(null);
     }
     result = new QuestData((i) ? i.dataValues : {});
     result.edittime = edittime;

--- a/services/quests/errors/definitions/427.tsx
+++ b/services/quests/errors/definitions/427.tsx
@@ -1,6 +1,6 @@
 export const NUMBER = 427;
-export const NAME = `Detected an invalid transition from this combat to another combat`;
-export const DESCRIPTION = `Jumping between combat nodes is not supported.`;
+export const NAME = `Invalid transition from this combat to another combat`;
+export const DESCRIPTION = `Jumping between combat cards is not supported.`;
 export const TEST_WITH_CRAWLER = true;
 
 export const INVALID = [
@@ -124,7 +124,7 @@ _combat_
 
 * on round
 
-  Users get here by entering the combat node first.
+  Users get here by entering the combat card first.
 
 * on win
 

--- a/services/quests/errors/definitions/427.tsx
+++ b/services/quests/errors/definitions/427.tsx
@@ -1,0 +1,136 @@
+export const NUMBER = 427;
+export const NAME = `Detected an invalid transition from this combat to another combat`;
+export const DESCRIPTION = `Jumping between combat nodes is not supported.`;
+export const TEST_WITH_CRAWLER = true;
+
+export const INVALID = [
+`_combat_
+
+- Giant Rat
+
+* on round
+
+  Here's another combat!
+
+  _combat_
+
+  - Giant Rat
+
+  * on win
+
+    Card
+
+  * on lose
+
+    Card
+
+* on win
+
+  Card
+
+* on lose
+
+  Card`,
+`_combat_
+
+- Giant Rat
+
+* on round
+
+  This is a round
+
+  **goto c2**
+
+* on win
+
+  Card
+
+* on lose
+
+  Card
+
+_combat_
+
+- Giant Rat
+
+* on round
+
+  _Round_ (#c2)
+
+  This is a round in a different combat
+
+* on win
+
+  Card
+
+* on lose
+
+  Card`,
+];
+
+export const VALID = [
+`_combat_
+
+- Giant Rat
+
+* on round
+
+  Let's finish this combat.
+
+* on win
+
+  Card
+
+* on lose
+
+  Card
+
+_Next combat_
+
+Here's another combat!
+
+_combat_
+
+- Giant Rat
+
+* on win
+
+  Card
+
+* on lose
+
+  Card`,
+`_combat_
+
+- Giant Rat
+
+* on round
+
+  This is a round. It triggers win, so users can wrap up combat.
+
+  **win**
+
+* on win
+
+  This happens first
+
+* on lose
+
+  Card
+
+_combat_
+
+- Giant Rat
+
+* on round
+
+  Users get here by entering the combat node first.
+
+* on win
+
+  Card
+
+* on lose
+
+  Card`,
+];

--- a/services/quests/errors/errors.tsx
+++ b/services/quests/errors/errors.tsx
@@ -15,6 +15,7 @@ import * as e423 from './definitions/423';
 import * as e424 from './definitions/424';
 import * as e425 from './definitions/425';
 import * as e426 from './definitions/426';
+import * as e427 from './definitions/427';
 import * as e428 from './definitions/428';
 import * as e429 from './definitions/429';
 import * as e430 from './definitions/430';
@@ -42,6 +43,7 @@ const errors: {[id: string]: ErrorType} = {
   424: e424,
   425: e425,
   426: e426,
+  427: e427,
   428: e428,
   429: e429,
   430: e430,

--- a/services/quests/src/playtest/PlaytestCrawler.tsx
+++ b/services/quests/src/playtest/PlaytestCrawler.tsx
@@ -18,6 +18,24 @@ const LOOT_INSTRUCTION = /(\w*\s*\w*\s*\w+ \w+ loot)/gi;
 const VALID_LOOT_INSTRUCTION = /(([dD]raw|[dD]iscard) (one|two|three|four|five|six|seven|eight|nine|ten) tier (I|II|III|IV|V) loot)|(discard \d+ loot)/;
 const ADVENTURER_INSTRUCTION = /(\w*\s*player(s?)\s*\w*)/g;
 
+function getCombatParent(node: Node<Context>): Cheerio|null {
+  let e = node.elem.parent();
+  while (e.get(0) && e.parent()) {
+    const tag = e.get(0).tagName;
+
+    // Don't count being within the win/lose events of a combat node as being "in combat".
+    if (tag === 'event' && (e.attr('on') === 'win' || e.attr('on') === 'lose')) {
+      return null;
+    }
+
+    if (tag === 'combat') {
+      return e;
+    }
+    e = e.parent();
+  }
+  return null;
+}
+
 // Surfaces errors, warnings, statistics, and other useful information
 // about particular states encountered during play through the quest, or
 // about the quest in aggregate.
@@ -64,6 +82,7 @@ export class PlaytestCrawler extends StatsCrawler {
         this.verifyChoiceCount(q.node, line);
         this.verifyInstructionFormat(q.node, line);
         this.verifyRoleplayArt(q.node, line);
+        this.verifyMidCombatRoleplayNoJumpToCombat(q.node, line);
         break;
       default:
         break;
@@ -122,6 +141,33 @@ export class PlaytestCrawler extends StatsCrawler {
         }
       }
     });
+  }
+
+  private verifyMidCombatRoleplayNoJumpToCombat(roleplayNode: Node<Context>, line: number) {
+    const cp1 = getCombatParent(roleplayNode);
+    if (!cp1) {
+      return;
+    }
+    const line1 = cp1.attr('data-line');
+
+    const keys = roleplayNode.getVisibleKeys();
+    for (const k of (keys.length > 0) ? keys : [0]) {
+      const dest = roleplayNode.handleAction(k);
+      if (!dest) {
+        continue; // This problem (no destination on action) handled elsewhere
+      }
+
+      if (keys.length === 0 && dest.elem.prev().attr('data-line') === line1) {
+        // If there were no choices from the node and we landed directly on the next node,
+        // then we probably are actually just exiting the mid-combat roleplay portion.
+        continue;
+      }
+
+      const cp2 = (dest.elem.get(0).tagName === 'combat') ? dest.elem : getCombatParent(dest);
+      if (cp2 && cp2.attr('data-line') !== line1) {
+        this.logger.err('Detected an invalid transition from this combat to another combat (line ' + cp2.attr('data-line') + ')', '427', line);
+      }
+    }
   }
 
   private verifyChoiceCount(roleplayNode: Node<Context>, line: number) {

--- a/services/quests/src/playtest/PlaytestCrawler.tsx
+++ b/services/quests/src/playtest/PlaytestCrawler.tsx
@@ -165,7 +165,7 @@ export class PlaytestCrawler extends StatsCrawler {
 
       const cp2 = (dest.elem.get(0).tagName === 'combat') ? dest.elem : getCombatParent(dest);
       if (cp2 && cp2.attr('data-line') !== line1) {
-        this.logger.err('Detected an invalid transition from this combat to another combat (line ' + cp2.attr('data-line') + ')', '427', line);
+        this.logger.err('Invalid transition from this combat to another combat (line ' + cp2.attr('data-line') + ')', '427', line);
       }
     }
   }


### PR DESCRIPTION
Fixes #315

Note that this handles both combat cases mentioned in the bug, and the op evaluation errors were addressed in a previous github issue.

Also includes a test to catch accidentally committing `test.only` to the repo, as this was accidentally done in a couple places and we had tests we didn't know were failing.