### PR TITLE
Fix text rendering in feedback/text dialogs

### DIFF
--- a/services/app/src/components/base/Dialogs.test.tsx
+++ b/services/app/src/components/base/Dialogs.test.tsx
@@ -92,7 +92,12 @@ describe('Dialogs', () => {
       expect(e.find('DialogContent').render().text()).toContain('Test Content');
     });
     test('updates text state', () => {
-      const {e} = setup();
+      const {e, props} = setup();
+      // Because we're testing with enzyme, renders don't happen typical to
+      // component lifecycle. Here we check that a rerender should occur
+      // (i.e. the update is not suppressed when the text input value changes).
+      expect(e.instance().shouldComponentUpdate(props, {text: 'asdf'})).toEqual(true);
+
       e.find('TextField').prop('onChange')({target: {value: 'asdf'}});
       e.find('#submitButton').hostNodes().prop('onClick')();
       expect(e.instance().onSubmitSpy).toHaveBeenCalledWith({text: 'asdf'});

--- a/services/app/src/components/base/Dialogs.tsx
+++ b/services/app/src/components/base/Dialogs.tsx
@@ -220,8 +220,8 @@ export class TextAreaDialog<T extends BaseDialogProps> extends React.Component<T
     throw new Error('Unimplemented');
   }
 
-  public shouldComponentUpdate(nextProps: BaseDialogProps) {
-    return nextProps.open !== this.props.open;
+  public shouldComponentUpdate(nextProps: BaseDialogProps, nextState: {text: string}) {
+    return nextProps.open !== this.props.open || nextState.text !== this.state.text;
   }
 
   public render(): JSX.Element {


### PR DESCRIPTION
Fixes beta testing report: "tried to send feedback on two different quests - could not type anything and when attempted multiple times, random non-deleteable letters started appearing (first "E", then "En", then "Enn" - i had been attempting to type "test". i've concluded that your app is possessed)"