### PR TITLE
Fix race in feedback API promise handling

### DIFF
--- a/services/api/src/Handlers.test.ts
+++ b/services/api/src/Handlers.test.ts
@@ -2,22 +2,27 @@ import { mockReq, mockRes } from 'sinon-express-mock';
 import {
   feedback,
   healthCheck,
+  loadQuestData,
   postAnalyticsEvent,
   publish,
   questXMLHandler,
+  saveQuestData,
   search,
   subscribe,
   unpublish,
   userQuests,
-  loadQuestData,
-  saveQuestData,
 } from './Handlers';
-import {MailService} from './Mail';
-import {AnalyticsEventInstance, Database, QuestInstance} from './models/Database';
+import { MailService } from './Mail';
+import {
+  AnalyticsEventInstance,
+  Database,
+  QuestInstance,
+} from './models/Database';
+import { getQuest } from './models/Quests';
 import {
   analyticsEvents as ae,
-  quests as q,
   questData as qd,
+  quests as q,
   renderedQuests as rq,
   testingDBWithState,
   users as u,
@@ -27,28 +32,40 @@ describe('handlers', () => {
   describe('healthCheck', () => {
     test('returns success', () => {
       const res = mockRes();
-      healthCheck(mockReq({body: ''}), res);
+      healthCheck(mockReq({ body: '' }), res);
       expect(res.end.calledWith(' ')).toEqual(true);
       expect(res.status.getCall(0).args[0]).toEqual(200);
     });
   });
 
   describe('announcement', () => {
-    test.skip('returns with message and link', () => { /* TODO */ });
-    test.skip('returns default version if unable to reach a version API', () => { /* TODO */ });
-    test.skip('returns the latest version from API', () => { /* TODO */ });
-    test.skip('caches valid version results', () => { /* TODO */ });
+    test.skip('returns with message and link', () => {
+      /* TODO */
+    });
+    test.skip('returns default version if unable to reach a version API', () => {
+      /* TODO */
+    });
+    test.skip('returns the latest version from API', () => {
+      /* TODO */
+    });
+    test.skip('caches valid version results', () => {
+      /* TODO */
+    });
   });
 
   describe('search', () => {
-    test.skip('handles missing locals', () => { /* TODO */ });
+    test.skip('handles missing locals', () => {
+      /* TODO */
+    });
     test('successfully searches and returns data', (done: DoneFn) => {
       const res = mockRes();
       testingDBWithState([q.basic])
-        .then((db) => search(db, mockReq({body: '{}'}), res))
+        .then(db => search(db, mockReq({ body: '{}' }), res))
         .then(() => {
           expect(res.end.calledOnce).toEqual(true);
-          expect(JSON.parse(res.end.getCall(0).args[0]).quests).toEqual([jasmine.objectContaining({id: q.basic.id})]);
+          expect(JSON.parse(res.end.getCall(0).args[0]).quests).toEqual([
+            jasmine.objectContaining({ id: q.basic.id }),
+          ]);
           done();
         })
         .catch(done.fail);
@@ -59,33 +76,51 @@ describe('handlers', () => {
     test('returns quest XML', (done: DoneFn) => {
       const res = mockRes();
       testingDBWithState([q.basic, rq.basic])
-        .then((db) => questXMLHandler(db, mockReq({body: '', params: {quest: q.basic.id}}), res))
+        .then(db =>
+          questXMLHandler(
+            db,
+            mockReq({ body: '', params: { quest: q.basic.id } }),
+            res,
+          ),
+        )
         .then(() => {
           expect(res.end.calledWith(rq.basic.xml));
           done();
         })
         .catch(done.fail);
     });
-    test.skip('returns error when given invalid quest id', () => { /* TODO */ });
+    test.skip('returns error when given invalid quest id', () => {
+      /* TODO */
+    });
   });
 
   describe('publish', () => {
     let ms: MailService;
     beforeEach(() => {
-      ms = {send: jasmine.createSpy('send')};
+      ms = { send: jasmine.createSpy('send') };
     });
 
-    test.skip('handles missing locals', () => { /* TODO */ });
-    test.skip('publishes minor release', () => { /* TODO */ });
-    test.skip('publishes major release', () => { /* TODO */ });
-    test.skip('sends mail to admin', () => { /* TODO */ });
-    test.skip('sends mail to user on first publish', () => { /* TODO */ });
+    test.skip('handles missing locals', () => {
+      /* TODO */
+    });
+    test.skip('publishes minor release', () => {
+      /* TODO */
+    });
+    test.skip('publishes major release', () => {
+      /* TODO */
+    });
+    test.skip('sends mail to admin', () => {
+      /* TODO */
+    });
+    test.skip('sends mail to user on first publish', () => {
+      /* TODO */
+    });
     test('publishes new quest', (done: DoneFn) => {
       const res = mockRes();
       res.locals.id = u.basic.id;
       let db: Database;
       testingDBWithState([])
-        .then((tdb) => {
+        .then(tdb => {
           db = tdb;
           const query = {
             author: q.basic.author,
@@ -104,14 +139,19 @@ describe('handlers', () => {
             summary: q.basic.summary,
             title: q.basic.title,
           };
-          return publish(db, ms, mockReq({body: rq.basic.xml, query, params: {id: q.basic.id}}), res);
+          return publish(
+            db,
+            ms,
+            mockReq({ body: rq.basic.xml, query, params: { id: q.basic.id } }),
+            res,
+          );
         })
         .then(() => {
           expect(res.status.getCall(0).args[0]).toEqual(200);
           expect(res.end.calledWith(q.basic.id)).toEqual(true);
-          return db.quests.findOne({where: {id: q.basic.id}});
+          return db.quests.findOne({ where: { id: q.basic.id } });
         })
-        .then((i: QuestInstance|null) => {
+        .then((i: QuestInstance | null) => {
           if (i === null) {
             throw new Error('quest not found');
           }
@@ -127,16 +167,20 @@ describe('handlers', () => {
       const res = mockRes();
       let db: Database;
       testingDBWithState([q.basic])
-        .then((tdb) => {
+        .then(tdb => {
           db = tdb;
-          return unpublish(db, mockReq({body: '', params: {quest: q.basic.id}}), res);
+          return unpublish(
+            db,
+            mockReq({ body: '', params: { quest: q.basic.id } }),
+            res,
+          );
         })
         .then(() => {
           expect(res.status.getCall(0).args[0]).toEqual(200);
           expect(res.end.calledWith('ok')).toEqual(true);
-          return db.quests.findOne({where: {id: q.basic.id}});
+          return db.quests.findOne({ where: { id: q.basic.id } });
         })
-        .then((i: QuestInstance|null) => {
+        .then((i: QuestInstance | null) => {
           if (i === null) {
             throw new Error('quest not found');
           }
@@ -145,7 +189,9 @@ describe('handlers', () => {
         })
         .catch(done.fail);
     });
-    test.skip('handles missing locals', () => { /* TODO */ });
+    test.skip('handles missing locals', () => {
+      /* TODO */
+    });
   });
 
   describe('postAnalyticsEvent', () => {
@@ -153,24 +199,33 @@ describe('handlers', () => {
       const res = mockRes();
       let db: Database;
       testingDBWithState([])
-        .then((tdb) => {
+        .then(tdb => {
           db = tdb;
-          return postAnalyticsEvent(db, mockReq({
-            body: JSON.stringify({
-              difficulty: ae.action.difficulty,
-              json: ae.action.json,
-              platform: ae.action.platform,
-              players: ae.action.players,
-              questid: ae.action.questID,
-              questversion: ae.action.questVersion,
-              userid: ae.action.userID,
-              version: ae.action.version,
+          return postAnalyticsEvent(
+            db,
+            mockReq({
+              body: JSON.stringify({
+                difficulty: ae.action.difficulty,
+                json: ae.action.json,
+                platform: ae.action.platform,
+                players: ae.action.players,
+                questid: ae.action.questID,
+                questversion: ae.action.questVersion,
+                userid: ae.action.userID,
+                version: ae.action.version,
+              }),
+              params: {
+                category: ae.action.category,
+                action: ae.action.action,
+              },
             }),
-            params: {category: ae.action.category, action: ae.action.action},
-          }), res);
+            res,
+          );
         })
-        .then(() => db.analyticsEvent.findOne({where: {userID: ae.action.userID}}))
-        .then((i: AnalyticsEventInstance|null) => {
+        .then(() =>
+          db.analyticsEvent.findOne({ where: { userID: ae.action.userID } }),
+        )
+        .then((i: AnalyticsEventInstance | null) => {
           expect(res.status.getCall(0).args[0]).toEqual(200);
           expect(i).not.toEqual(null);
           done();
@@ -182,19 +237,27 @@ describe('handlers', () => {
   describe('feedback', () => {
     let ms: MailService;
     beforeEach(() => {
-      ms = {send: jasmine.createSpy('send')};
+      ms = { send: jasmine.createSpy('send') };
     });
 
     test('rejects non-parseable feedback', (done: DoneFn) => {
       const res = mockRes();
       testingDBWithState([])
-        .then((db) => feedback(db, ms, mockReq({body: '{', params: {type: 'feedback'}}), res))
+        .then(db =>
+          feedback(
+            db,
+            ms,
+            mockReq({ body: '{', params: { type: 'feedback' } }),
+            res,
+          ),
+        )
         .then(done.fail)
         .catch(() => {
           expect(res.status.getCall(0).args[0]).toEqual(400);
           expect(res.end.calledWith('Error reading request.')).toEqual(true);
           done();
-        }).catch(done.fail);
+        })
+        .catch(done.fail);
     });
 
     test('rejects invalid data', (done: DoneFn) => {
@@ -205,13 +268,24 @@ describe('handlers', () => {
       };
       const res = mockRes();
       testingDBWithState([q.basic])
-        .then((db) => feedback(db, ms, mockReq({body: JSON.stringify(data), params: {type: 'feedback'}}), res))
+        .then(db =>
+          feedback(
+            db,
+            ms,
+            mockReq({
+              body: JSON.stringify(data),
+              params: { type: 'feedback' },
+            }),
+            res,
+          ),
+        )
         .then(done.fail)
         .catch(() => {
           expect(res.status.getCall(0).args[0]).toEqual(400);
           expect(res.end.calledWith('Invalid request.')).toEqual(true);
           done();
-        }).catch(done.fail);
+        })
+        .catch(done.fail);
     });
     test('publishes with minimal data', (done: DoneFn) => {
       const data = {
@@ -221,13 +295,24 @@ describe('handlers', () => {
       };
       const res = mockRes();
       testingDBWithState([q.basic])
-        .then((db) => feedback(db, ms, mockReq({body: JSON.stringify(data), params: {type: 'feedback'}}), res))
+        .then(db =>
+          feedback(
+            db,
+            ms,
+            mockReq({
+              body: JSON.stringify(data),
+              params: { type: 'feedback' },
+            }),
+            res,
+          ),
+        )
         .then(() => {
           expect(res.end.calledWith('ok')).toEqual(true);
           done();
-        }).catch(done.fail);
+        })
+        .catch(done.fail);
     });
-    test('publishes feedback', (done: DoneFn) => {
+    test('publishes rating feedback', (done: DoneFn) => {
       const data = {
         difficulty: 'HARD',
         email: 'test@email.com',
@@ -245,12 +330,27 @@ describe('handlers', () => {
         version: '1.6.0',
       };
       const res = mockRes();
+      let db: any;
       testingDBWithState([q.basic])
-        .then((db) => feedback(db, ms, mockReq({body: JSON.stringify(data), params: {type: 'feedback'}}), res))
+        .then(tdb => {
+          db = tdb;
+          return feedback(
+            db,
+            ms,
+            mockReq({ body: JSON.stringify(data), params: { type: 'rating' } }),
+            res,
+          );
+        })
         .then(() => {
           expect(res.end.calledWith('ok')).toEqual(true);
+          return getQuest(db, q.basic.partition, q.basic.id);
+        })
+        .then(r => {
+          expect(r.ratingcount).toEqual(1);
+          expect(r.ratingavg).toEqual(3);
           done();
-        }).catch(done.fail);
+        })
+        .catch(done.fail);
     });
   });
 
@@ -258,40 +358,57 @@ describe('handlers', () => {
     test('gets quest played by user', (done: DoneFn) => {
       const res = mockRes();
       res.locals.id = ae.questEnd.userID;
-      testingDBWithState([
-        ae.questEnd,
-        q.basic,
-      ])
-        .then((db) => userQuests(db, mockReq({}), res))
+      testingDBWithState([ae.questEnd, q.basic])
+        .then(db => userQuests(db, mockReq({}), res))
         .then(() => {
           expect(res.status.getCall(0).args[0]).toEqual(200);
-          expect(JSON.parse(res.end.getCall(0).args[0])).toEqual({[ae.questEnd.questID]: jasmine.any(Object)});
-          done();
-        }).catch(done.fail);
-    });
-  });
-
-  describe('loadQuestData', () => {
-    test('loads most recent quest', (done) => {
-      const res = mockRes();
-      res.locals.id = qd.basic.userid;
-      testingDBWithState([
-        qd.basic,
-        qd.older,
-      ])
-        .then((db) => loadQuestData(db, mockReq({params: {quest: qd.basic.id, edittime: qd.basic.edittime}}), res))
-        .then(() => {
-          expect(res.status.getCall(0).args[0]).toEqual(200);
-          expect(JSON.parse(res.end.getCall(0).args[0])).toEqual({data: qd.basic.data, notes: qd.basic.notes, metadata: JSON.parse(qd.basic.metadata)});
+          expect(JSON.parse(res.end.getCall(0).args[0])).toEqual({
+            [ae.questEnd.questID]: jasmine.any(Object),
+          });
           done();
         })
         .catch(done.fail);
     });
-    test('returns 404 when quest not found', (done) => {
+  });
+
+  describe('loadQuestData', () => {
+    test('loads most recent quest', done => {
+      const res = mockRes();
+      res.locals.id = qd.basic.userid;
+      testingDBWithState([qd.basic, qd.older])
+        .then(db =>
+          loadQuestData(
+            db,
+            mockReq({
+              params: { quest: qd.basic.id, edittime: qd.basic.edittime },
+            }),
+            res,
+          ),
+        )
+        .then(() => {
+          expect(res.status.getCall(0).args[0]).toEqual(200);
+          expect(JSON.parse(res.end.getCall(0).args[0])).toEqual({
+            data: qd.basic.data,
+            notes: qd.basic.notes,
+            metadata: JSON.parse(qd.basic.metadata),
+          });
+          done();
+        })
+        .catch(done.fail);
+    });
+    test('returns 404 when quest not found', done => {
       const res = mockRes();
       res.locals.id = qd.basic.userid;
       testingDBWithState([])
-        .then((db) => loadQuestData(db, mockReq({params: {quest: qd.basic.id, edittime: qd.basic.edittime}}), res))
+        .then(db =>
+          loadQuestData(
+            db,
+            mockReq({
+              params: { quest: qd.basic.id, edittime: qd.basic.edittime },
+            }),
+            res,
+          ),
+        )
         .then(() => {
           expect(res.status.getCall(0).args[0]).toEqual(404);
           done();
@@ -301,14 +418,25 @@ describe('handlers', () => {
   });
 
   describe('saveQuestData', () => {
-    test('notifies when other client is editing quest', (done) => {
+    test('notifies when other client is editing quest', done => {
       const res = mockRes();
       res.locals.id = qd.basic.userid;
       testingDBWithState([qd.basic])
-        .then((db) => saveQuestData(db, mockReq({
-          params: {id: qd.basic.id},
-          body: JSON.stringify({data: 'test data', notes: 'test notes', metadata: '{a: 5}', edittime: new Date(qd.basic.edittime.getTime() + 100)}),
-        }), res))
+        .then(db =>
+          saveQuestData(
+            db,
+            mockReq({
+              params: { id: qd.basic.id },
+              body: JSON.stringify({
+                data: 'test data',
+                notes: 'test notes',
+                metadata: '{a: 5}',
+                edittime: new Date(qd.basic.edittime.getTime() + 100),
+              }),
+            }),
+            res,
+          ),
+        )
         .then(() => {
           expect(res.status.getCall(0).args[0]).toEqual(409);
           done();
@@ -318,18 +446,29 @@ describe('handlers', () => {
   });
 
   describe('subscribe', () => {
-    test.skip('handles invalid email address', () => { /* TODO */ });
+    test.skip('handles invalid email address', () => {
+      /* TODO */
+    });
     test('subscribes user to list', () => {
       const res = mockRes();
       let result: any;
-      const mc = {post: (list: any, details: any, cb: any) => {
-        result = {list, details};
-        cb(null, null);
-      }};
+      const mc = {
+        post: (list: any, details: any, cb: any) => {
+          result = { list, details };
+          cb(null, null);
+        },
+      };
       const email = 'asdf@ghjk.com';
-      subscribe(mc, 'testlist', mockReq({body: JSON.stringify({email})}), res);
+      subscribe(
+        mc,
+        'testlist',
+        mockReq({ body: JSON.stringify({ email }) }),
+        res,
+      );
       expect(result.list).toContain('testlist');
-      expect(result.details).toEqual(jasmine.objectContaining({email_address: email}));
+      expect(result.details).toEqual(
+        jasmine.objectContaining({ email_address: email }),
+      );
     });
   });
 });

--- a/services/api/src/Handlers.ts
+++ b/services/api/src/Handlers.ts
@@ -58,7 +58,7 @@ interface Versions {
 
 function getAndroidVersion(): Bluebird<string | null> {
   return request(
-    'https://play.google.com/store/apps/details?id=io.fabricate.expedition'
+    'https://play.google.com/store/apps/details?id=io.fabricate.expedition',
   )
     .then((body: string) => {
       const $ = cheerio.load(body);
@@ -73,7 +73,7 @@ function getAndroidVersion(): Bluebird<string | null> {
 
 function getIosVersion(): Bluebird<string | null> {
   return request(
-    'http://itunes.apple.com/lookup?bundleId=io.fabricate.expedition'
+    'http://itunes.apple.com/lookup?bundleId=io.fabricate.expedition',
   )
     .then((body: string) => {
       const version = JSON.parse(body).results[0].version;
@@ -100,7 +100,7 @@ function getVersions(date: string): Bluebird<Versions> {
     getAndroidVersion(),
     getIosVersion(),
     getWebVersion(),
-  ]).then((values) => {
+  ]).then(values => {
     return {
       android: values[0] || values[1] || '1.0.0', // Android scraping is fragile; fall back to iOS
       ios: values[1] || '1.0.0',
@@ -147,7 +147,7 @@ export interface QuestSearchResponse {
 function doSearch(
   db: Database,
   userId: string,
-  params: QuestSearchParams
+  params: QuestSearchParams,
 ): Bluebird<QuestSearchResponse> {
   return searchQuests(db, userId, params)
     .then((quests: QuestInstance[]) => {
@@ -163,7 +163,7 @@ function doSearch(
       console.log(
         `Found ${
           quests.length
-        } quests for user ${userId}, params: ${JSON.stringify(params)}`
+        } quests for user ${userId}, params: ${JSON.stringify(params)}`,
       );
       return {
         error: null,
@@ -183,7 +183,7 @@ function doSearch(
 export function search(
   db: Database,
   req: express.Request,
-  res: express.Response
+  res: express.Response,
 ) {
   let body: any;
   try {
@@ -210,7 +210,7 @@ export function search(
     showPrivate: body.showPrivate,
   };
 
-  return doSearch(db, res.locals.id, params).then((result) => {
+  return doSearch(db, res.locals.id, params).then(result => {
     res.status(result.error ? 500 : 200).end(JSON.stringify(result));
   });
 }
@@ -218,7 +218,7 @@ export function search(
 export function questXMLHandler(
   db: Database,
   req: express.Request,
-  res: express.Response
+  res: express.Response,
 ) {
   db.renderedQuests
     .findOne({
@@ -239,7 +239,7 @@ export function questXMLHandler(
             res.header('Content-Type', 'text/xml');
             res.header('Location', url);
             res.status(301).end();
-          }
+          },
         );
       }
       res.header('Content-Type', 'text/xml');
@@ -254,13 +254,13 @@ export function questXMLHandler(
 export function loadQuestData(
   db: Database,
   req: express.Request,
-  res: express.Response
+  res: express.Response,
 ) {
   return claimNewestQuestData(
     db,
     req.params.quest,
     res.locals.id,
-    new Date(parseInt(req.params.edittime, 10))
+    new Date(parseInt(req.params.edittime, 10)),
   )
     .then((instance: QuestData | null) => {
       if (!instance) {
@@ -271,7 +271,7 @@ export function loadQuestData(
           data: instance.data,
           notes: instance.notes,
           metadata: JSON.parse(instance.metadata),
-        })
+        }),
       );
     })
     .catch((e: Error) => {
@@ -283,7 +283,7 @@ export function loadQuestData(
 export function saveQuestData(
   db: Database,
   req: express.Request,
-  res: express.Response
+  res: express.Response,
 ) {
   let parsed: {
     data: string;
@@ -311,7 +311,7 @@ export function saveQuestData(
       metadata: JSON.stringify(parsed.metadata || {}),
       created: new Date(),
       edittime: parsed.edittime,
-    })
+    }),
   )
     .then(() => {
       res.status(200).end('ok');
@@ -322,7 +322,7 @@ export function saveQuestData(
         return res
           .status(409)
           .send(
-            'quest is being edited elsewhere. Reload to take over the editing session.'
+            'quest is being edited elsewhere. Reload to take over the editing session.',
           );
       }
       return res.status(500).end(GENERIC_ERROR_MESSAGE);
@@ -333,7 +333,7 @@ export function publish(
   db: Database,
   mail: MailService,
   req: express.Request,
-  res: express.Response
+  res: express.Response,
 ) {
   const quest = Quest.create({
     author: req.query.author,
@@ -373,7 +373,7 @@ export function publish(
 export function unpublish(
   db: Database,
   req: express.Request,
-  res: express.Response
+  res: express.Response,
 ) {
   return unpublishQuest(db, Partition.expeditionPublic, req.params.quest)
     .then(() => {
@@ -388,7 +388,7 @@ export function unpublish(
 export function postAnalyticsEvent(
   db: Database,
   req: express.Request,
-  res: express.Response
+  res: express.Response,
 ) {
   let body: any;
   try {
@@ -410,7 +410,7 @@ export function postAnalyticsEvent(
         questVersion: body.questversion,
         userID: body.userid,
         version: body.version,
-      })
+      }),
     )
     .then(() => {
       res.status(200).end('ok');
@@ -425,7 +425,7 @@ export function feedback(
   db: Database,
   mail: MailService,
   req: express.Request,
-  res: express.Response
+  res: express.Response,
 ): Bluebird<any> {
   let body: any;
   try {
@@ -463,10 +463,10 @@ export function feedback(
   }
   const platformDump: string = body.platformDump;
   const consoleDump: string[] = body.console || [];
-  const action: Bluebird<any> = maybeGetUserByEmail(db, data.email);
+  let action: Bluebird<any> = maybeGetUserByEmail(db, data.email);
   switch (req.params.type as FeedbackType) {
     case 'feedback':
-      action.then((user) =>
+      action = action.then(user =>
         submitFeedback(
           db,
           mail,
@@ -474,15 +474,15 @@ export function feedback(
           data,
           platformDump,
           consoleDump,
-          user
-        )
+          user,
+        ),
       );
       break;
     case 'rating':
-      action.then((user) => submitRating(db, mail, data, user));
+      action = action.then(user => submitRating(db, mail, data, user));
       break;
     case 'report_error':
-      action.then((user) =>
+      action = action.then(user =>
         submitFeedback(
           db,
           mail,
@@ -490,13 +490,13 @@ export function feedback(
           data,
           platformDump,
           consoleDump,
-          user
-        )
+          user,
+        ),
       );
       break;
     case 'report_quest':
-      action.then((user) =>
-        submitReportQuest(db, mail, data, platformDump, user)
+      action = action.then(user =>
+        submitReportQuest(db, mail, data, platformDump, user),
       );
       break;
     default:
@@ -518,7 +518,7 @@ export function feedback(
 export function userQuests(
   db: Database,
   req: express.Request,
-  res: express.Response
+  res: express.Response,
 ) {
   return getUserQuests(db, res.locals.id)
     .then((userQuests: UserQuestsType) => {
@@ -537,7 +537,7 @@ export function subscribe(
   mailchimp: any,
   listId: string,
   req: express.Request,
-  res: express.Response
+  res: express.Response,
 ) {
   try {
     req.body = JSON.parse(req.body);
@@ -570,7 +570,7 @@ export function subscribe(
               const status = (err as any).status;
               if (status === 400) {
                 console.log(
-                  `Mailchimp 400 subscribing ${email}: ${(err as any).detail}`
+                  `Mailchimp 400 subscribing ${email}: ${(err as any).detail}`,
                 );
                 return res.status(200).end(); // Already on the list - but that's ok!
               } else {
@@ -580,21 +580,21 @@ export function subscribe(
             }
             console.log(email + ' subscribed as pending to player list');
             return res.status(200).end();
-          }
+          },
         );
       }
-    }
+    },
   );
 }
 
 export function userFeedbacks(
   db: Database,
   req: express.Request,
-  res: express.Response
+  res: express.Response,
 ) {
   return getUserFeedbacks(db, res.locals.id)
     .then((feedbacks: IUserFeedback[]) =>
-      res.status(200).end(JSON.stringify(feedbacks))
+      res.status(200).end(JSON.stringify(feedbacks)),
     )
     .catch((e: Error) => {
       console.error(e);

--- a/services/api/src/Handlers.ts
+++ b/services/api/src/Handlers.ts
@@ -33,6 +33,7 @@ import {
   QuestSearchParams,
   searchQuests,
   unpublishQuest,
+  updateQuestRatings,
 } from './models/Quests';
 import {
   getUserFeedbacks,
@@ -599,5 +600,24 @@ export function userFeedbacks(
     .catch((e: Error) => {
       console.error(e);
       return res.status(500).end(GENERIC_ERROR_MESSAGE);
+    });
+}
+
+export function recalculateRatings(
+  db: Database,
+  req: express.Request,
+  res: express.Response,
+) {
+  return db.quests
+    .findAll()
+    .then((qs: QuestInstance[]) => {
+      const updates: Array<Bluebird<any>> = [];
+      for (const q of qs) {
+        updates.push(updateQuestRatings(db, q.get('partition'), q.get('id')));
+      }
+      return Promise.all(updates);
+    })
+    .then(() => {
+      res.status(200).end('All quest ratings updated');
     });
 }

--- a/services/api/src/Routes.ts
+++ b/services/api/src/Routes.ts
@@ -1,18 +1,21 @@
 import * as express from 'express';
-import {installRoutes as installAdminRoutes} from './admin/Routes';
+import { installRoutes as installAdminRoutes } from './admin/Routes';
 import Config from './config';
 import * as Handlers from './Handlers';
-import {limitCors} from './lib/cors';
-import {installOAuthRoutes, oauth2Template} from './lib/oauth2';
+import { limitCors } from './lib/cors';
+import { installOAuthRoutes, oauth2Template } from './lib/oauth2';
 import * as Mail from './Mail';
-import {Database} from './models/Database';
+import { Database } from './models/Database';
 import * as MultiplayerHandlers from './multiplayer/Handlers';
 import * as Stripe from './Stripe';
 
 const RateLimit = require('express-rate-limit');
 
 const Mailchimp = require('mailchimp-api-v3');
-const mailchimp = (Config.get('NODE_ENV') !== 'dev' && Config.get('MAILCHIMP_KEY')) ? new Mailchimp(Config.get('MAILCHIMP_KEY')) : null;
+const mailchimp =
+  Config.get('NODE_ENV') !== 'dev' && Config.get('MAILCHIMP_KEY')
+    ? new Mailchimp(Config.get('MAILCHIMP_KEY'))
+    : null;
 
 export function installRoutes(db: Database, router: express.Router) {
   // Use the oauth middleware to automatically get the user's profile
@@ -23,20 +26,26 @@ export function installRoutes(db: Database, router: express.Router) {
     delayAfter: 2, // begin slowing down responses after the second request
     delayMs: 3 * 1000, // slow down subsequent responses by 3 seconds per request
     max: 5, // start blocking after 5 requests
-    message: 'Publishing too frequently. Please wait 1 minute and then try again',
+    message:
+      'Publishing too frequently. Please wait 1 minute and then try again',
     windowMs: 60 * 1000, // 1 minute window
   });
 
   const sessionLimiter = new RateLimit({
-    delayAfter: 4,     // begin slowing down responses after the fourth request
-    delayMs: 3 * 1000,   // slow down subsequent responses by 3 seconds per request
-    max: 5,            // start blocking after 5 requests
-    message: 'Creating sessions too frequently. Please wait 1 minute and then try again',
+    delayAfter: 4, // begin slowing down responses after the fourth request
+    delayMs: 3 * 1000, // slow down subsequent responses by 3 seconds per request
+    max: 5, // start blocking after 5 requests
+    message:
+      'Creating sessions too frequently. Please wait 1 minute and then try again',
     windowMs: 60 * 1000, // 1 minute window
   });
 
   // We store auth details in res.locals. If there's no stored data there, the user is not logged in.
-  function requireAuth(req: express.Request, res: express.Response, next: express.NextFunction) {
+  function requireAuth(
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ) {
     if (!res.locals || !res.locals.id) {
       return res.status(500).end('You are not signed in.');
     }
@@ -47,28 +56,85 @@ export function installRoutes(db: Database, router: express.Router) {
     res.header('Access-Control-Allow-Origin', req.get('origin'));
     res.header('Access-Control-Allow-Credentials', 'true');
     res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
-    res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Content-Length, X-Requested-With');
+    res.header(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Authorization, Content-Length, X-Requested-With',
+    );
     res.sendStatus(200);
   });
 
   router.get('/healthcheck', limitCors, Handlers.healthCheck);
   router.get('/announcements', limitCors, Handlers.announcement);
   router.get('/qc/announcements', limitCors, Handlers.qcAnnouncement);
-  router.post('/analytics/:category/:action', limitCors, (req, res) => {Handlers.postAnalyticsEvent(db, req, res); });
-  router.post('/quests', limitCors, (req, res) => {Handlers.search(db, req, res); });
-  router.post('/save/quest/:id', limitCors, (req, res) => {Handlers.saveQuestData(db, req, res); });
-  router.get('/qdl/:quest/:edittime', limitCors, (req, res) => {Handlers.loadQuestData(db, req, res); });
-  router.get('/raw/:partition/:quest/:version', limitCors, (req, res) => {Handlers.questXMLHandler(db, req, res); });
-  router.post('/publish/:id', publishLimiter, limitCors, requireAuth, (req, res) => {Handlers.publish(db, Mail, req, res); });
-  router.post('/unpublish/:quest', limitCors, requireAuth, (req, res) => {Handlers.unpublish(db, req, res); });
-  router.post('/quest/feedback/:type', limitCors, (req, res) => {Handlers.feedback(db, Mail, req, res); });
-  router.post('/user/subscribe', limitCors, (req, res) => {Handlers.subscribe(mailchimp, Config.get('MAILCHIMP_PLAYERS_LIST_ID'), req, res); });
-  router.get('/user/quests', limitCors, requireAuth, (req, res) => {Handlers.userQuests(db, req, res); });
-  router.get('/user/feedbacks', limitCors, requireAuth, (req, res) => {Handlers.userFeedbacks(db, req, res); });
-  router.get('/multiplayer/v1/user', limitCors, requireAuth, (req, res) => {MultiplayerHandlers.user(db, req, res); });
-  router.post('/multiplayer/v1/new_session', sessionLimiter, limitCors, requireAuth, (req, res) => {MultiplayerHandlers.newSession(db, req, res); });
-  router.post('/multiplayer/v1/connect', limitCors, requireAuth, (req, res) => {MultiplayerHandlers.connect(db, req, res); });
-  router.post('/stripe/checkout', limitCors, (req, res) => {Stripe.checkout(req, res); });
+  router.post('/analytics/:category/:action', limitCors, (req, res) => {
+    Handlers.postAnalyticsEvent(db, req, res);
+  });
+  router.post('/quests', limitCors, (req, res) => {
+    Handlers.search(db, req, res);
+  });
+  router.post('/save/quest/:id', limitCors, (req, res) => {
+    Handlers.saveQuestData(db, req, res);
+  });
+  router.get('/qdl/:quest/:edittime', limitCors, (req, res) => {
+    Handlers.loadQuestData(db, req, res);
+  });
+  router.get('/raw/:partition/:quest/:version', limitCors, (req, res) => {
+    Handlers.questXMLHandler(db, req, res);
+  });
+  router.post(
+    '/publish/:id',
+    publishLimiter,
+    limitCors,
+    requireAuth,
+    (req, res) => {
+      Handlers.publish(db, Mail, req, res);
+    },
+  );
+  router.post('/unpublish/:quest', limitCors, requireAuth, (req, res) => {
+    Handlers.unpublish(db, req, res);
+  });
+  router.post('/quest/feedback/:type', limitCors, (req, res) => {
+    Handlers.feedback(db, Mail, req, res);
+  });
+  router.post('/user/subscribe', limitCors, (req, res) => {
+    Handlers.subscribe(
+      mailchimp,
+      Config.get('MAILCHIMP_PLAYERS_LIST_ID'),
+      req,
+      res,
+    );
+  });
+  router.get('/user/quests', limitCors, requireAuth, (req, res) => {
+    Handlers.userQuests(db, req, res);
+  });
+  router.get('/user/feedbacks', limitCors, requireAuth, (req, res) => {
+    Handlers.userFeedbacks(db, req, res);
+  });
+  router.get('/multiplayer/v1/user', limitCors, requireAuth, (req, res) => {
+    MultiplayerHandlers.user(db, req, res);
+  });
+  router.post(
+    '/multiplayer/v1/new_session',
+    sessionLimiter,
+    limitCors,
+    requireAuth,
+    (req, res) => {
+      MultiplayerHandlers.newSession(db, req, res);
+    },
+  );
+  router.post('/multiplayer/v1/connect', limitCors, requireAuth, (req, res) => {
+    MultiplayerHandlers.connect(
+      db,
+      req,
+      res,
+    );
+  });
+  router.post('/stripe/checkout', limitCors, (req, res) => {
+    Stripe.checkout(req, res);
+  });
+  router.get('/admin/recalcratings', limitCors, (req, res) => {
+    Handlers.recalculateRatings(db, req, res);
+  });
 
   installAdminRoutes(db, router);
   installOAuthRoutes(db, router);

--- a/services/api/src/models/Quests.test.ts
+++ b/services/api/src/models/Quests.test.ts
@@ -2,8 +2,8 @@ import { object } from 'joi';
 import { Partition } from 'shared/schema/Constants';
 import { Quest } from 'shared/schema/Quests';
 import { QuestInstance } from './Database';
-import { searchQuests } from './Quests';
-import { quests as q, testingDBWithState } from './TestData';
+import { getQuest, searchQuests, updateQuestRatings } from './Quests';
+import { feedback as f, quests as q, testingDBWithState } from './TestData';
 
 const Moment = require('moment');
 
@@ -349,8 +349,26 @@ describe('quest', () => {
   });
 
   describe('updateQuestRatings', () => {
-    test.skip('calculates the count and average of multiple ratings', () => {
-      /* TODO */
+    test('calculates the count and average of multiple ratings', done => {
+      const q1 = new Quest({
+        ...q.basic,
+        partition: Partition.expeditionPublic,
+        id: f.rating.questid,
+        created: Moment().subtract(1, 'month'),
+      });
+      let db: any;
+      testingDBWithState([q1, f.rating])
+        .then(tdb => {
+          db = tdb;
+          return updateQuestRatings(db, q1.partition, q1.id);
+        })
+        .then(() => getQuest(db, q1.partition, q1.id))
+        .then(result => {
+          expect(result.ratingcount).toEqual(1);
+          expect(result.ratingavg).toEqual(4);
+          done();
+        })
+        .catch(done.fail);
     });
 
     test.skip('excludes ratings from quest versions before the last major release', () => {

--- a/services/quests/src/playtest/StatsCrawler.tsx
+++ b/services/quests/src/playtest/StatsCrawler.tsx
@@ -1,6 +1,6 @@
 import {Context} from 'shared/parse/Context';
-import {Node} from 'shared/parse/Node';
 import {CrawlEntry, CrawlerBase, CrawlEvent} from 'shared/parse/Crawler';
+import {Node} from 'shared/parse/Node';
 
 export interface CrawlerStats {
   inputs: Set<string>;
@@ -72,7 +72,7 @@ export class StatsCrawler extends CrawlerBase<Context> {
   }
 
   private lineWithinCombatRound(line: number): boolean {
-    let n = this.root.elem.find(`[data-line=${line}]`);
+    const n = this.root.elem.find(`[data-line=${line}]`);
     console.log(n);
     return n.closest('event[on="round"]').length > 0;
   }


### PR DESCRIPTION
#642 - adds tests to ensure quest rating values update correctly and a handler to recalculate any ratings that may have drifted since the bug. We'll need to make a backup of the DB and then run the handler in production.

Verified feedback was updated by sending feedback for a quest in the beta instance.