### PR TITLE
Fix loading certain saved quests

### DIFF
--- a/services/app/src/actions/SavedQuests.test.tsx
+++ b/services/app/src/actions/SavedQuests.test.tsx
@@ -115,6 +115,18 @@ describe('SavedQuest actions', () => {
       </quest>`, [0, '|3', 'round']);
       expect(node.elem.text()).toEqual('expected');
     });
+    test('handles error on mid-combat roleplay', () => {
+      const {node} = recreateNodeFromPath(`<quest>
+        <roleplay>expected</roleplay>
+        <combat>
+          <e>Bandit</e>
+          <event on="round" if="_.currentCombatRound() == 4">
+            <roleplay>never get here</roleplay>
+          </event>
+        </combat>
+      </quest>`, [0, '|3', 'round']);
+      expect(node.elem.text()).toEqual('expected');
+    });
     test('handles exiting of combat (win/lose)', () => {
       const {node} = recreateNodeFromPath(`<quest>
         <roleplay></roleplay>

--- a/services/app/src/actions/SavedQuests.test.tsx
+++ b/services/app/src/actions/SavedQuests.test.tsx
@@ -46,7 +46,7 @@ describe('SavedQuest actions', () => {
     });
     test('stores xml and context path', () => {
       storeSavedQuest(pnode, {id: NEW_ID} as any as Quest, NEW_TS);
-      expect(getStorageJson(savedQuestKey(NEW_ID, NEW_TS), {})).toEqual({xml: (quest + ''), path: [0]});
+      expect(getStorageJson(savedQuestKey(NEW_ID, NEW_TS), {})).toEqual(jasmine.objectContaining({xml: (quest + ''), path: [0]}));
     });
   });
 
