### PR TITLE
Harden fetchLocal to aborted requests + display different network errors

### DIFF
--- a/services/app/src/actions/SavedQuests.tsx
+++ b/services/app/src/actions/SavedQuests.tsx
@@ -55,7 +55,7 @@ export function saveQuestForOffline(details: Quest) {
       return dispatch(openSnackbar('Saved for offline play.'));
     })
     .catch((e: Error) => {
-      return dispatch(openSnackbar(Error('Network error: Please check your connection.')));
+      return dispatch(openSnackbar(Error('Network error saving quest: Please check your connection'), true));
     });
   };
 }

--- a/services/app/src/actions/Search.tsx
+++ b/services/app/src/actions/Search.tsx
@@ -72,7 +72,7 @@ export function searchInternal(a: DoSearchParams, dispatch: Redux.Dispatch<any>,
       type: 'SEARCH_RESPONSE',
     } as SearchResponseAction);
   }).catch((error: Error) => {
-    dispatch(openSnackbar(Error('Network error: Please check your connection.')));
+    dispatch(openSnackbar(Error('Network error on search: Please check your connection.'), true));
   });
 
   return {...a, promise};
@@ -117,7 +117,7 @@ export function searchAndPlayInternal(id: string, dispatch: Redux.Dispatch<any>,
       dispatch(previewQuest({ quest: response.quests[0] }));
     }
   }).catch((error: Error) => {
-    dispatch(openSnackbar(Error('Network error: Please check your connection.')));
+    dispatch(openSnackbar(Error('Network error fetching quest: Please check your connection.'), true));
   });
   return {...params, promise};
 }

--- a/services/app/src/actions/Web.tsx
+++ b/services/app/src/actions/Web.tsx
@@ -57,7 +57,7 @@ export const fetchQuestXML = remoteify(function fetchQuestXML(a: FetchQuestXMLAr
     return dispatch(loadQuestXML({details: a.details, questNode, ctx}));
   })
   .catch((e: Error) => {
-    return dispatch(openSnackbar(Error('Network error: Please check your connection.')));
+    return dispatch(openSnackbar(Error('Network error fetching quest: Please check your connection.'), true));
   });
 
   return {...a, seed: ctx.seed, promise};

--- a/shared/requests/index.tsx
+++ b/shared/requests/index.tsx
@@ -23,6 +23,9 @@ export function fetchLocal(url: string) {
     request.onerror = () => {
       reject(new Error('network error'));
     };
+    request.onabort = () => {
+      reject(new Error('connection aborted'));
+    };
     request.open('GET', url);
     request.send();
   });


### PR DESCRIPTION
Fixes #671

Well, not really... but it should fix user behavior on similar bugs and give us more details if users report persistent network errors in the future. Also handles XHR aborts if those happen to occur.