### PR TITLE
Propagate op errors, add default timing metadata

### DIFF
--- a/services/quests/package.json
+++ b/services/quests/package.json
@@ -5,6 +5,6 @@
   "homepage": "http://quests.expeditiongame.com",
   "scripts": {
     "start": "webpack-dev-server --progress",
-    "build": "node --max-old-space-size=8192 ../../node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.dist.config.js"
+    "build": "SKIP_RUNNER=true webpack --config webpack.dist.config.js"
   }
 }

--- a/services/quests/package.json
+++ b/services/quests/package.json
@@ -5,6 +5,6 @@
   "homepage": "http://quests.expeditiongame.com",
   "scripts": {
     "start": "webpack-dev-server --progress",
-    "build": "node --max-old-space-size=8192 node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.dist.config.js"
+    "build": "node --max-old-space-size=8192 ../../node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.dist.config.js"
   }
 }

--- a/services/quests/package.json
+++ b/services/quests/package.json
@@ -5,6 +5,6 @@
   "homepage": "http://quests.expeditiongame.com",
   "scripts": {
     "start": "webpack-dev-server --progress",
-    "build": "webpack --config webpack.dist.config.js"
+    "build": "node --max-old-space-size=8192 node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.dist.config.js"
   }
 }

--- a/services/quests/src/Constants.tsx
+++ b/services/quests/src/Constants.tsx
@@ -24,6 +24,8 @@ export const METADATA_DEFAULTS = {
   expansionscarredlands: false,
   maxplayers: MAX_PLAYERS,
   minplayers: MIN_PLAYERS,
+  mintimeminutes: 10,
+  maxtimeminutes: 999,
   requirespenpaper: false,
   theme: 'base',
 };

