### PR TITLE
Add user creation and login count to feedback emails

### DIFF
--- a/scripts/meta.test.js
+++ b/scripts/meta.test.js
@@ -161,6 +161,8 @@ describe('Typescript files', () => {
       const body = fs.readFileSync(f);
       if (body.indexOf('test.only') !== -1) {
         violations.push(f);
+      } else if (body.indexOf(' fit(') !== -1) { // fit() for force-select test may still be used in some places.
+        violations.push(f);
       }
     }
     expect(violations).toEqual([]);

--- a/services/api/src/models/Users.ts
+++ b/services/api/src/models/Users.ts
@@ -19,13 +19,18 @@ export function setLootPoints(db: Database, id: string, lootPoints: number) {
 export function incrementLoginCount(db: Database, id: string) {
   return db.users.update({
     loginCount: Sequelize.literal('login_count + 1') as any,
-    lastLogin: Sequelize.fn('NOW') as any,
+    lastLogin: Sequelize.literal('CURRENT_TIMESTAMP') as any,
   }, { where: {id}});
 }
 
 export function getUser(db: Database, id: string): Bluebird<User> {
   return db.users.findOne({where: {id}})
   .then((result) =>  new User((result) ? result.dataValues : {}));
+}
+
+export function maybeGetUserByEmail(db: Database, email: string): Bluebird<User|null> {
+  return db.users.findOne({where: {email}})
+  .then((result) => (result) ? new User(result.dataValues) : null);
 }
 
 export function subscribeToCreatorsList(mc: any, email: string) {


### PR DESCRIPTION
Fixes #264

Also includes extra testing around use of `fit()` for force testing, since apparently that can get left on as well.