@@ -120,11 +120,23 @@ describe('SavedQuest actions', () => {
         <roleplay>expected</roleplay>
         <combat>
           <e>Bandit</e>
-          <event on="round" if="_.currentCombatRound() == 4">
+          <event on="round" if="false">
             <roleplay>never get here</roleplay>
           </event>
         </combat>
       </quest>`, [0, '|3', 'round']);
+      expect(node.elem.text()).toEqual('expected');
+    });
+    test('uses saved seed', () => {
+      const {node} = recreateNodeFromPath(`<quest>
+        <roleplay></roleplay>
+        <combat>
+          <e>Bandit</e>
+          <event on="round" if="randomInt(100) == 71">
+            <roleplay>expected</roleplay>
+          </event>
+        </combat>
+      </quest>`, [0, '|3', 'round'], 'asdg');
       expect(node.elem.text()).toEqual('expected');
     });
     test('handles exiting of combat (win/lose)', () => {

--- a/services/app/src/actions/SavedQuests.tsx
+++ b/services/app/src/actions/SavedQuests.tsx
@@ -106,7 +106,8 @@ function recreateNodeThroughCombat(node: ParserNode, i: number, path: string|num
       if (typeof action !== 'number') {
         const handled = node.handleAction(action);
         if (handled === null) {
-          throw Error('Failed to load quest (invalid combat action)');
+          console.warn(`Failed to load quest (invalid combat action '${action}' for node ${i} along path '${node.ctx.path}')`);
+          return {nextNode: null, i};
         }
         node = handled;
         if (action === 'win' || action === 'lose') {
@@ -144,7 +145,7 @@ export function recreateNodeFromPath(xml: string, path: string|number[]): {node:
     let next: ParserNode|null;
     next = node.handleAction(action);
     if (!next) {
-      console.warn('Failed to load quest (action #' + i + '), returning early');
+      console.warn(`Failed to load quest (action #${i} for node along path '${node.ctx.path}'), returning early`);
       return {node, complete: false};
     }
 
@@ -167,7 +168,6 @@ export function recreateNodeFromPath(xml: string, path: string|number[]): {node:
 }
 
 export function loadSavedQuest(id: string, ts: number) {
-  console.log('Gonna load that svaed quets');
   return (dispatch: Redux.Dispatch<any>) => {
     const savedQuests = getSavedQuestMeta();
     let details: Quest|null = null;
@@ -185,7 +185,7 @@ export function loadSavedQuest(id: string, ts: number) {
     logEvent('save', 'quest_save_load', { ...details, action: details.title, label: details.id });
     const data: SavedQuest = getStorageJson(savedQuestKey(id, ts), {}) as any;
     if (!data.xml || !data.path) {
-      throw new Error('Could not load quest.');
+      throw new Error('Could not load quest - invalid save data');
     }
     const {node, complete} = recreateNodeFromPath(data.xml, data.path);
     if (!complete) {

--- a/services/app/src/actions/SavedQuests.tsx
+++ b/services/app/src/actions/SavedQuests.tsx
@@ -15,7 +15,7 @@ import {openSnackbar} from './Snackbar';
 
 const cheerio = require('cheerio') as CheerioAPI;
 
-declare interface SavedQuest {xml: string; path: number[]; }
+declare interface SavedQuest {xml: string; path: number[]; seed: string; }
 
 export const SAVED_QUESTS_KEY = 'SAVED_QUESTS';
 

--- a/shared/parse/Context.test.tsx
+++ b/shared/parse/Context.test.tsx
@@ -18,31 +18,31 @@ describe('Context', () => {
 
   describe('evaluateOp', () => {
     test('handles string equality', () => {
-      expect(evaluateOp('"abc" == "abc"', defaultContext())).toEqual(true);
-      expect(evaluateOp('"abc" == "123"', defaultContext())).toEqual(false);
+      expect(evaluateOp('"abc" == "abc"', {})).toEqual(true);
+      expect(evaluateOp('"abc" == "123"', {})).toEqual(false);
     });
     test('throws error on invalid parse', () => {
-      evaluateOp('foo==\'a\'', defaultContext());
+      evaluateOp('foo==\'a\'', {});
       expect(window.onerror)
         .toHaveBeenCalledWith(
           'Value expected. Note: strings must be enclosed by double quotes (char 6) Op: (foo==\'a\')',
           'shared/parse/context');
     });
     test('throws error on invalid eval', () => {
-      evaluateOp('asdf', defaultContext());
+      evaluateOp('asdf', {});
       expect(window.onerror)
         .toHaveBeenCalledWith('Undefined symbol asdf Op: (asdf)', 'shared/parse/context');
     });
     test('returns value and updates context', () => {
-      const ctx = {...defaultContext(), scope: {b: '1'} as any};
+      const ctx = {scope: {b: '1'} as any};
       expect(evaluateOp('a=b+1;a', ctx)).toEqual(2);
       expect(ctx.scope).toEqual({a: 2, b: '1'});
     });
     test('does not return if last operation assigns a value', () => {
-      expect(evaluateOp('a=1', defaultContext())).toEqual(null);
+      expect(evaluateOp('a=1', {})).toEqual(null);
     });
     test('generates varied random numbers', () => {
-      const ctx = {...defaultContext()};
+      const ctx = {};
       const rng = () => Math.random();
       const output = [];
       for (let i = 0; i < 50; i++) {
@@ -51,7 +51,7 @@ describe('Context', () => {
       expect(arrayUniques(output).length).toBeGreaterThan(20);
     });
     test('has repeatable random() behavior based on seed', () => {
-      const ctx = {...defaultContext()};
+      const ctx = {};
       const rng = () => 0.1;
       const expected = evaluateOp('random()', ctx, rng);
       for (let i = 0; i < 50; i++) {
@@ -61,7 +61,7 @@ describe('Context', () => {
       expect(evaluateOp('random(10, 100)', ctx, rng)).toEqual(evaluateOp('random(10, 100)', ctx, rng));
     });
     test('has repeatable randomInt() behavior based on seed', () => {
-      const ctx = {...defaultContext()};
+      const ctx = {};
       const rng = () => 0.1;
       const expected = evaluateOp('randomInt()', ctx, rng);
       for (let i = 0; i < 50; i++) {
@@ -71,7 +71,7 @@ describe('Context', () => {
       expect(evaluateOp('randomInt(10, 100)', ctx, rng)).toEqual(evaluateOp('randomInt(10, 100)', ctx, rng));
     });
     test('has repeatable pickRandom() behavior based on seed', () => {
-      const ctx = {...defaultContext()};
+      const ctx = {};
       const rng = () => 0.1;
       const expected = evaluateOp('pickRandom([1,2,3])', ctx, rng);
       for (let i = 0; i < 50; i++) {
@@ -82,26 +82,26 @@ describe('Context', () => {
 
   describe('evaluateContentOps', () => {
     test('persists state', () => {
-      const ctx = defaultContext();
+      const ctx = {};
       expect(evaluateContentOps('{{text="TEST"}}', ctx)).toEqual('');
       expect(evaluateContentOps('{{text}}', ctx)).toEqual('TEST');
     });
 
     test('handles multiple ops in one string', () => {
-      const ctx = defaultContext();
+      const ctx = {};
       expect(evaluateContentOps('{{text="TEST"}}\n{{text}}', ctx)).toEqual('TEST');
     });
 
     test('varies results when random() called in same set of ops', () => {
-      const ctx = defaultContext();
+      const ctx = {};
       const result = evaluateContentOps('{{random()}}\n{{random()}}', ctx).split('\n');
       expect(result[1]).not.toEqual(result[2]);
     });
 
     test('changes random result for different contexts', () => {
-      let ctx = defaultContext();
+      let ctx = {};
       const r1 = evaluateContentOps('{{random()}}', ctx);
-      ctx = defaultContext();
+      ctx = {};
       const r2 = evaluateContentOps('{{random()}}', ctx);
       expect(r1).not.toEqual(r2);
     });
@@ -111,7 +111,7 @@ describe('Context', () => {
     const dummyElem = cheerio.load('<combat></combat>')('combat');
 
     test('appends to path', () => {
-      const ctx = defaultContext();
+      const ctx = {};
       expect(ctx.path).toEqual([]);
       const ctx2 = updateContext(dummyElem, ctx, 2);
       expect(ctx2.path).toEqual([2]);
@@ -121,13 +121,13 @@ describe('Context', () => {
       expect(ctx4.path).toEqual([2, 'win', '#testID']);
     });
     test('does not affect other contexts', () => {
-      const ctx = defaultContext();
+      const ctx = {};
       updateContext(dummyElem, ctx, 2);
       expect(ctx.path).not.toEqual([2]);
     });
     test('updates view count', () => {
       const dummyElem = cheerio.load('<roleplay id="1234"></roleplay>')('roleplay');
-      const ctx = updateContext(dummyElem, defaultContext(), 0);
+      const ctx = updateContext(dummyElem, {}, 0);
       expect(ctx.views['1234']).toEqual(1);
     });
   });

--- a/shared/parse/Context.test.tsx
+++ b/shared/parse/Context.test.tsx
@@ -34,72 +34,72 @@ describe('Context', () => {
         .toHaveBeenCalledWith('Undefined symbol asdf Op: (asdf)', 'shared/parse/context');
     });
     test('returns value and updates context', () => {
-      const ctx = {scope: {b: '1'} as any};
-      expect(evaluateOp('a=b+1;a', ctx)).toEqual(2);
-      expect(ctx.scope).toEqual({a: 2, b: '1'});
+      const scope = {b: '1'};
+      expect(evaluateOp('a=b+1;a', scope)).toEqual(2);
+      expect(scope).toEqual({a: 2, b: '1'});
     });
     test('does not return if last operation assigns a value', () => {
       expect(evaluateOp('a=1', {})).toEqual(null);
     });
     test('generates varied random numbers', () => {
-      const ctx = {};
+      const scope = {};
       const rng = () => Math.random();
       const output = [];
       for (let i = 0; i < 50; i++) {
-        output.push(evaluateOp('random()', ctx, rng));
+        output.push(evaluateOp('random()', scope, rng));
       }
       expect(arrayUniques(output).length).toBeGreaterThan(20);
     });
     test('has repeatable random() behavior based on seed', () => {
-      const ctx = {};
+      const scope = {};
       const rng = () => 0.1;
-      const expected = evaluateOp('random()', ctx, rng);
+      const expected = evaluateOp('random()', scope, rng);
       for (let i = 0; i < 50; i++) {
-        expect(evaluateOp('random()', ctx, rng)).toEqual(expected);
+        expect(evaluateOp('random()', scope, rng)).toEqual(expected);
       }
-      expect(evaluateOp('random(100)', ctx, rng)).toEqual(evaluateOp('random(100)', ctx, rng));
-      expect(evaluateOp('random(10, 100)', ctx, rng)).toEqual(evaluateOp('random(10, 100)', ctx, rng));
+      expect(evaluateOp('random(100)', scope, rng)).toEqual(evaluateOp('random(100)', scope, rng));
+      expect(evaluateOp('random(10, 100)', scope, rng)).toEqual(evaluateOp('random(10, 100)', scope, rng));
     });
     test('has repeatable randomInt() behavior based on seed', () => {
-      const ctx = {};
+      const scope = {};
       const rng = () => 0.1;
-      const expected = evaluateOp('randomInt()', ctx, rng);
+      const expected = evaluateOp('randomInt()', scope, rng);
       for (let i = 0; i < 50; i++) {
-        expect(evaluateOp('randomInt()', ctx, rng)).toEqual(expected);
+        expect(evaluateOp('randomInt()', scope, rng)).toEqual(expected);
       }
-      expect(evaluateOp('randomInt(100)', ctx, rng)).toEqual(evaluateOp('randomInt(100)', ctx, rng));
-      expect(evaluateOp('randomInt(10, 100)', ctx, rng)).toEqual(evaluateOp('randomInt(10, 100)', ctx, rng));
+      expect(evaluateOp('randomInt(100)', scope, rng)).toEqual(evaluateOp('randomInt(100)', scope, rng));
+      expect(evaluateOp('randomInt(10, 100)', scope, rng)).toEqual(evaluateOp('randomInt(10, 100)', scope, rng));
     });
     test('has repeatable pickRandom() behavior based on seed', () => {
-      const ctx = {};
+      const scope = {};
       const rng = () => 0.1;
-      const expected = evaluateOp('pickRandom([1,2,3])', ctx, rng);
+      const expected = evaluateOp('pickRandom([1,2,3])', scope, rng);
       for (let i = 0; i < 50; i++) {
-        expect(evaluateOp('pickRandom([1,2,3])', ctx, rng)).toEqual(expected);
+        expect(evaluateOp('pickRandom([1,2,3])', scope, rng)).toEqual(expected);
       }
     });
   });
 
   describe('evaluateContentOps', () => {
     test('persists state', () => {
-      const ctx = {};
+      const ctx = defaultContext();
       expect(evaluateContentOps('{{text="TEST"}}', ctx)).toEqual('');
       expect(evaluateContentOps('{{text}}', ctx)).toEqual('TEST');
     });
 
     test('handles multiple ops in one string', () => {
-      const ctx = {};
+      const ctx = defaultContext();
       expect(evaluateContentOps('{{text="TEST"}}\n{{text}}', ctx)).toEqual('TEST');
     });
 
     test('varies results when random() called in same set of ops', () => {
-      const ctx = {};
+      const ctx = defaultContext();
       const result = evaluateContentOps('{{random()}}\n{{random()}}', ctx).split('\n');
       expect(result[1]).not.toEqual(result[2]);
     });
 
     test('changes random result for different contexts', () => {
-      let ctx = {};
+      let ctx = defaultContext();
       const r1 = evaluateContentOps('{{random()}}', ctx);
       ctx = {};
       const r2 = evaluateContentOps('{{random()}}', ctx);
@@ -111,7 +111,7 @@ describe('Context', () => {
     const dummyElem = cheerio.load('<combat></combat>')('combat');
 
     test('appends to path', () => {
-      const ctx = {};
+      const ctx = defaultContext();
       expect(ctx.path).toEqual([]);
       const ctx2 = updateContext(dummyElem, ctx, 2);
       expect(ctx2.path).toEqual([2]);
@@ -121,13 +121,13 @@ describe('Context', () => {
       expect(ctx4.path).toEqual([2, 'win', '#testID']);
     });
     test('does not affect other contexts', () => {
-      const ctx = {};
+      const ctx = defaultContext();
       updateContext(dummyElem, ctx, 2);
       expect(ctx.path).not.toEqual([2]);
     });
     test('updates view count', () => {
       const dummyElem = cheerio.load('<roleplay id="1234"></roleplay>')('roleplay');
-      const ctx = updateContext(dummyElem, {}, 0);
+      const ctx = updateContext(dummyElem, defaultContext(), 0);
       expect(ctx.views['1234']).toEqual(1);
     });
   });

--- a/shared/parse/Context.tsx
+++ b/shared/parse/Context.tsx
@@ -104,7 +104,7 @@ export function evaluateContentOps(content: string, ctx: Context): string {
 // Attempts to evaluate op using ctx.
 // If the evaluation is successful, the context is modified as determined by the op.
 // If the last operation does not assign a value, the result is returned.
-export function evaluateOp(op: string, scope: Object, rng: () => number = Math.random): any {
+export function evaluateOp(op: string, scope: any, rng: () => number = Math.random): any {
   let parsed;
   let evalResult;
 

--- a/shared/parse/Context.tsx
+++ b/shared/parse/Context.tsx
@@ -89,7 +89,7 @@ export function evaluateContentOps(content: string, ctx: Context): string {
   for (const m of matches) {
     const op = parseOpString(m);
     if (op) {
-      const evalResult = evaluateOp(op, ctx, rng);
+      const evalResult = evaluateOp(op, ctx.scope, rng);
       if (evalResult || evalResult === 0) {
         result += evalResult;
       }
@@ -104,7 +104,7 @@ export function evaluateContentOps(content: string, ctx: Context): string {
 // Attempts to evaluate op using ctx.
 // If the evaluation is successful, the context is modified as determined by the op.
 // If the last operation does not assign a value, the result is returned.
-export function evaluateOp(op: string, ctx: Context, rng: () => number = Math.random): any {
+export function evaluateOp(op: string, scope: Object, rng: () => number = Math.random): any {
   let parsed;
   let evalResult;
 
@@ -127,7 +127,7 @@ export function evaluateOp(op: string, ctx: Context, rng: () => number = Math.ra
 
   try {
     parsed = MathJS.parse(HtmlDecode(op));
-    evalResult = parsed.compile().eval(ctx.scope);
+    evalResult = parsed.compile().eval(scope);
   } catch (err) {
     const message = err.message + ' Op: (' + op + ')';
     if (self && !self.document) { // webworker

--- a/shared/parse/Node.tsx
+++ b/shared/parse/Node.tsx
@@ -1,4 +1,4 @@
-import {evaluateOp, Context, evaluateContentOps, updateContext} from './Context';
+import {Context, evaluateContentOps, evaluateOp, updateContext} from './Context';
 
 const seedrandom = require('seedrandom');
 const Clone = require('clone');
@@ -266,7 +266,7 @@ export class Node<C extends Context> {
 
     try {
       // Operate on copied scope - checking for enablement should never change the current context.
-      const visible = evaluateOp(ifExpr, Clone(this.ctx.scope), this.rng);
+      const visible = evaluateOp(ifExpr, {scope: Clone(this.ctx.scope)}, this.rng);
       // We check for truthiness here, so nonzero numbers are true, etc.
       return Boolean(visible);
     } catch (e) {

--- a/shared/parse/Node.tsx
+++ b/shared/parse/Node.tsx
@@ -266,7 +266,7 @@ export class Node<C extends Context> {
 
     try {
       // Operate on copied scope - checking for enablement should never change the current context.
-      const visible = evaluateOp(ifExpr, {scope: Clone(this.ctx.scope)}, this.rng);
+      const visible = evaluateOp(ifExpr, Clone(this.ctx.scope), this.rng);
       // We check for truthiness here, so nonzero numbers are true, etc.
       return Boolean(visible);
     } catch (e) {


### PR DESCRIPTION
Fixes #644

- Found an error path, instead made it load an earlier stage in the quest.
- Found repro for #644 - mid-combat RP events with RNG was not properly observed and threw the error (now warning). To get take a stab at fixing the real problem, I hooked up evaluation of conditional quest events to the node's seed.
- Also extended the console logging when reconstructing a quest so we have more details next time.