### PR TITLE
Re-fix combat onround error

### DIFF
--- a/services/quests/src/playtest/StatsCrawler.test.tsx
+++ b/services/quests/src/playtest/StatsCrawler.test.tsx
@@ -85,7 +85,7 @@ describe('StatsCrawler', () => {
       expect(Array.from(crawler.getStatsForId('A1').outputs)).toEqual(['IMPLICIT_END']);
     });
 
-    test.only('ignores implicit ends within combat "on round" event triggers', () => {
+    test('ignores implicit ends within combat "on round" event triggers', () => {
       const xml = cheerio.load(`<quest>
         <roleplay data-line="1"><p>prefixing with roleplay sometimes causes errors</p></roleplay>
         <combat title="A1" id="A1" data-line="2">

--- a/services/quests/src/playtest/StatsCrawler.test.tsx
+++ b/services/quests/src/playtest/StatsCrawler.test.tsx
@@ -85,16 +85,18 @@ describe('StatsCrawler', () => {
       expect(Array.from(crawler.getStatsForId('A1').outputs)).toEqual(['IMPLICIT_END']);
     });
 
-    test('ignores implicit ends within combat "on round" event triggers', () => {
-      const xml = cheerio.load(`<combat title="A1" id="A1" data-line="2">
+    test.only('ignores implicit ends within combat "on round" event triggers', () => {
+      const xml = cheerio.load(`<quest>
+        <roleplay data-line="1"><p>prefixing with roleplay sometimes causes errors</p></roleplay>
+        <combat title="A1" id="A1" data-line="2">
         <event on="round">
-          <roleplay data-line="3"></roleplay>
+          <roleplay data-line="3"><p>asdf</p></roleplay>
         </event>
-      </roleplay>`)(':first-child');
+        </combat>
+      </quest>`)('quest > :first-child');
       const crawler = new StatsCrawler();
       crawler.crawl(new Node(xml, defaultContext()));
-
-      expect(Array.from(crawler.getStatsForLine(2).outputs)).not.toContain(['IMPLICIT_END']);
+      expect(Array.from(crawler.getStatsByEvent('IMPLICIT_END'))).toEqual([]);
     });
 
     test('safely handles nodes without line annotations', () => {

--- a/services/quests/src/playtest/StatsCrawler.tsx
+++ b/services/quests/src/playtest/StatsCrawler.tsx
@@ -63,6 +63,10 @@ export class StatsCrawler extends CrawlerBase<Context> {
     return this.statsByLine[line];
   }
 
+  public getStatsByEvent(evt: string) {
+    return this.statsByEvent[evt];
+  }
+
   public getLines(): number[] {
     return Object.keys(this.statsByLine).filter((k: string) => (k !== '-1')).map((s: string) => parseInt(s, 10));
   }
@@ -72,8 +76,7 @@ export class StatsCrawler extends CrawlerBase<Context> {
   }
 
   private lineWithinCombatRound(line: number): boolean {
-    const n = this.root.elem.find(`[data-line=${line}]`);
-    console.log(n);
+    const n = this.root.elem.closest('quest').find(`[data-line=${line}]`);
     return n.closest('event[on="round"]').length > 0;
   }
 


### PR DESCRIPTION
Fixes #638 (again)

The test passed but prod still had the bug because of a slight inconsistency with establishment of the "root" element. When actually crawling, the first element *within* the `<quest>` tag is actually set as the root element, but the test treated the `<combat>` element as the root. This is important when calling `find()` as it originally searched within the root element to check and see if the IMPLICIT_END event happened inside of combat. It didn't find a node, so failed open.

This change makes the test look more like reality (where `root` is the first node and not the node under test), and the code is now changed to seek up to the `<quest>` tag before calling `find()`.