### PR TITLE
Add maxrolls json feature to decisions

### DIFF
--- a/services/app/src/components/views/quest/cardtemplates/decision/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Actions.test.tsx
@@ -29,6 +29,16 @@ const TEST_NODE = new ParserNode(cheerio.load(`
     <event on="interrupted"></event>
   </decision>`)('decision'), defaultContext());
 
+const TEST_NODE_MAX_2 = new ParserNode(cheerio.load(`
+  <decision maxrolls="2">
+    <p>Decision text</p>
+    <event on="light athletics"></event>
+    <event on="dark athletics"></event>
+    <event on="charisma"></event>
+    <event on="failure"><roleplay>failure node reached</roleplay></event>
+    <event on="interrupted"></event>
+  </decision>`)('decision'), defaultContext());
+
 // Parsed from TEST_NODE
 const testDecision = (requiredSuccesses: number) => {
   return {
@@ -122,6 +132,9 @@ describe('Decision actions', () => {
     });
     test('computes interrupted', () => {
       expect(computeOutcome([20, 20, 20, 20, 10], selected, s.basic, TEST_NODE, m.s2p5)).toEqual(Outcome.interrupted);
+    });
+    test('computes interrupted when over max rolls', () => {
+      expect(computeOutcome([20, 10], selected, s.basic, TEST_NODE_MAX_2, m.s2p5)).toEqual(Outcome.interrupted);
     });
     test('computes retry', () => {
       expect(computeOutcome([20, 20, 20, 20], selected, s.basic, TEST_NODE, m.s2p5)).toEqual(Outcome.retry);

--- a/services/app/src/components/views/quest/cardtemplates/decision/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Actions.tsx
@@ -96,7 +96,7 @@ export function computeOutcome(rolls: number[], selected: LeveledSkillCheck, set
   const retryThreshold = RETRY_THRESHOLD_MAP[selected.difficulty || 'Medium'];
   const successes = computeSuccesses(rolls, selected);
   const failures = rolls.reduce((acc, r) => (r < retryThreshold) ? acc + 1 : acc, 0);
-  const maxRolls = parseInt(node.elem.attr('maxrolls'));
+  const maxRolls = parseInt(node.elem.attr('maxrolls'), 10);
   let outcome: (keyof typeof Outcome)|null = null;
   if (successes >= selected.requiredSuccesses) {
     outcome = Outcome.success;

--- a/services/app/src/components/views/quest/cardtemplates/decision/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Actions.tsx
@@ -96,12 +96,13 @@ export function computeOutcome(rolls: number[], selected: LeveledSkillCheck, set
   const retryThreshold = RETRY_THRESHOLD_MAP[selected.difficulty || 'Medium'];
   const successes = computeSuccesses(rolls, selected);
   const failures = rolls.reduce((acc, r) => (r < retryThreshold) ? acc + 1 : acc, 0);
+  const maxRolls = parseInt(node.elem.attr('maxrolls'));
   let outcome: (keyof typeof Outcome)|null = null;
   if (successes >= selected.requiredSuccesses) {
     outcome = Outcome.success;
   } else if (failures > 0) {
     outcome = Outcome.failure;
-  } else if (rolls.length >= aliveAdventurers) {
+  } else if (rolls.length >= aliveAdventurers || (maxRolls && rolls.length >= maxRolls)) {
     outcome = Outcome.interrupted;
   } else if (rolls.length > 0) {
     outcome = Outcome.retry;


### PR DESCRIPTION
Fixes #683

This allows users to set a maximum number of skill check rolls - e.g. if they want to simulate a single adventurer making a skill check, they don't have to go through 5 rerolls if there's a 6-person party.