### PR TITLE
Disabling combat timer on prepare card switches to non-timer card

### DIFF
--- a/services/app/src/components/Compositor.tsx
+++ b/services/app/src/components/Compositor.tsx
@@ -91,7 +91,7 @@ export default class Compositor extends React.Component<Props, {}> {
         if (!this.props.quest || !this.props.quest.node) {
           throw new Error('QUEST_CARD without quest/node');
         }
-        return renderCardTemplate(this.props.card, this.props.quest.node);
+        return renderCardTemplate(this.props.card, this.props.quest.node, this.props.settings);
       case 'QUEST_END':
         return <QuestEndContainer />;
       case 'GM_CARD':

--- a/services/app/src/components/views/quest/cardtemplates/Template.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.tsx
@@ -1,5 +1,5 @@
 import {getContentSets, numAdventurers} from 'app/actions/Settings';
-import {AppStateWithHistory, CardState, CardThemeType} from 'app/reducers/StateTypes';
+import {AppStateWithHistory, CardState, CardThemeType, SettingsType} from 'app/reducers/StateTypes';
 import {getStore} from 'app/Store';
 import * as React from 'react';
 import Redux from 'redux';
@@ -39,7 +39,7 @@ export function initCardTemplate(node: ParserNode) {
   };
 }
 
-export function renderCardTemplate(card: CardState, node: ParserNode): JSX.Element {
+export function renderCardTemplate(card: CardState, node: ParserNode, settings: SettingsType): JSX.Element {
   const phase = card.phase || 'ROLEPLAY';
   switch (phase) {
     case 'ROLEPLAY':
@@ -53,7 +53,14 @@ export function renderCardTemplate(card: CardState, node: ParserNode): JSX.Eleme
     case 'DRAW_ENEMIES':
       return <DrawEnemiesContainer node={node}/>;
     case 'PREPARE':
-      return <PrepareTimerContainer node={node}/>;
+      // Must handle conditional display of timer vs no timer here to
+      // allow for timer length changes on the "prepare" card to dynamically
+      // change which screen is shown.
+      if (!settings.timerSeconds) {
+        return <NoTimerContainer node={node}/>;
+      } else {
+        return <PrepareTimerContainer node={node}/>;
+      }
     case 'TIMER':
       return <TimerCardContainer node={node}/>;
     case 'SURGE':
@@ -66,14 +73,12 @@ export function renderCardTemplate(card: CardState, node: ParserNode): JSX.Eleme
       return <VictoryContainer node={node}/>;
     case 'DEFEAT':
       return <DefeatContainer node={node}/>;
-    case 'NO_TIMER':
-      return <NoTimerContainer node={node}/>;
     case 'MID_COMBAT_ROLEPLAY':
       return <MidCombatRoleplayContainer node={node}/>;
     case 'MID_COMBAT_DECISION':
     case 'MID_COMBAT_DECISION_TIMER':
       const combat = node.ctx.templates.combat;
-      return renderCardTemplate({...card, phase: ((combat) ? combat.decisionPhase : 'PREPARE_DECISION')}, node);
+      return renderCardTemplate({...card, phase: ((combat) ? combat.decisionPhase : 'PREPARE_DECISION')}, node, settings);
     default:
       throw new Error('Unknown template for card phase ' + card.phase);
   }
@@ -89,7 +94,6 @@ export function getCardTemplateTheme(card: CardState): CardThemeType {
     case 'RESOLVE_DAMAGE':
     case 'VICTORY':
     case 'DEFEAT':
-    case 'NO_TIMER':
     case 'MID_COMBAT_ROLEPLAY':
     case 'MID_COMBAT_DECISION':
     case 'MID_COMBAT_DECISION_TIMER':

--- a/services/app/src/components/views/quest/cardtemplates/combat/DrawEnemies.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/DrawEnemies.tsx
@@ -22,8 +22,6 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 export default function drawEnemies(props: Props): JSX.Element {
-  const nextCard = (props.settings.timerSeconds) ? 'PREPARE' : 'NO_TIMER';
-
   let repeatEnemy = false;
   let uniqueEnemy = false;
   const enemyNames: Set<string> = new Set();
@@ -68,7 +66,7 @@ export default function drawEnemies(props: Props): JSX.Element {
       </p>
       {enemies}
       {helpText}
-      <Button onClick={() => props.onNext(nextCard)}>Next</Button>
+      <Button onClick={() => props.onNext('PREPARE')}>Next</Button>
       <AudioControlsContainer />
     </Card>
   );

--- a/services/app/src/components/views/quest/cardtemplates/combat/MidCombatRoleplayContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/MidCombatRoleplayContainer.tsx
@@ -21,7 +21,7 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
     const tier = combatContext.tier;
     histIdx--;
     const phase = state._history[histIdx].card.phase;
-    if (tier && phase !== null && ['PREPARE', 'NO_TIMER'].indexOf(phase) !== -1) {
+    if (tier && phase !== null && phase === 'PREPARE') {
       maxTier = Math.max(maxTier, tier);
     }
   }

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.tsx
@@ -32,8 +32,6 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 export default function playerTier(props: Props): JSX.Element {
-  const nextCard: CombatPhase = (props.settings.timerSeconds) ? 'PREPARE' : 'NO_TIMER';
-
   let shouldRunDecision = false;
   if (props.contentSets.has('future')) {
     shouldRunDecision = (props.combat.roundCount % 5 === 0 || props.combat.roundCount % 5 === 3);
@@ -81,7 +79,7 @@ export default function playerTier(props: Props): JSX.Element {
       <Button
         className={(props.numAliveAdventurers === 0 || props.tier === 0) ? 'subtle' : ''}
         disabled={props.numAliveAdventurers <= 0 || props.tier <= 0}
-        onClick={() => (shouldRunDecision) ? props.onDecisionSetup(props.node, props.seed) : props.onNext(nextCard)}>Next</Button>
+        onClick={() => (shouldRunDecision) ? props.onDecisionSetup(props.node, props.seed) : props.onNext('PREPARE')}>Next</Button>
       <Button
         className={(props.tier !== 0) ? 'subtle' : ''}
         disabled={props.numAliveAdventurers <= 0 && props.tier > 0}

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
@@ -28,7 +28,7 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
     const tier = combatContext.tier;
     histIdx--;
     const phase = state._history[histIdx].card.phase;
-    if (tier && phase !== null && ['PREPARE', 'NO_TIMER'].indexOf(phase) !== -1) {
+    if (tier && phase !== null && phase === 'PREPARE') {
       maxTier = Math.max(maxTier, tier);
     }
   }

--- a/services/app/src/components/views/quest/cardtemplates/combat/Types.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Types.tsx
@@ -42,7 +42,6 @@ export type CombatPhase = 'DRAW_ENEMIES'
   | 'RESOLVE_DAMAGE'
   | 'VICTORY'
   | 'DEFEAT'
-  | 'NO_TIMER'
   | 'MID_COMBAT_ROLEPLAY'
   | 'MID_COMBAT_DECISION'
   | 'MID_COMBAT_DECISION_TIMER'; // Timer must be separate to allow skip of timer during onReturn.


### PR DESCRIPTION
Fixes beta test bug: "if you disable timer mid-combat, it becomes a timer of zero and immediately starts counting down into negative numbers with higher damage taken. disabling timer before combat works fine."