### PR TITLE
streamline rules wordings

### DIFF
--- a/services/app/src/components/views/quest/cardtemplates/combat/Victory.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Victory.tsx
@@ -34,7 +34,7 @@ function renderHealing(props: Props): JSX.Element|null {
     );
   } else {
     return (
-      <p><strong>Heal to full health</strong> (All adventurers, even if at 0 health).</p>
+      <p><strong>Heal to full</strong> (All adventurers, even if at 0 health).</p>
     );
   }
 }
@@ -78,33 +78,43 @@ function maybeRenderLevelUp(props: Props): JSX.Element|null {
   return (
     <span>
       <h2>LEVEL UP! <img className="inline_icon" src={'images/' + formatImg('cards', props.theme) + '.svg'}></img></h2>
-      <p>All adventurers may learn a new ability{(props.settings.showHelp) ? ':' : '.'}</p>
-      {props.settings.showHelp && <span>
-        <ul>
-          <li>Draw 3 abilities from one of the decks listed on your adventurer card.</li>
-            {props.contentSets.has(Expansion.horror) && <ul>
-              <li>
-                <img className="inline_icon" src={'images/' + formatImg('horror', props.theme) + '.svg'} />
-                <strong>{CONTENT_SET_FULL_NAMES.horror}:</strong> All adventurers may also draw from the Influence deck.
-              </li>
-            </ul>}
-          <li>Add 1 to your ability deck, and place the remaining 2 at the bottom of the deck you drew from.</li>
-          <li>You <i>may</i> choose to discard an ability.</li>
-        </ul>
-      </span>}
-      {props.contentSets.has(Expansion.future) && <span>
-        <p>
+      <p>All adventurers <i>may</i> (pick one):</p>
+      <ul>
+        <li>Learn a new ability.
+          {props.settings.showHelp && <ul>
+            <li>Draw 3 abilities from one of the decks listed on your adventurer card.</li>
+              {props.contentSets.has(Expansion.horror) && <ul>
+                <li>
+                  <img className="inline_icon" src={'images/' + formatImg('horror', props.theme) + '.svg'} />
+                  <strong>{CONTENT_SET_FULL_NAMES.horror}:</strong> All adventurers may also draw from the Influence deck.
+                </li>
+              </ul>}
+            <li>Add 1 to your ability deck, and place the remaining 2 at the bottom of their deck.</li>
+            <li>You <i>may</i> choose to discard an ability.</li>
+          </ul>}
+        </li>
+        {props.contentSets.has(Expansion.horror) && <li>
+          <img className="inline_icon" src={'images/' + formatImg('horror', props.theme) + '.svg'} />
+          <strong>The Horror:</strong> Increase their Persona by 2.
+        </li>}
+        {props.contentSets.has(Expansion.future) && <li>
           <img className="inline_icon" src={'images/' + formatImg('synth', props.theme) + '.svg'} />
-          <strong>The Future:</strong> Adventurers can learn or advance a skill instead of learning an ability.
-        </p>
-        {props.settings.showHelp && <span>
-          <ul>
+          <strong>The Future:</strong> Learn a new skill.
+          {props.settings.showHelp && <ul>
             <li>Draw 3 skills and select one of them.</li>
             <li>Place it face up near your adventurer, and add a clip at the leftmost level position.</li>
             <li>Place the remaining 2 at the bottom of the skill deck.</li>
-          </ul>
-        </span>}
-      </span>}
+          </ul>}
+        </li>}
+        {props.contentSets.has(Expansion.future) && <li>
+          <img className="inline_icon" src={'images/' + formatImg('synth', props.theme) + '.svg'} />
+          <strong>The Future:</strong> Level up a skill.
+          {props.settings.showHelp && <ul>
+            <li>Move the clip on one skill one position to the right.</li>
+          </ul>}
+        </li>}
+      </ul>
+
     </span>
   );
 }

--- a/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecision.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecision.tsx
@@ -57,21 +57,20 @@ export default function resolveDecision(props: Props): JSX.Element {
     helpText = (<span>
       <h2>Roll <img className="inline_icon" src={'images/' + formatImg('roll', props.theme) + '.svg'}></img></h2>
       <p>
-        <strong>Roll</strong> for a single adventurer above zero health that hasn't yet rolled.
-        This counts as a roleplaying roll.
+        <strong>Roll</strong> for a single adventurer, picked by the party.
       </p>
       <h2>Add <img className="inline_icon" src={'images/' + formatImg('skill', props.theme) + '.svg'}></img></h2>
       <p>
-        <strong>Add</strong> the level of each of the adventurer's {selected.skill} skills.
+        <strong>Add</strong> the sum of levels of their {selected.skill} skills to their roll.
         {selected.persona && ` Also add 1 if the adventurer's persona type is ${selected.persona}.`}
       </p>
       <h2>Resolve <img className="inline_icon" src={'images/' + formatImg('damage', props.theme) + '.svg'}></img></h2>
       <p>
-        <strong>Tap</strong> the button matching your roll.
+        <strong>Tap</strong> the button matching your modified roll.
       </p>
       <p>
         <strong>Careful!</strong> Some actions are riskier than others,
-        <br/>and rolling too low may cause instant failure.
+        <br/>and rolling too low may cause bad things to happen.
       </p>
     </span>);
   }


### PR DESCRIPTION
Streamlines combat and skill check rules wordings. Further work could be done with https://github.com/ExpeditionRPG/expedition/issues/718, but that's a larger discussion.

The new combat rules:
<img width="972" alt="Screen Shot 2019-06-30 at 12 09 53" src="https://user-images.githubusercontent.com/775657/60399282-3adfed00-9b30-11e9-9e41-90ed4e066e27.png">
<img width="393" alt="Screen Shot 2019-06-30 at 12 10 04" src="https://user-images.githubusercontent.com/775657/60399283-3adfed00-9b30-11e9-8047-ff17c048d4ff.png">
