### PR TITLE
Fix new quest creation

### DIFF
--- a/services/quests/src/actions/Quest.test.tsx
+++ b/services/quests/src/actions/Quest.test.tsx
@@ -18,6 +18,16 @@ describe('quest actions', () => {
     fetchMock.restore();
   });
 
+  describe('newQuest', () => {
+    test.skip('calls out to Drive API to create file', () => { /* TODO */ });
+
+    test.skip('grants file discovery to Fabricate', () => { /* TODO */ });
+
+    test.skip('uploads example quest to API', () => { /* TODO */ });
+
+    test.skip('begins quest load after new quest created', () => { /* TODO */ });
+  });
+
   describe('saveQuest', () => {
     test.skip('converts md to xml', () => { /* TODO */ });
 

--- a/services/quests/src/actions/Quest.tsx
+++ b/services/quests/src/actions/Quest.tsx
@@ -27,16 +27,18 @@ const QueryString = require('query-string');
 
 // Override realtime api error handling, which by default
 // calls alert() and sets window.href to "/" whenever an error occurs.
-realtimeUtils.__proto__.onError = (error: any) => {
-  if (error.type === window.gapi.drive.realtime.ErrorType
-      .TOKEN_REFRESH_REQUIRED) {
-    realtimeUtils.authorizer.authorize(() => {
-      console.log('Error, auth refreshed');
-    }, false);
-  } else {
-    console.error(error);
-  }
-};
+if (realtimeUtils) {
+  realtimeUtils.__proto__.onError = (error: any) => {
+    if (error.type === window.gapi.drive.realtime.ErrorType
+        .TOKEN_REFRESH_REQUIRED) {
+      realtimeUtils.authorizer.authorize(() => {
+        console.log('Error, auth refreshed');
+      }, false);
+    } else {
+      console.error(error);
+    }
+  };
+}
 
 // Loaded on index.html
 declare var window: any;


### PR DESCRIPTION
Due to realtime utils implementation, any error with realtime throws an `alert()` and sets `window.location.href = "/"`, which isn't exactly "fail silently".

Tests added as stubs since significant mocking/refactoring would be required to test new quest creation effectively, and prod is broken now.

Fixes #595.