--- a/services/quests/src/playtest/PlaytestCrawler.test.tsx
+++ b/services/quests/src/playtest/PlaytestCrawler.test.tsx
@@ -147,8 +147,8 @@ describe('PlaytestCrawler', () => {
         <trigger>end</trigger>
       </quest>`)('quest > :first-child'));
 
-      expect(msgs.warning.length).toEqual(1);
-      expect(msgs.warning[0].text).toContain('notavar');
+      expect(msgs.error.length).toEqual(1);
+      expect(msgs.error[0].text).toContain('notavar');
     });
 
     test.skip('logs if quest length is too varied', () => { /* TODO */ });

--- a/services/quests/src/playtest/PlaytestCrawler.tsx
+++ b/services/quests/src/playtest/PlaytestCrawler.tsx
@@ -89,9 +89,9 @@ export class PlaytestCrawler extends StatsCrawler {
     }
   }
 
-  protected onWarnings(q: StatsCrawlEntry, warnings: Error[], line: number) {
-    for (const w of warnings) {
-      this.logger.warn(w.toString(), '427', line);
+  protected onErrors(q: StatsCrawlEntry, errors: Error[], line: number) {
+    for (const e of errors) {
+      this.logger.err(e.toString(), '427', line);
     }
   }
 

--- a/services/quests/src/playtest/Runner.test.tsx
+++ b/services/quests/src/playtest/Runner.test.tsx
@@ -1,0 +1,3 @@
+describe('Runner', () => {
+  test.skip('runs', () => { /* TODO */ });
+});

--- a/services/quests/src/playtest/Runner.tsx
+++ b/services/quests/src/playtest/Runner.tsx
@@ -1,0 +1,142 @@
+import {fetchSearchResults} from 'app/actions/Search';
+import {initialSearch} from 'app/reducers/Search';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import {connect, Provider} from 'react-redux';
+import Redux, {applyMiddleware, compose, createStore} from 'redux';
+import thunk from 'redux-thunk';
+
+interface RunState {[id: string]: {xml: string, messages: string[], complete: boolean}; }
+
+const middleware = [thunk];
+const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+function reduce(state: RunState, action: Redux.Action): RunState {
+  state = state || ({} as RunState);
+
+  const id = (action as any).id;
+  if (!id) {
+    return state;
+  }
+
+  switch (action.type) {
+    case 'PLAYTEST_START':
+      state = {...state, [id]: {title: (action as any).title, email: (action as any).email, author: (action as any).author, messages: [], complete: false}};
+      break;
+    case 'PLAYTEST_COMPLETE':
+      state = {...state, [id]: {...state[id]}};
+      state[id].complete = true;
+      break;
+    case 'PLAYTEST_MESSAGE':
+      state = {...state, [id]: {...state[id]}};
+      state[id].messages = (action as any).msg;
+      break;
+    case 'PLAYTEST_ERROR':
+      state = {...state, [id]: {...state[id]}};
+      state[id].messages = (action as any).msg;
+      break;
+  }
+  return state;
+}
+
+const store = createStore(reduce, {}, composeEnhancers(applyMiddleware(...middleware)));
+
+function startSearching() {
+  fetchSearchResults(initialSearch.params).then((results: any) => {
+    const proms: any[] = [];
+    for (const r of results.quests) {
+      proms.push(fetch(r.publishedurl).then((response) => response.text()).then((xml) => {
+        return {id: r.id, title: r.title, author: r.author, email: r.email, xml};
+      }));
+    }
+    return Promise.all(proms);
+  }).then((loadedQuests: any) => {
+    for (const q of loadedQuests) {
+      if (!(window as any).Worker) {
+        console.log('Web worker not available, skipping playtest.');
+        return;
+      }
+
+      const worker = new Worker('playtest.js');
+      worker.onerror = (ev: ErrorEvent) => {
+        store.dispatch({type: 'PLAYTEST_ERROR', msg: ev.error, id: q.id});
+        worker.terminate();
+      };
+      worker.onmessage = (e: MessageEvent) => {
+        if (e.data.status === 'COMPLETE') {
+          store.dispatch({type: 'PLAYTEST_COMPLETE', id: q.id});
+        } else {
+          store.dispatch({type: 'PLAYTEST_MESSAGE', msg: e.data.error, id: q.id});
+        }
+      };
+
+      // TODO proper settings
+      worker.postMessage({type: 'RUN', xml: q.xml, settings: {
+        expansionhorror: true,
+        expansionfuture: true,
+        expansionscarredlands: true,
+      }});
+      console.log('started worker for quest ' + q.id);
+      store.dispatch({type: 'PLAYTEST_START', id: q.id, title: q.title, author: q.author, email: q.email});
+    }
+  });
+}
+
+setTimeout(() => {
+  startSearching();
+}, 1000);
+
+interface Props {
+  state: any;
+}
+
+const Main = (props: Props): JSX.Element => {
+  const results: JSX.Element[] = [];
+  for (const id of Object.keys(props.state)) {
+    const msgs = props.state[id].messages.map((msg: any, i: number) => {
+      return <li key={i}>{JSON.stringify(msg)}</li>;
+    });
+    results.push(
+      <div key={id}>
+        <h3>
+          <a href={'https://quests.expeditiongame.com/#' + id} target="_blank">{props.state[id].title}</a>
+          &nbsp;by {props.state[id].author}
+          &nbsp;({props.state[id].email})
+          &nbsp;{(props.state[id].complete) ? 'DONE' : '...'}
+        </h3>
+        <ul>
+          {msgs}
+        </ul>
+      </div>
+    );
+  }
+
+  return <div>{results}</div>;
+};
+
+const mapStateToProps = (state: any): any => {
+  return {state};
+};
+
+const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): any => {
+  return {};
+};
+
+const MainContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Main);
+
+const render = () => {
+  const base = document.getElementById('react-app');
+  if (!base) {
+    throw new Error('Could not find react-app element');
+  }
+  ReactDOM.unmountComponentAtNode(base);
+  ReactDOM.render(
+      <Provider store={store}>
+        <MainContainer/>
+      </Provider>,
+    base
+  );
+};
+render();

--- a/services/quests/src/playtest/Runner.tsx
+++ b/services/quests/src/playtest/Runner.tsx
@@ -1,3 +1,7 @@
+// This file is a quick hack and not used by external users!
+// When loaded, it does a default search and runs the playtest code against all results,
+// displaying any playtest errors as well as a link to the quest and the author's contact details.
+
 import {fetchSearchResults} from 'app/actions/Search';
 import {initialSearch} from 'app/reducers/Search';
 import * as React from 'react';
@@ -69,7 +73,6 @@ function startSearching() {
         }
       };
 
-      // TODO proper settings
       worker.postMessage({type: 'RUN', xml: q.xml, settings: {
         expansionhorror: true,
         expansionfuture: true,

--- a/services/quests/src/playtest/Runner.tsx
+++ b/services/quests/src/playtest/Runner.tsx
@@ -38,6 +38,8 @@ function reduce(state: RunState, action: Redux.Action): RunState {
       state = {...state, [id]: {...state[id]}};
       state[id].messages = (action as any).msg;
       break;
+    default:
+      break;
   }
   return state;
 }

--- a/services/quests/src/playtest/StatsCrawler.tsx
+++ b/services/quests/src/playtest/StatsCrawler.tsx
@@ -96,7 +96,7 @@ export class StatsCrawler extends CrawlerBase<Context> {
     this.statsByEvent[e].push({line: q.prevLine, id: q.prevId, fromAction: q.fromAction});
   }
 
-  protected onWarnings(q: StatsCrawlEntry, warnings: Error[], line: number) {
+  protected onErrors(q: StatsCrawlEntry, errors: Error[], line: number) {
     // Do nothing, but required as implementation of abstract class.
   }
 

--- a/services/quests/src/runner.html
+++ b/services/quests/src/runner.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Expedition Quest Creator - Quest Runner</title>
+    <link rel='shortcut icon' href='/images/favicon.ico' type='image/x-icon'/>
+    <script src="//apis.google.com/js/api.js"></script>
+    <script src="scripts/jquery.3.2.1.min.js"></script>
+    <script src="scripts/realtime-client-utils.min.js"></script>
+  </head>
+  <body>
+    <section id="react-app"></section>
+    <script type="text/javascript" src="runner.js"></script>
+  </body>
+</html>

--- a/services/quests/webpack.config.js
+++ b/services/quests/webpack.config.js
@@ -5,17 +5,12 @@ const shared = require('../../shared/webpack.shared');
 
 const options = {
   entry: {
-    bundle: [
-      './src/React.tsx',
-      './src/Style.scss',
-      '../app/src/Style.scss',
-    ],
-    playtest: [
-      './src/playtest/PlaytestWorker.tsx',
-    ],
+    bundle: ['./src/React.tsx', './src/Style.scss', '../app/src/Style.scss'],
+    playtest: ['./src/playtest/PlaytestWorker.tsx'],
+    runner: ['./src/playtest/Runner.tsx'],
   },
   output: {
-    globalObject: "this", // Fixes web workers - https://github.com/webpack/webpack/issues/6642
+    globalObject: 'this', // Fixes web workers - https://github.com/webpack/webpack/issues/6642
   },
   plugins: [
     new Webpack.DefinePlugin({
@@ -23,10 +18,19 @@ const options = {
     }),
     new CopyWebpackPlugin([
       { from: 'src/index.html' },
+      { from: 'src/runner.html' },
       { from: 'src/assets' },
       { from: '../app/src/images', to: 'images' },
-      { from: { glob: '../../shared/images/icons/*.svg' }, flatten: true, to: './images' },
-      { from: { glob: '../../shared/images/art/*.png' }, flatten: true, to: './images' },
+      {
+        from: { glob: '../../shared/images/icons/*.svg' },
+        flatten: true,
+        to: './images',
+      },
+      {
+        from: { glob: '../../shared/images/art/*.png' },
+        flatten: true,
+        to: './images',
+      },
     ]),
   ],
 };

--- a/services/quests/webpack.config.js
+++ b/services/quests/webpack.config.js
@@ -3,12 +3,17 @@ const Webpack = require('webpack');
 const Merge = require('webpack-merge');
 const shared = require('../../shared/webpack.shared');
 
+const entry = {
+  bundle: ['./src/React.tsx', './src/Style.scss', '../app/src/Style.scss'],
+  playtest: ['./src/playtest/PlaytestWorker.tsx'],
+};
+
+if (process.env.SKIP_RUNNER !== 'true') {
+  entry.runner = ['./src/playtest/Runner.tsx'];
+}
+
 const options = {
-  entry: {
-    bundle: ['./src/React.tsx', './src/Style.scss', '../app/src/Style.scss'],
-    playtest: ['./src/playtest/PlaytestWorker.tsx'],
-    runner: ['./src/playtest/Runner.tsx'],
-  },
+  entry,
   output: {
     globalObject: 'this', // Fixes web workers - https://github.com/webpack/webpack/issues/6642
   },
@@ -22,13 +27,13 @@ const options = {
       { from: 'src/assets' },
       { from: '../app/src/images', to: 'images' },
       {
-        from: { glob: '../../shared/images/icons/*.svg' },
         flatten: true,
+        from: { glob: '../../shared/images/icons/*.svg' },
         to: './images',
       },
       {
-        from: { glob: '../../shared/images/art/*.png' },
         flatten: true,
+        from: { glob: '../../shared/images/art/*.png' },
         to: './images',
       },
     ]),

--- a/shared/parse/Context.tsx
+++ b/shared/parse/Context.tsx
@@ -130,9 +130,7 @@ export function evaluateOp(op: string, scope: any, rng: () => number = Math.rand
     evalResult = parsed.compile().eval(scope);
   } catch (err) {
     const message = err.message + ' Op: (' + op + ')';
-    if (self && !self.document) { // webworker
-      return null;
-    } else if (window && window.onerror) {
+    if (self && self.document && window && window.onerror) {
       window.onerror(message, 'shared/parse/context');
       return null;
     } else {

--- a/shared/parse/Crawler.test.tsx
+++ b/shared/parse/Crawler.test.tsx
@@ -10,11 +10,11 @@ class CrawlTest extends CrawlerBase<Context> {
 
   constructor(onEvent: ((q: CrawlEntry<Context>, e: CrawlEvent) => any)|null,
               onNode: ((q: CrawlEntry<Context>, nodeStr: string, id: string, line: number) => any)|null,
-              onWarnings: ((q: CrawlEntry<Context>, warnings: Error[], line: number) => any)|null) {
+              onErrors: ((q: CrawlEntry<Context>, errors: Error[], line: number) => any)|null) {
     super();
     this.efn = onEvent;
     this.nfn = onNode;
-    this.wfn = onWarnings;
+    this.wfn = onErrors;
   }
 
   protected onEvent(q: CrawlEntry<Context>, e: CrawlEvent) {
@@ -27,7 +27,7 @@ class CrawlTest extends CrawlerBase<Context> {
       this.nfn(q, nodeStr, id, line);
     }
   }
-  protected onWarnings(q: CrawlEntry<Context>, warnings: Error[], line: number) {
+  protected onErrors(q: CrawlEntry<Context>, errors: Error[], line: number) {
     if (this.wfn) {
       this.wfn(q, warnings, line);
     }
@@ -290,20 +290,28 @@ describe('CrawlerBase', () => {
       crawler.crawl(new Node(xml, defaultContext()));
     });
 
-    test('handles warnings', () => {
+    test('handles errors in conditionals', () => {
       const xml = cheerio.load(`
         <roleplay title="I" data-line="2">
           <choice if="notavar"><roleplay></roleplay></choice>
         </roleplay>`)(':first-child');
-      let foundWarnings = false;
-      const crawler = new CrawlTest(null, null, (q: CrawlEntry<Context>, warnings: Error[], line: number) => {
-        foundWarnings = true;
-        expect(warnings[0].toString()).toContain('notavar');
+      let foundErrors = false;
+      const crawler = new CrawlTest(null, null, (q: CrawlEntry<Context>, errors: Error[], line: number) => {
+        foundErrors = true;
+        expect(errors[0].toString()).toContain('notavar');
         expect(line).toEqual(2);
       });
       crawler.crawl(new Node(xml, defaultContext()));
 
-      expect(foundWarnings).toEqual(true);
+      expect(foundErrors).toEqual(true);
+    });
+
+    test('handles errors in body', () => {
+      // TODO
+    });
+
+    test('handles errors in attributes', () => {
+      // TODO
     });
   });
 });

--- a/shared/parse/Crawler.test.tsx
+++ b/shared/parse/Crawler.test.tsx
@@ -29,7 +29,7 @@ class CrawlTest extends CrawlerBase<Context> {
   }
   protected onErrors(q: CrawlEntry<Context>, errors: Error[], line: number) {
     if (this.wfn) {
-      this.wfn(q, warnings, line);
+      this.wfn(q, errors, line);
     }
   }
 }
@@ -290,7 +290,7 @@ describe('CrawlerBase', () => {
       crawler.crawl(new Node(xml, defaultContext()));
     });
 
-    test('handles errors in conditionals', () => {
+    test('handles errors in attributes', () => {
       const xml = cheerio.load(`
         <roleplay title="I" data-line="2">
           <choice if="notavar"><roleplay></roleplay></choice>
@@ -307,11 +307,33 @@ describe('CrawlerBase', () => {
     });
 
     test('handles errors in body', () => {
-      // TODO
+      const xml = cheerio.load(`
+        <roleplay title="I" data-line="2">
+          <p>{{notavar}}</p>
+        </roleplay>`)(':first-child');
+      let foundErrors = false;
+      const crawler = new CrawlTest(null, null, (q: CrawlEntry<Context>, errors: Error[], line: number) => {
+        foundErrors = true;
+        expect(errors[0].toString()).toContain('notavar');
+        expect(line).toEqual(2);
+      });
+      crawler.crawl(new Node(xml, defaultContext()));
+      expect(foundErrors).toEqual(true);
     });
 
-    test('handles errors in attributes', () => {
-      // TODO
+    test('handles errors in trigger', () => {
+      const xml = cheerio.load(`
+        <roleplay title="I" data-line="2">
+          <trigger>{{notavar}}</trigger>
+        </roleplay>`)(':first-child');
+      let foundErrors = false;
+      const crawler = new CrawlTest(null, null, (q: CrawlEntry<Context>, errors: Error[], line: number) => {
+        foundErrors = true;
+        expect(errors[0].toString()).toContain('notavar');
+        expect(line).toEqual(2);
+      });
+      crawler.crawl(new Node(xml, defaultContext()));
+      expect(foundErrors).toEqual(true);
     });
   });
 });

