### PR TITLE
Pass credentials when searching

### DIFF
--- a/services/app/src/actions/Search.test.tsx
+++ b/services/app/src/actions/Search.test.tsx
@@ -1,5 +1,6 @@
 describe('Search actions', () => {
   describe('Search', () => {
+    test.skip('credentials are included', () => { /* TODO */ });
     test.skip('calls getSearchResults with provided params, players and settings', () => { /* TODO */ });
     test.skip('calls getSearchResults with expansion enabled', () => { /* TODO */ });
     test.skip('dispatches search results', () => { /* TODO */ }); // $10

--- a/services/app/src/actions/Search.tsx
+++ b/services/app/src/actions/Search.tsx
@@ -86,6 +86,7 @@ function getSearchResults(
     dispatch({ type: 'SEARCH_REQUEST' });
 
     fetch(AUTH_SETTINGS.URL_BASE + '/quests', {
+      credentials: 'include',
       method: 'POST',
       headers: {
         'Content-Type': 'text/plain',


### PR DESCRIPTION
Followon to #588,  #585

User credentials are used to identify what private quests a user has when searching quests.

Testing added as a stub here because the current search code is not testable in an async fashion without significant refactoring. Filed #592 for followup.