### PR TITLE
Fix crawling of combat "on round"

### DIFF
--- a/services/quests/src/playtest/StatsCrawler.test.tsx
+++ b/services/quests/src/playtest/StatsCrawler.test.tsx
@@ -85,6 +85,18 @@ describe('StatsCrawler', () => {
       expect(Array.from(crawler.getStatsForId('A1').outputs)).toEqual(['IMPLICIT_END']);
     });
 
+    test('ignores implicit ends within combat "on round" event triggers', () => {
+      const xml = cheerio.load(`<combat title="A1" id="A1" data-line="2">
+        <event on="round">
+          <roleplay data-line="3"></roleplay>
+        </event>
+      </roleplay>`)(':first-child');
+      const crawler = new StatsCrawler();
+      crawler.crawl(new Node(xml, defaultContext()));
+
+      expect(Array.from(crawler.getStatsForLine(2).outputs)).not.toContain(['IMPLICIT_END']);
+    });
+
     test('safely handles nodes without line annotations', () => {
       const xml = cheerio.load(`
         <roleplay title="A0" id="A0" data-line="2"><p></p></roleplay>

--- a/services/quests/src/playtest/StatsCrawler.tsx
+++ b/services/quests/src/playtest/StatsCrawler.tsx
@@ -35,11 +35,11 @@ export class StatsCrawler extends CrawlerBase<Context> {
     };
   }
 
-  public crawl(root?: Node<C>, timeLimitMillis = 500, depthLimit = 50): boolean {
+  public crawl(root?: Node<Context>, timeLimitMillis = 500, depthLimit = 50): boolean {
     if (!this.root && root) {
       this.root = root;
     }
-    super.crawl(root, timeLimitMillis, depthLimit);
+    return super.crawl(root, timeLimitMillis, depthLimit);
   }
 
   // Retrieves stats for a given node ID.
@@ -71,7 +71,7 @@ export class StatsCrawler extends CrawlerBase<Context> {
     return Object.keys(this.statsById).filter((k: string) => (k !== 'START'));
   }
 
-  private lineWithinCombatRound(line: number): bool {
+  private lineWithinCombatRound(line: number): boolean {
     let n = this.root.elem.find(`[data-line=${line}]`);
     console.log(n);
     return n.closest('event[on="round"]').length > 0;


### PR DESCRIPTION
Now properly ignores cases where there is an implicit end within an "on round" section of combat - the app treats this as "go back to combat", so we shouldn't error when this happens.

Fixes #638