--- a/shared/parse/Crawler.tsx
+++ b/shared/parse/Crawler.tsx
@@ -65,7 +65,7 @@ export abstract class CrawlerBase<C extends Context> {
 
   protected abstract onNode(q: CrawlEntry<C>, nodeStr: string, id: string, line: number): void;
 
-  protected abstract onWarnings(q: CrawlEntry<C>, warnings: Error[], line: number): void;
+  protected abstract onErrors(q: CrawlEntry<C>, errors: Error[], line: number): void;
 
   // Traverses the graph in breadth-first order starting with a given node.
   // Stats are collected separately per-id and per-line
@@ -142,9 +142,9 @@ export abstract class CrawlerBase<C extends Context> {
           fromAction: k,
         });
       }
-      const warnings = q.node.getWarnings();
-      if (warnings.length > 0) {
-        this.onWarnings(q, warnings, line);
+      const errors = q.node.getErrors();
+      if (errors.length > 0) {
+        this.onErrors(q, errors, line);
       }
     }
     return (this.queue.size > 0);

--- a/shared/parse/Node.test.tsx
+++ b/shared/parse/Node.test.tsx
@@ -73,7 +73,7 @@ describe('Node', () => {
         throw new Error('getNext returned null node');
       }
       expect(next.elem.text()).toEqual('expected');
-      expect(pnode.getWarnings()[0].toString()).toContain('notavalue');
+      expect(pnode.getErrors()[0].toString()).toContain('notavalue');
     });
   });
 

--- a/shared/parse/Node.test.tsx
+++ b/shared/parse/Node.test.tsx
@@ -65,7 +65,7 @@ describe('Node', () => {
       }
       expect(next.elem.text()).toEqual('expected');
     });
-    test('safely handles failing to eval conditional choice, logs warning', () => {
+    test('safely handles failing to eval conditional choice, logs error', () => {
       const quest = cheerio.load('<quest><roleplay><choice if="notavalue"><roleplay>expected</roleplay></choice><choice><roleplay>bad</roleplay></choice></roleplay></quest>')('quest');
       const pnode = new Node(quest.children().eq(0), defaultContext());
       const next = pnode.getNext(0);


### PR DESCRIPTION
Fixes #698
#422

Quest creator previously ignored failures in op node parsing within the body of the quest - this promotes those op errors to real errors when the crawler encounters them, so that quests are more likely to succeed in the wild.