### PR TITLE
Move contact button to top of screen

### DIFF
--- a/services/quests/src/Style.scss
+++ b/services/quests/src/Style.scss
@@ -182,8 +182,12 @@ label {
   }
 }
 
-body .olark-launch-button { /*must be more specifc than olark styles */
-  bottom: 32px !important;
+body #olark-wrapper button.olark-launch-button { /*must be more specifc than olark styles */
+  margin-left: auto !important;
+  margin-right: auto !important;
+  position: fixed !important;
+  top: 10px !important;
+  left: 50% !important;
 }
 
 .splash {


### PR DESCRIPTION
Top middle is the least obstructive place for the contact button to go, short of a bunch of added complexity to embed the contact button into the page itself (difficult because we render the page via React after olark has loaded, and we'd likely need to mount/unmount if/when the page rerenders).

Fixes #589

![image](https://user-images.githubusercontent.com/607666/51608433-7cb39a00-1ee5-11e9-8c9b-e0b1e6a308fe.png)
![image](https://user-images.githubusercontent.com/607666/51608456-8937f280-1ee5-11e9-80ec-ec98caf38b88.png)
