### PR TITLE
re-add support for older browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,10 +201,10 @@
         {
           "targets": {
             "browsers": [
-              ">5%",
+              ">2%",
               "last 2 years",
               "last 3 iOS versions",
-              "chrome >= 39"
+              "chrome >= 30"
             ]
           }
         }


### PR DESCRIPTION
Increases bundle size from ~2.4->~2.7mb (primarily from the 5->2% change, not the Chrome change), but we've been getting a lot of errors from older devices in Sentry and this will hopefully help