### PR TITLE
Fix search result ordering by newest

### DIFF
--- a/services/api/src/Handlers.ts
+++ b/services/api/src/Handlers.ts
@@ -161,15 +161,7 @@ export function search(db: Database, req: express.Request, res: express.Response
   };
 
   return doSearch(db, res.locals.id, params).then((result) => {
-    const sortedQuests: Quest[] = result.quests.sort((a: Quest, b: Quest) => {
-      if (a.partition.toLowerCase() <= b.partition.toLowerCase()) {
-        return -1;
-      } else {
-        return 1;
-      }
-    });
-    const sortedResult: QuestSearchResponse = {...result, quests: sortedQuests};
-    res.status((result.error) ? 500 : 200).end(JSON.stringify(sortedResult));
+    res.status((result.error) ? 500 : 200).end(JSON.stringify(result));
   });
 }
 

--- a/services/api/src/models/Quests.test.ts
+++ b/services/api/src/models/Quests.test.ts
@@ -209,7 +209,7 @@ describe('quest', () => {
     });
   });
 
-  test.only('allows ordering results by created', (done) => {
+  test('allows ordering results by created', (done) => {
     const q1 = new Quest({
       ...q.basic,
       id: 'q1',

--- a/services/api/src/models/Quests.test.ts
+++ b/services/api/src/models/Quests.test.ts
@@ -209,6 +209,42 @@ describe('quest', () => {
     });
   });
 
+  test.only('allows ordering results by created', (done) => {
+    const q1 = new Quest({
+      ...q.basic,
+      id: 'q1',
+      created: Moment().subtract(1, 'month'),
+    });
+    const q3 = new Quest({
+      ...q.basic,
+      id: 'q3',
+      created: Moment().subtract(3, 'month'),
+    });
+    const q4 = new Quest({
+      ...q.basic,
+      id: 'q4',
+      created: Moment().subtract(4, 'month'),
+    });
+    const q2 = new Quest({
+      ...q.basic,
+      id: 'q2',
+      created: Moment().subtract(2, 'month'),
+    });
+
+    testingDBWithState([q1, q2, q3, q4])
+      .then((tdb) => searchQuests(tdb, '', { order: '-created' }))
+      .then((results) => {
+        expect(results.map(r => r.get('id'))).toEqual([
+          'q1',
+          'q2',
+          'q3',
+          'q4',
+        ]);
+        done();
+      })
+      .catch(done.fail);
+  });
+
   describe('publishQuest', () => {
     test.skip('shows up in public search results', () => {
       /* TODO */


### PR DESCRIPTION
Fixes #598

The search SQL query already orders the search results, and recent added code attempted to sort the ordered results without factoring in the ordering params, so I removed it. Also added a test to ensure we don't break ordering in the SQL query.