### PR TITLE
Add player count to MP lobby, prevent too many players

### DIFF
--- a/services/app/src/Style.scss
+++ b/services/app/src/Style.scss
@@ -226,6 +226,7 @@ body {
   .peers {
     flex: 8;
     text-align: center;
+    overflow: hidden;
 
     .group {
       padding-left: size(base);

--- a/services/app/src/components/base/Dialogs.test.tsx
+++ b/services/app/src/components/base/Dialogs.test.tsx
@@ -201,7 +201,7 @@ describe('Dialogs', () => {
         settings: {...initialSettings},
         onClose: jasmine.createSpy('onClose'),
         onMultitouchChange: jasmine.createSpy('onMultitouchChange'),
-        onPlayerDelta: jasmine.createSpy('onPlayerDelta'),
+        onPlayerChange: jasmine.createSpy('onPlayerChange'),
         playQuest: jasmine.createSpy('playQuest'),
         ...overrides,
       };
@@ -213,8 +213,8 @@ describe('Dialogs', () => {
     })
     test('can adjust player count', () => {
       const {props, e} = setup();
-      e.find('#adventurerCount IconButton').at(0).simulate('click');
-      expect(props.onPlayerDelta).toHaveBeenCalledWith(jasmine.any(Number), jasmine.any(Number));
+      console.log(e.find('PlayerCount#playerCount').prop('onChange')(0));
+      expect(props.onPlayerChange).toHaveBeenCalledWith(0);
     });
     test('can enable/disable multitouch', () => {
       const {props, e} = setup();

--- a/services/app/src/components/base/Dialogs.test.tsx
+++ b/services/app/src/components/base/Dialogs.test.tsx
@@ -213,7 +213,7 @@ describe('Dialogs', () => {
     })
     test('can adjust player count', () => {
       const {props, e} = setup();
-      console.log(e.find('PlayerCount#playerCount').prop('onChange')(0));
+      e.find('PlayerCount#playerCount').prop('onChange')(0);
       expect(props.onPlayerChange).toHaveBeenCalledWith(0);
     });
     test('can enable/disable multitouch', () => {

--- a/services/app/src/components/base/Dialogs.tsx
+++ b/services/app/src/components/base/Dialogs.tsx
@@ -6,12 +6,12 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import TextField from '@material-ui/core/TextField';
 import * as React from 'react';
 import {Quest} from 'shared/schema/Quests';
-import {getContentSets} from '../../actions/Settings';
+import {getContentSets, numPlayers} from '../../actions/Settings';
 import {openWindow} from '../../Globals';
 import {MultiplayerCounters} from '../../multiplayer/Counters';
 import {ContentSetsType, DialogState, FeedbackType, MultiplayerState, QuestState, SavedQuestMeta, SettingsType, UserState} from '../../reducers/StateTypes';
 import Checkbox from './Checkbox';
-import Picker from './Picker';
+import PlayerCount from './PlayerCount';
 
 const pluralize = require('pluralize');
 
@@ -310,7 +310,7 @@ interface SetPlayerCountDialogProps extends React.Props<any> {
   multiplayer: MultiplayerState;
   onClose: () => void;
   onMultitouchChange: (v: boolean) => void;
-  onPlayerDelta: (numLocalPlayers: number, delta: number) => void;
+  onPlayerChange: (numLocalPlayers: number) => void;
   playQuest: (quest: Quest) => void;
 }
 
@@ -318,14 +318,14 @@ export class SetPlayerCountDialog extends React.Component<SetPlayerCountDialogPr
   public render(): JSX.Element {
     const quest = this.props.quest;
     let playersAllowed = true;
+    const allPlayers = numPlayers(this.props.settings, this.props.multiplayer);
     if (quest.minplayers && quest.maxplayers) {
-      playersAllowed = (this.props.settings.numLocalPlayers >= quest.minplayers &&
-        this.props.settings.numLocalPlayers <= quest.maxplayers);
+      playersAllowed = (allPlayers >= quest.minplayers &&
+        allPlayers <= quest.maxplayers);
     }
     let contents = <div>
-        <Picker id="adventurerCount" label="Adventurers" value={this.props.settings.numLocalPlayers} onDelta={(i: number) => this.props.onPlayerDelta(this.props.settings.numLocalPlayers, i)}>
-          {!playersAllowed && `Quest requires ${quest.minplayers} - ${quest.maxplayers} players.`}
-        </Picker>
+        {!playersAllowed && `Quest requires ${quest.minplayers} - ${quest.maxplayers} players.`}
+        <PlayerCount id="playerCount" localPlayers={this.props.settings.numLocalPlayers} allPlayers={allPlayers} onChange={(i: number) => this.props.onPlayerChange(i)}/>
         <Checkbox id="multitouch" label="Multitouch" value={this.props.settings.multitouch} onChange={this.props.onMultitouchChange}>
           {(this.props.settings.multitouch) ? 'All players must hold their finger on the screen to end combat.' : 'A single tap will end combat.'}
         </Checkbox>
@@ -379,7 +379,7 @@ export interface DispatchProps {
   onExpansionSelect: (contentSets: ContentSetsType) => void;
   onFeedbackSubmit: (type: FeedbackType, quest: QuestState, settings: SettingsType, user: UserState, text: string) => void;
   onMultitouchChange: (v: boolean) => void;
-  onPlayerDelta: (numLocalPlayers: number, delta: number) => void;
+  onPlayerChange: (numLocalPlayers: number) => void;
   playQuest: (quest: Quest) => void;
 }
 
@@ -452,7 +452,7 @@ const Dialogs = (props: Props): JSX.Element => {
       <SetPlayerCountDialog
         open={props.dialog && props.dialog.open === 'SET_PLAYER_COUNT'}
         onMultitouchChange={props.onMultitouchChange}
-        onPlayerDelta={props.onPlayerDelta}
+        onPlayerChange={props.onPlayerChange}
         onClose={props.onClose}
         playQuest={props.playQuest}
         quest={props.quest.details}

--- a/services/app/src/components/base/DialogsContainer.test.tsx
+++ b/services/app/src/components/base/DialogsContainer.test.tsx
@@ -27,9 +27,7 @@ describe('DialogsContainer', () => {
       return {store, dispatchProps};
     }
     test.skip('dispatches dialog change with onClose', () => { /* TODO */ });
-
     test.skip('onFeedbackSubmit validates input', () => { /* TODO */ });
-    test.skip('onPlayerDelta does nothing when going below min/above max players', () => { /* TODO */ });
 
     describe('onExitQuest', () => {
       test('submits feedback if there is any', (done) => {

--- a/services/app/src/components/base/DialogsContainer.tsx
+++ b/services/app/src/components/base/DialogsContainer.tsx
@@ -76,11 +76,7 @@ export const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps
     onMultitouchChange: (v: boolean) => {
       dispatch(changeSettings({multitouch: v}));
     },
-    onPlayerDelta: (numLocalPlayers: number, delta: number) => {
-      numLocalPlayers += delta;
-      if (numLocalPlayers <= 0 || numLocalPlayers > 6) {
-        return;
-      }
+    onPlayerChange: (numLocalPlayers: number) => {
       dispatch(changeSettings({numLocalPlayers}));
     },
     playQuest: (details: Quest) => {

--- a/services/app/src/components/base/Picker.test.tsx
+++ b/services/app/src/components/base/Picker.test.tsx
@@ -1,5 +1,32 @@
-describe('Picker', () => {
-  test.skip('triggers onDelta when buttons clicked', () => { /* TODO */ });
+import * as React from 'react';
+import {mount, unmountAll} from 'app/Testing';
+import Picker, {Props} from './Picker';
 
-  test.skip('shows label & value', () => { /* TODO */ });
+describe('Picker', () => {
+
+  afterEach(unmountAll);
+
+  function setup(overrides?: Partial<Props>) {
+    const props: Props = {
+      value: 'testvalue',
+      label: 'testlabel',
+      id: 'testid',
+      onDelta: jasmine.createSpy('onDelta'),
+      ...overrides,
+    };
+    const e = mount(<Picker {...(props as any as Props)} />);
+    return {props, e};
+  }
+
+  test('triggers onDelta when buttons clicked', () => {
+    const {e, props} = setup();
+    e.find('IconButton').first().prop('onClick')();
+    expect(props.onDelta).toHaveBeenCalledWith(-1);
+  });
+
+  test('shows label & value', () => {
+    const text = setup().e.text();
+    expect(text).toContain('testvalue');
+    expect(text).toContain('testlabel');
+  });
 });

--- a/services/app/src/components/base/PlayerCount.test.tsx
+++ b/services/app/src/components/base/PlayerCount.test.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import {mount, unmountAll} from 'app/Testing';
+import PlayerCount, {Props} from './PlayerCount';
+import {MAX_ADVENTURERS} from 'app/Constants';
+
+describe('PlayerCount', () => {
+
+  afterEach(unmountAll);
+
+  function setup(overrides?: Partial<Props>) {
+    const props: Props = {
+      allPlayers: 4,
+      localPlayers: 3,
+      id: 'testid',
+      onChange: jasmine.createSpy('onChange'),
+      ...overrides,
+    };
+    const e = mount(<PlayerCount {...(props as any as Props)} />);
+    return {props, e};
+  }
+  test('can adjust up', () => {
+    const {e, props} = setup();
+    e.find('Picker').prop('onDelta')(1);
+    expect(props.onChange).toHaveBeenCalledWith(4);
+  });
+  test('can adjust down', () => {
+    const {e, props} = setup();
+    e.find('Picker').prop('onDelta')(-1);
+    expect(props.onChange).toHaveBeenCalledWith(2);
+  });
+  test('does not go above MAX_ADVENTURERS players', () => {
+    const {e, props} = setup({allPlayers: MAX_ADVENTURERS, localPlayers: MAX_ADVENTURERS});
+    e.find('Picker').prop('onDelta')(1);
+    expect(props.onChange).not.toHaveBeenCalled();
+  });
+  test('does not go below 1 player (local)', () => {
+    const {e, props} = setup({allPlayers: 1, localPlayers: 1});
+    e.find('Picker').prop('onDelta')(-1);
+    expect(props.onChange).not.toHaveBeenCalled();
+  });
+  test('allows backing down when over limit', () => {
+    const {e, props} = setup({allPlayers: 7, localPlayers: 7});
+    e.find('Picker').prop('onDelta')(-1);
+    expect(props.onChange).toHaveBeenCalledWith(6);
+  });
+  test('shows solo play details when one player', () => {
+    const text = setup({allPlayers: 1, localPlayers: 1}).e.text();
+    expect(text).toContain('Solo play');
+  });
+  test('shows count across all devices when multiplayer', () => {
+    const text = setup({allPlayers: 3, localPlayers: 1}).e.text();
+    expect(text).toContain('across all devices');
+  });
+  test('hides count across all devices when no multiplayer', () => {
+    const text = setup({allPlayers: 3, localPlayers: 3}).e.text();
+    expect(text).not.toContain('across all devices');
+  });
+})

--- a/services/app/src/components/base/PlayerCount.tsx
+++ b/services/app/src/components/base/PlayerCount.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import {MAX_ADVENTURERS} from '../../Constants';
+import Picker from './Picker';
+
+interface Props extends React.Props<any> {
+  allPlayers: number;
+  localPlayers: number;
+  id?: string;
+  onChange: (localPlayers: number) => any;
+}
+
+export default class PlayerCount extends React.Component<Props, {}> {
+  private onDelta(delta: number) {
+    if (delta > 0 && this.props.allPlayers + delta > MAX_ADVENTURERS) {
+      return;
+    }
+    if (delta < 0 && this.props.localPlayers + delta < 1) {
+      return;
+    }
+    this.props.onChange(this.props.localPlayers + delta);
+  }
+
+  public render() {
+    return (
+      <Picker id={this.props.id} label="Players" value={this.props.localPlayers} onDelta={(i: number) => this.onDelta(i)}>
+        {(this.props.allPlayers > 1) ? 'The number of players.' : <div><strong>Solo play:</strong> Play as two adventurers with double the combat timer.</div>}
+        {(this.props.allPlayers > this.props.localPlayers) && <div>({this.props.allPlayers} across all devices)</div>}
+      </Picker>
+    );
+  }
+}

--- a/services/app/src/components/base/PlayerCount.tsx
+++ b/services/app/src/components/base/PlayerCount.tsx
@@ -23,7 +23,7 @@ export default class PlayerCount extends React.Component<Props, {}> {
   public render() {
     return (
       <Picker id={this.props.id} label="Players" value={this.props.localPlayers} onDelta={(i: number) => this.onDelta(i)}>
-        {(this.props.allPlayers > 1) ? 'The number of players.' : <div><strong>Solo play:</strong> Play as two adventurers with double the combat timer.</div>}
+        {(this.props.allPlayers > 1) ? 'The number of players.' : <div><strong>Solo play:</strong> Play as two adventurers with double the timer.</div>}
         {(this.props.allPlayers > this.props.localPlayers) && <div>({this.props.allPlayers} across all devices)</div>}
       </Picker>
     );

--- a/services/app/src/components/views/ModeSelect.test.tsx
+++ b/services/app/src/components/views/ModeSelect.test.tsx
@@ -14,7 +14,7 @@ describe('ModeSelect', () => {
       settings: initialSettings;
       multiplayer: initialMultiplayer;
       user: loggedOutUser;
-      onDelta: jasmine.createSpy('onDelta'),
+      onPlayerChange: jasmine.createSpy('onPlayerChange'),
       onLocalSelect: jasmine.createSpy('onLocalSelect'),
       onMultiplayerSelect: jasmine.createSpy('onMultiplayerSelect'),
       onMultitouchChange: jasmine.createSpy('onMultitouchChange'),
@@ -45,8 +45,8 @@ describe('ModeSelect', () => {
   });
   test('can change player count', () => {
     const {elem, props} = setup();
-    elem.find('Picker#playerCount').prop('onDelta')(1);
-    expect(props.onDelta).toHaveBeenCalledWith(jasmine.any(Number), 1);
+    elem.find('PlayerCount#playerCount').prop('onChange')(1);
+    expect(props.onPlayerChange).toHaveBeenCalledWith(1);
   });
   test('shows count across all devices', () => {
     const {elem, props} = setup({
@@ -60,10 +60,10 @@ describe('ModeSelect', () => {
         },
       },
     });
-    expect(elem.find('Picker#playerCount').text()).toContain('5 across all devices');
+    expect(elem.find('PlayerCount#playerCount').text()).toContain('5 across all devices');
   });
   test('hides count across all devices when no multiplayer', () => {
     const {elem, props} = setup({multiplayer: initialMultiplayer});
-    expect(elem.find('Picker#playerCount').text()).not.toContain('across all devices');
+    expect(elem.find('PlayerCount#playerCount').text()).not.toContain('across all devices');
   });
 });

--- a/services/app/src/components/views/ModeSelect.tsx
+++ b/services/app/src/components/views/ModeSelect.tsx
@@ -1,10 +1,10 @@
-import {numAdventurers} from 'app/actions/Settings';
+import {numPlayers} from 'app/actions/Settings';
 import * as React from 'react';
 import {MultiplayerState, SettingsType, UserState} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
 import Checkbox from '../base/Checkbox';
-import Picker from '../base/Picker';
+import PlayerCount from '../base/PlayerCount';
 import TextDivider from '../base/TextDivider';
 
 export interface StateProps {
@@ -15,7 +15,7 @@ export interface StateProps {
 }
 
 export interface DispatchProps {
-  onDelta: (numLocalPlayers: number, delta: number) => void;
+  onPlayerChange: (numLocalPlayers: number) => void;
   onLocalSelect: () => void;
   onMultiplayerSelect: (user: UserState) => void;
   onMultitouchChange: (change: boolean) => void;
@@ -24,13 +24,10 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 const ModeSelect = (props: Props): JSX.Element => {
-  const adventurers = numAdventurers(props.settings, props.multiplayer);
+  const allPlayers = numPlayers(props.settings, props.multiplayer);
   return (
     <Card title="Game Setup">
-      <Picker id="playerCount" label="Players" onDelta={(i: number) => props.onDelta(props.settings.numLocalPlayers, i)} value={props.settings.numLocalPlayers}>
-      {(adventurers > 1) ? 'The number of players.' : <div><strong>Solo play:</strong> Play as two adventurers with double the combat timer.</div>}
-      {props.multiplayer.session && <div>({adventurers} across all devices)</div>}
-      </Picker>
+      <PlayerCount id="playerCount" onChange={(i: number) => props.onPlayerChange(i)} localPlayers={props.settings.numLocalPlayers} allPlayers={allPlayers}/>
       <Checkbox id="multitouch" label="Multitouch" value={props.settings.multitouch} onChange={props.onMultitouchChange}>
         {(props.settings.multitouch) ? 'All players must hold their finger on the screen to end combat.' : 'A single tap will end combat.'}
       </Checkbox>

--- a/services/app/src/components/views/ModeSelectContainer.test.tsx
+++ b/services/app/src/components/views/ModeSelectContainer.test.tsx
@@ -1,3 +1,3 @@
 describe('ModeSelectContainer', () => {
-  test.skip('Only allows players in the min-max range', () => { /* TODO */ });
+  test('Empty', () => {});
 });

--- a/services/app/src/components/views/ModeSelectContainer.tsx
+++ b/services/app/src/components/views/ModeSelectContainer.tsx
@@ -4,6 +4,7 @@ import {toNavCard} from '../../actions/Card';
 import {loadMultiplayer} from '../../actions/Multiplayer';
 import {changeSettings} from '../../actions/Settings';
 import {ensureLogin} from '../../actions/User';
+import {MAX_ADVENTURERS} from '../../Constants';
 import {AppState, UserState} from '../../reducers/StateTypes';
 import ModeSelect, {DispatchProps, StateProps} from './ModeSelect';
 
@@ -20,7 +21,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
     onDelta: (numLocalPlayers: number, delta: number) => {
       numLocalPlayers += delta;
-      if (numLocalPlayers < 1 || numLocalPlayers > 6) {
+      if (numLocalPlayers < 1 || numLocalPlayers > MAX_ADVENTURERS) {
         return;
       }
       dispatch(changeSettings({numLocalPlayers}));

--- a/services/app/src/components/views/ModeSelectContainer.tsx
+++ b/services/app/src/components/views/ModeSelectContainer.tsx
@@ -4,7 +4,6 @@ import {toNavCard} from '../../actions/Card';
 import {loadMultiplayer} from '../../actions/Multiplayer';
 import {changeSettings} from '../../actions/Settings';
 import {ensureLogin} from '../../actions/User';
-import {MAX_ADVENTURERS} from '../../Constants';
 import {AppState, UserState} from '../../reducers/StateTypes';
 import ModeSelect, {DispatchProps, StateProps} from './ModeSelect';
 
@@ -19,18 +18,14 @@ const mapStateToProps = (state: AppState): StateProps => {
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
-    onDelta: (numLocalPlayers: number, delta: number) => {
-      numLocalPlayers += delta;
-      if (numLocalPlayers < 1 || numLocalPlayers > MAX_ADVENTURERS) {
-        return;
-      }
+    onPlayerChange: (numLocalPlayers: number) => {
       dispatch(changeSettings({numLocalPlayers}));
     },
     onLocalSelect: () => {
       dispatch(changeSettings({multitouch: false}));
       dispatch(toNavCard({}));
     },
-    onMultiplayerSelect(user: UserState): void {
+    onMultiplayerSelect: (user: UserState) => {
       dispatch(ensureLogin())
         .then((u: UserState) => {
           dispatch(loadMultiplayer(u));

--- a/services/app/src/components/views/Multiplayer.test.tsx
+++ b/services/app/src/components/views/Multiplayer.test.tsx
@@ -12,12 +12,14 @@ describe('Multiplayer lobby', () => {
     const props: Props = {
       phase: 'LOBBY',
       user: loggedOutUser,
+      settings: initialSettings,
       multiplayer: initialMultiplayer,
       contentSets: new Set(),
       onConnect: jasmine.createSpy('onConnect'),
       onReconnect: jasmine.createSpy('onReconnect'),
       onNewSessionRequest: jasmine.createSpy('onNewSessionRequest'),
       onStart: jasmine.createSpy('onStart'),
+      onPlayerChange: jasmine.createSpy('onPlayerChange'),
       ...overrides,
     };
     const elem = mount(renderLobby(props));
@@ -50,5 +52,8 @@ describe('Multiplayer lobby', () => {
     const {elem, props} = setup();
     elem.find('ExpeditionButton#start').prop('onClick')();
     expect(props.onStart).toHaveBeenCalled();
+  });
+  test('disables onStart when too many players', () => {
+    // TODO
   });
 });

--- a/services/app/src/components/views/Multiplayer.test.tsx
+++ b/services/app/src/components/views/Multiplayer.test.tsx
@@ -54,6 +54,7 @@ describe('Multiplayer lobby', () => {
     expect(props.onStart).toHaveBeenCalled();
   });
   test('disables onStart when too many players', () => {
-    // TODO
+    const {elem, props} = setup({settings: {...initialSettings, numLocalPlayers: 7}});
+    expect(elem.find('ExpeditionButton#start').prop('disabled')).toEqual(true);
   });
 });

--- a/services/app/src/components/views/Multiplayer.tsx
+++ b/services/app/src/components/views/Multiplayer.tsx
@@ -118,7 +118,7 @@ export function renderLobby(props: Props): JSX.Element {
         <PlayerCount id="playerCount" localPlayers={props.settings.numLocalPlayers} allPlayers={allPlayers} onChange={(localPlayers: number) => props.onPlayerChange(localPlayers)} />
         <br/>
         <p>Once everyone is ready, click Start:</p>
-        <Button id="start" className="mediumbutton" disabled={allPlayers > MAX_ADVENTURERS} onClick={() => {props.onStart(); }}>{(allPlayers > MAX_ADVENTURERS) ? `Player count must be < ${MAX_ADVENTURERS}` : 'Start'}</Button>
+        <Button id="start" className="mediumbutton" disabled={allPlayers > MAX_ADVENTURERS} onClick={() => {props.onStart(); }}>{(allPlayers > MAX_ADVENTURERS) ? `Player count must be ≤ ${MAX_ADVENTURERS}` : 'Start'}</Button>
       </div>
     </Card>
   );

--- a/services/app/src/components/views/Multiplayer.tsx
+++ b/services/app/src/components/views/Multiplayer.tsx
@@ -3,12 +3,12 @@ import NetworkWifi from '@material-ui/icons/NetworkWifi';
 import SignalWifiOff from '@material-ui/icons/SignalWifiOff';
 import * as React from 'react';
 import {SessionID} from 'shared/multiplayer/Session';
-import {numAdventurers} from '../../actions/Settings';
+import {numPlayers} from '../../actions/Settings';
 import {CONTENT_SET_FULL_NAMES, MAX_ADVENTURERS} from '../../Constants';
 import {ContentSetsType, MultiplayerPhase, MultiplayerSessionMeta, MultiplayerState, SettingsType, UserState} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
-import Picker from '../base/Picker';
+import PlayerCount from '../base/PlayerCount';
 
 const Moment = require('moment');
 
@@ -27,7 +27,7 @@ export interface DispatchProps {
   onReconnect: (user: UserState, id: SessionID, secret: string) => void;
   onNewSessionRequest: (user: UserState) => void;
   onStart: () => void;
-  onDelta: (numLocalPlayers: number, delta: number, adventurers: number) => void;
+  onPlayerChange: (localPlayers: number) => void;
 }
 
 export interface Props extends StateProps, DispatchProps {}
@@ -81,7 +81,7 @@ class MultiplayerConnect extends React.Component<Props, {}> {
 
 // TODO: Put this in a separate file and move the switch statemenet to Compositor
 export function renderLobby(props: Props): JSX.Element {
-  const adventurers = numAdventurers(props.settings, props.multiplayer);
+  const allPlayers = numPlayers(props.settings, props.multiplayer);
   return (
     <Card title="Lobby">
       <div className="remoteplay">
@@ -115,11 +115,10 @@ export function renderLobby(props: Props): JSX.Element {
         <p>Click the connected adventurers or connection state for more information.</p>
         <h2>Adventurers</h2>
         <p>Max of {MAX_ADVENTURERS} players allowed in multiplayer.</p>
-        <Picker id="playerCount" label="Players" onDelta={(i: number) => props.onDelta(props.settings.numLocalPlayers, i, adventurers)} value={props.settings.numLocalPlayers}>
-        The number of local players. <div>({adventurers} across all devices)</div>
-        </Picker><br/>
-        <p>Once everyone is connected, click Start:</p>
-        <Button id="start" className="mediumbutton" disabled={adventurers > MAX_ADVENTURERS} onClick={() => {props.onStart(); }}>{(adventurers > MAX_ADVENTURERS) ? `Player count must be < ${MAX_ADVENTURERS}` : 'Start'}</Button>
+        <PlayerCount id="playerCount" localPlayers={props.settings.numLocalPlayers} allPlayers={allPlayers} onChange={(localPlayers: number) => props.onPlayerChange(localPlayers)} />
+        <br/>
+        <p>Once everyone is ready, click Start:</p>
+        <Button id="start" className="mediumbutton" disabled={allPlayers > MAX_ADVENTURERS} onClick={() => {props.onStart(); }}>{(allPlayers > MAX_ADVENTURERS) ? `Player count must be < ${MAX_ADVENTURERS}` : 'Start'}</Button>
       </div>
     </Card>
   );

--- a/services/app/src/components/views/Multiplayer.tsx
+++ b/services/app/src/components/views/Multiplayer.tsx
@@ -3,10 +3,12 @@ import NetworkWifi from '@material-ui/icons/NetworkWifi';
 import SignalWifiOff from '@material-ui/icons/SignalWifiOff';
 import * as React from 'react';
 import {SessionID} from 'shared/multiplayer/Session';
-import {CONTENT_SET_FULL_NAMES} from '../../Constants';
-import {ContentSetsType, MultiplayerPhase, MultiplayerSessionMeta, MultiplayerState, UserState} from '../../reducers/StateTypes';
+import {numAdventurers} from '../../actions/Settings';
+import {CONTENT_SET_FULL_NAMES, MAX_ADVENTURERS} from '../../Constants';
+import {ContentSetsType, MultiplayerPhase, MultiplayerSessionMeta, MultiplayerState, SettingsType, UserState} from '../../reducers/StateTypes';
 import Button from '../base/Button';
 import Card from '../base/Card';
+import Picker from '../base/Picker';
 
 const Moment = require('moment');
 
@@ -16,6 +18,7 @@ export interface StateProps {
   phase: MultiplayerPhase;
   user: UserState;
   multiplayer: MultiplayerState;
+  settings: SettingsType;
   contentSets: Set<keyof ContentSetsType>;
 }
 
@@ -24,6 +27,7 @@ export interface DispatchProps {
   onReconnect: (user: UserState, id: SessionID, secret: string) => void;
   onNewSessionRequest: (user: UserState) => void;
   onStart: () => void;
+  onDelta: (numLocalPlayers: number, delta: number, adventurers: number) => void;
 }
 
 export interface Props extends StateProps, DispatchProps {}
@@ -77,6 +81,7 @@ class MultiplayerConnect extends React.Component<Props, {}> {
 
 // TODO: Put this in a separate file and move the switch statemenet to Compositor
 export function renderLobby(props: Props): JSX.Element {
+  const adventurers = numAdventurers(props.settings, props.multiplayer);
   return (
     <Card title="Lobby">
       <div className="remoteplay">
@@ -108,8 +113,13 @@ export function renderLobby(props: Props): JSX.Element {
           </tbody>
         </table>
         <p>Click the connected adventurers or connection state for more information.</p>
+        <h2>Adventurers</h2>
+        <p>Max of {MAX_ADVENTURERS} players allowed in multiplayer.</p>
+        <Picker id="playerCount" label="Players" onDelta={(i: number) => props.onDelta(props.settings.numLocalPlayers, i, adventurers)} value={props.settings.numLocalPlayers}>
+        The number of local players. <div>({adventurers} across all devices)</div>
+        </Picker><br/>
         <p>Once everyone is connected, click Start:</p>
-        <Button id="start" className="mediumbutton" onClick={() => {props.onStart(); }}>Start</Button>
+        <Button id="start" className="mediumbutton" disabled={adventurers > MAX_ADVENTURERS} onClick={() => {props.onStart(); }}>{(adventurers > MAX_ADVENTURERS) ? `Player count must be < ${MAX_ADVENTURERS}` : 'Start'}</Button>
       </div>
     </Card>
   );

--- a/services/app/src/components/views/MultiplayerContainer.tsx
+++ b/services/app/src/components/views/MultiplayerContainer.tsx
@@ -5,7 +5,6 @@ import {toNavCard} from '../../actions/Card';
 import {multiplayerConnect, multiplayerNewSession} from '../../actions/Multiplayer';
 import {changeSettings, getContentSets} from '../../actions/Settings';
 import {openSnackbar} from '../../actions/Snackbar';
-import {MAX_ADVENTURERS} from '../../Constants';
 import {logEvent} from '../../Logging';
 import {AppState, UserState} from '../../reducers/StateTypes';
 import Multiplayer, {DispatchProps, MIN_SECRET_LENGTH, StateProps} from './Multiplayer';
@@ -29,14 +28,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       }
       return dispatch(multiplayerConnect(user, secret.toUpperCase()));
     },
-    onDelta: (numLocalPlayers: number, delta: number, adventurers: number) => {
-      if (delta > 0 && adventurers + delta > MAX_ADVENTURERS) {
-        return;
-      }
-      if (delta < 0 && adventurers + delta < 1) {
-        return;
-      }
-      numLocalPlayers += delta;
+    onPlayerChange: (numLocalPlayers: number) => {
       dispatch(changeSettings({numLocalPlayers}));
     },
     onStart: () => {

--- a/services/app/src/components/views/Settings.test.tsx
+++ b/services/app/src/components/views/Settings.test.tsx
@@ -19,7 +19,7 @@ describe('Settings', () => {
       onExperimentalChange: jasmine.createSpy('onExperimentalChange'),
       onFontSizeDelta: jasmine.createSpy('onFontSizeDelta'),
       onMultitouchChange: jasmine.createSpy('onMultitouchChange'),
-      onPlayerDelta: jasmine.createSpy('onPlayerDelta'),
+      onPlayerChange: jasmine.createSpy('onPlayerChange'),
       onShowHelpChange: jasmine.createSpy('onShowHelpChange'),
       onTimerSecondsDelta: jasmine.createSpy('onTimerSecondsDelta'),
       onVibrationChange: jasmine.createSpy('onVibrationChange'),
@@ -32,23 +32,10 @@ describe('Settings', () => {
   test.skip('displays with initial settings', () => { /* TODO */ });
   test.skip('displays with timerSeconds = null', () => { /* TODO */ });
 
-  test('shows count across all devices', () => {
-    const {elem, props} = setup({
-      multiplayer: {
-        ...initialMultiplayer,
-        session: {id: 'asdf', secret: 'ghjk'},
-        connected: true,
-        clientStatus: {
-          d: {type: 'STATUS', connected: true, numLocalPlayers: 3},
-          e: {type: 'STATUS', connected: true, numLocalPlayers: 2},
-        },
-      },
-    });
-    expect(elem.find('Picker#playerCount').text()).toContain('5 across all devices');
-  });
-  test('hides count across all devices when no multiplayer', () => {
-    const {elem, props} = setup({multiplayer: initialMultiplayer});
-    expect(elem.find('Picker#playerCount').text()).not.toContain('across all devices');
+  test('changes player count', () => {
+    const {elem, props} = setup();
+    const text = elem.find('PlayerCount#playerCount').prop('onChange')(1);
+    expect(props.onPlayerChange).toHaveBeenCalledWith(1);
   });
   test('shows current locally configured content sets', () => {
     const {elem, props} = setup({settings: {...initialSettings, contentSets: {horror: true, future: false}}});

--- a/services/app/src/components/views/Settings.tsx
+++ b/services/app/src/components/views/Settings.tsx
@@ -1,5 +1,5 @@
 import Button from '@material-ui/core/Button';
-import {getContentSets, numAdventurers} from 'app/actions/Settings';
+import {getContentSets, numPlayers} from 'app/actions/Settings';
 import * as React from 'react';
 import {CONTENT_SET_FULL_NAMES, URLS, VERSION} from '../../Constants';
 import {openWindow} from '../../Globals';
@@ -7,6 +7,7 @@ import {DifficultyType, FontSizeType, MultiplayerState, SettingsType} from '../.
 import Card from '../base/Card';
 import Checkbox from '../base/Checkbox';
 import Picker from '../base/Picker';
+import PlayerCount from '../base/PlayerCount';
 
 export interface StateProps {
   settings: SettingsType;
@@ -21,7 +22,7 @@ export interface DispatchProps {
   onExperimentalChange: (change: boolean) => void;
   onFontSizeDelta: (idx: number, delta: number) => void;
   onMultitouchChange: (change: boolean) => void;
-  onPlayerDelta: (numLocalPlayers: number, i: number) => void;
+  onPlayerChange: (numLocalPlayers: number) => void;
   onShowHelpChange: (change: boolean) => void;
   onTimerSecondsDelta: (idx: number, delta: number) => void;
   onVibrationChange: (change: boolean) => void;
@@ -57,7 +58,7 @@ const Settings = (props: Props): JSX.Element => {
   const difficultyIdx = difficultyValues.indexOf(props.settings.difficulty);
   const fontSizeIdx = fontSizeValues.indexOf(props.settings.fontSize);
   const timerIdx = props.settings.timerSeconds ? timerValues.indexOf(props.settings.timerSeconds) : 0;
-  const adventurers = numAdventurers(props.settings, props.multiplayer);
+  const allPlayers = numPlayers(props.settings, props.multiplayer);
   const localExpansions = stringifyContentSet(Object.keys(props.settings.contentSets).filter((k) => props.settings.contentSets[k]));
   const globalExpansions = stringifyContentSet([...getContentSets(props.settings, props.multiplayer)]);
 
@@ -73,10 +74,7 @@ const Settings = (props: Props): JSX.Element => {
       <Button className="primary large" onClick={() => props.onExpansionSelect()}>Choose game / expansion</Button>
       {expansions}
 
-      <Picker id="playerCount" label="Adventurers" value={props.settings.numLocalPlayers} onDelta={(i: number) => props.onPlayerDelta(props.settings.numLocalPlayers, i)}>
-        {(adventurers > 1) ? 'The number of players.' : <div><strong>Solo play:</strong> Play as two adventurers with double the combat timer.</div>}
-        {props.multiplayer.session && <div>({adventurers} across all devices)</div>}
-      </Picker>
+      <PlayerCount id="playerCount" localPlayers={props.settings.numLocalPlayers} allPlayers={allPlayers} onChange={(i: number) => props.onPlayerChange(i)} />
 
       <Checkbox label="Multitouch" value={props.settings.multitouch} onChange={props.settings.onMultitouchChange}>
         {(props.settings.multitouch) ? 'All players must hold their finger on the screen to end combat.' : 'A single tap will end combat.'}

--- a/services/app/src/components/views/SettingsContainer.tsx
+++ b/services/app/src/components/views/SettingsContainer.tsx
@@ -2,7 +2,6 @@ import {connect} from 'react-redux';
 import Redux from 'redux';
 import {setDialog} from '../../actions/Dialog';
 import {changeSettings} from '../../actions/Settings';
-import {MAX_ADVENTURERS} from '../../Constants';
 import {logEvent} from '../../Logging';
 import {AppState, DifficultyType} from '../../reducers/StateTypes';
 import Settings, {DispatchProps, fontSizeValues, StateProps, timerValues} from './Settings';
@@ -65,11 +64,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
     onMultitouchChange: (v: boolean) => {
       dispatch(changeSettings({multitouch: v}));
     },
-    onPlayerDelta: (numLocalPlayers: number, delta: number) => {
-      numLocalPlayers += delta;
-      if (numLocalPlayers <= 0 || numLocalPlayers > MAX_ADVENTURERS) {
-        return;
-      }
+    onPlayerChange: (numLocalPlayers: number) => {
       dispatch(changeSettings({numLocalPlayers}));
     },
     onShowHelpChange: (v: boolean) => {

--- a/services/app/src/components/views/quest/cardtemplates/Template.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.test.tsx
@@ -15,7 +15,21 @@ describe('CardTemplates template', () => {
       });
       expect(ctx.scope._.contentSets()).toEqual({horror: true});
     });
-    test.skip('numAdventurers gets adventurer count', () => { /* TODO */ });
-    test.skip('viewCount gets the view count for a node id', () => { /* TODO */ });
+    test('numAdventurers gets adventurer count', () => {
+      const ctx = defaultContext(() => return {
+        settings: {...initialSettings, numLocalPlayers: 3},
+        multiplayer: initialMultiplayer,
+      });
+      expect(ctx.scope._.numAdventurers()).toEqual(3);
+    });
+    test('viewCount gets the view count for a node id', () => {
+      const ctx = defaultContext(() => return {});
+      ctx.views['a'] = 5;
+      expect(ctx.scope._.viewCount('a')).toEqual(5);
+    });
+    test ('viewCount handles unviewed nodes', () => {
+      const ctx = defaultContext(() => return {});
+      expect(ctx.scope._.viewCount('a')).toEqual(0);
+    });
   });
 });


### PR DESCRIPTION
Over size:
![image](https://user-images.githubusercontent.com/607666/49687763-cda63500-fad5-11e8-9eae-11630ea6c1e6.png)

Correct size:
![image](https://user-images.githubusercontent.com/607666/49687770-e0206e80-fad5-11e8-85a1-224692b8badf.png)

Fixes #506 

Includes tests for `<Picker/>` and `ctx._.numAdventurers()`.