### PR TITLE
Prevent sending null multiplayer status

### DIFF
--- a/services/app/src/actions/Multiplayer.test.tsx
+++ b/services/app/src/actions/Multiplayer.test.tsx
@@ -200,6 +200,14 @@ describe('Multiplayer actions', () => {
       const {c, actions} = doTest();
       expect(c.sendEvent).toHaveBeenCalledTimes(1);
     });
+    test('does nothing when empty client', () => {
+      const {c, actions} = doTest(null, multiplayer.instance, undefined, {multiplayer: {...multiplayer, client: null, instance: null}});
+      expect(c.sendEvent).not.toHaveBeenCalled();
+    });
+    test('does nothing when empty instance', () => {
+      const {c, actions} = doTest(multiplayer.client, null, undefined, {multiplayer: {...multiplayer, client: null, instance: null}});
+      expect(c.sendEvent).not.toHaveBeenCalled();
+    });
     test('does not send to remote clients if not self status', () => {
       const {c, actions} = doTest("nnn", "mmm");
       expect(c.sendEvent).not.toHaveBeenCalled();

--- a/services/app/src/actions/Multiplayer.tsx
+++ b/services/app/src/actions/Multiplayer.tsx
@@ -157,8 +157,15 @@ export function sendStatus(client?: string, instance?: string, partialStatus?: S
     const selfStatus = (multiplayer && multiplayer.clientStatus && multiplayer.clientStatus[toClientKey(multiplayer.client, multiplayer.instance)]);
     const storeClient = multiplayer && multiplayer.client;
     const storeInstance = multiplayer && multiplayer.instance;
-    client = client || storeClient || '';
-    instance = instance || storeInstance || '';
+    client = client || storeClient;
+    instance = instance || storeInstance;
+
+    // Typically happens during initial setup, when the client and instance
+    // have not yet been populated. In this case we're still setting up,
+    // so it's OK to silently ignore this call.
+    if (!client || !instance) {
+      return Promise.resolve();
+    }
 
     // Send remote if we're the origin
     if (client === storeClient && instance === storeInstance) {

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
@@ -141,7 +141,7 @@ describe('Combat actions', () => {
     const runTest = (overrides: any) => {
       const node = newCombatNode(); // Caution: this reset the multiplayer connection
       const conn = fakeConnection();
-      const store = newMockStore({multiplayer: initialMultiplayer}, conn);
+      const store = newMockStore({multiplayer: m.s2p5}, conn);
       store.dispatch(handleCombatTimerStop({
         elapsedMillis: 1000,
         node,

--- a/services/app/src/reducers/TestData.tsx
+++ b/services/app/src/reducers/TestData.tsx
@@ -25,16 +25,18 @@ export const Multiplayer: {[k: string]: MultiplayerState} = {
   basic: {...initialMultiplayer},
   s2p5: {
     ...initialMultiplayer,
+    client: 'abc',
+    instance: 'def',
     session: {id: 123, secret: 'def'},
     clientStatus: {
-      1: {
+      'abc|def': {
         connected: true,
         contentSets: ['horror', 'future'],
         numLocalPlayers: 3,
         aliveAdventurers: 3,
         type: 'STATUS',
       },
-      2: {
+      '2': {
         connected: true,
         contentSets: ['horror'],
         numLocalPlayers: 2,
@@ -45,15 +47,17 @@ export const Multiplayer: {[k: string]: MultiplayerState} = {
   },
   s2p2a1: {
     ...initialMultiplayer,
+    client: 'abc',
+    instance: 'def',
     session: {id: 123, secret: 'def'},
     clientStatus: {
-      1: {
+      'abc|def': {
         connected: true,
         numLocalPlayers: 1,
         aliveAdventurers: 0,
         type: 'STATUS',
       },
-      2: {
+      '2': {
         connected: true,
         numLocalPlayers: 1,
         aliveAdventurers: 1,


### PR DESCRIPTION
Fixes beta test bug: "connecting two devices results in a display of three devices connected."