### PR TITLE
1.21.0; fix level-up text

### DIFF
--- a/services/api/src/models/Feedback.ts
+++ b/services/api/src/models/Feedback.ts
@@ -45,9 +45,7 @@ function formatUserMetadata(user: User | null) {
   if (!user || !user.created || !user.loginCount) {
     return '';
   }
-  return `User joined on ${user.created} and has logged in ${
-    user.loginCount
-  } time(s)`;
+  return `User joined on ${user.created} and has logged in ${user.loginCount} time(s)`;
 }
 
 function mailFeedbackToAdmin(
@@ -71,9 +69,7 @@ function mailFeedbackToAdmin(
     message += `
       <p>Quest: ${quest.title}</p>
       <p>Author email: <a href="mailto:${quest.email}">${quest.email}</a></p>
-      <p>Quest creator link: <a href="https://quests.expeditiongame.com/#${
-        feedback.questid
-      }">https://quests.expeditiongame.com/#${feedback.questid}</a></p>
+      <p>Quest creator link: <a href="https://quests.expeditiongame.com/#${feedback.questid}">https://quests.expeditiongame.com/#${feedback.questid}</a></p>
     `;
     if (feedback.questline > 0) {
       message += `<p>Quest Line #: ${feedback.questline}</p>`;
@@ -180,14 +176,10 @@ function mailFirstRating(
     message += `<p>User feedback:</p><p>"${feedback.text}"</p>`;
   }
   if (feedback.email && !feedback.anonymous) {
-    message += `<p>Reviewer email: <a href="mailto:${feedback.email}">${
-      feedback.email
-    }</a></p>`;
+    message += `<p>Reviewer email: <a href="mailto:${feedback.email}">${feedback.email}</a></p>`;
   }
   message += `<p>${formatUserMetadata(user)}</p>`;
-  message += `<p>Link to edit quest: <a href="https://quests.expeditiongame.com/#${
-    feedback.questid
-  }">https://quests.expeditiongame.com/#${feedback.questid}</a></p>`;
+  message += `<p>Link to edit quest: <a href="https://quests.expeditiongame.com/#${feedback.questid}">https://quests.expeditiongame.com/#${feedback.questid}</a></p>`;
   return mail.send(emails, subject, message);
 }
 
@@ -220,9 +212,7 @@ function mailNewRating(
     }">https://quests.expeditiongame.com/#${feedback.questid}</a></p>
   `;
   if (feedback.email && !feedback.anonymous) {
-    message += `<p>Reviewer email: <a href="mailto:${feedback.email}">${
-      feedback.email
-    }</a></p>`;
+    message += `<p>Reviewer email: <a href="mailto:${feedback.email}">${feedback.email}</a></p>`;
   }
   message += `<p>${formatUserMetadata(user)}</p>`;
   return mail.send(emails, subject, message);

--- a/services/api/src/models/Quests.ts
+++ b/services/api/src/models/Quests.ts
@@ -190,9 +190,7 @@ function mailNewQuestToAdmin(mail: MailService, quest: Quest) {
   // If this is a newly published quest, email us!
   // We don't care if this fails.
   const to = ['team+newquest@fabricate.io'];
-  const subject = `Please review! New quest published: ${quest.title} (${
-    quest.partition
-  }, ${quest.language})`;
+  const subject = `Please review! New quest published: ${quest.title} (${quest.partition}, ${quest.language})`;
   const message = `Summary: ${quest.summary}.\n
     By ${quest.author} (${quest.email}),
     for ${quest.minplayers} - ${quest.maxplayers} players
@@ -269,9 +267,7 @@ export function publishQuest(
       const updateValues: Partial<Quest> = {
         ...quest.withoutDefaults(),
         published: new Date(),
-        publishedurl: `http://quests.expeditiongame.com/raw/${
-          quest.partition
-        }/${quest.id}/${quest.questversion}`,
+        publishedurl: `http://quests.expeditiongame.com/raw/${quest.partition}/${quest.id}/${quest.questversion}`,
         questversion:
           (instance.get('questversion') || quest.questversion || 0) + 1,
         tombstone: null as any, // Remove tombstone; need null instead of undefined to trigger Sequelize update override

--- a/services/api/src/multiplayer/Handlers.ts
+++ b/services/api/src/multiplayer/Handlers.ts
@@ -328,9 +328,7 @@ export function websocketSession(
   }
 
   console.log(
-    `Client ${params.client} connected to session ${
-      params.session
-    } with secret ${params.secret}`,
+    `Client ${params.client} connected to session ${params.session} with secret ${params.secret}`,
   );
 
   // Setup chaos handlers (if configured)

--- a/services/app/config.xml
+++ b/services/app/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="1020005" id="io.fabricate.expedition" version="1.20.5" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
+<widget android-versionCode="1021000" id="io.fabricate.expedition" version="1.21.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
     <name>Expedition</name>
     <description>
     The Companion App for Expedition: The Roleplaying Card Game.

--- a/services/app/package.json
+++ b/services/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expedition-app",
-  "version": "1.20.5",
+  "version": "1.21.0",
   "description": "The App for Expedition: The Roleplaying Card Game",
   "homepage": "http://app.expeditiongame.com",
   "scripts": {

--- a/services/app/src/components/views/quest/cardtemplates/combat/Victory.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Victory.test.tsx
@@ -84,7 +84,7 @@ describe('Combat victory', () => {
     expect(setup({
       settings: {showHelp: true},
       contentSets: new Set(['future']),
-    }).e.text()).toContain(FUTURE_SUBSTR);
+    }).e.text()).toContain('skill');
   });
   test('hides expansion tips if no expansion', () => {
     const text = setup({

--- a/services/app/src/components/views/quest/cardtemplates/combat/Victory.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Victory.tsx
@@ -81,7 +81,7 @@ function maybeRenderLevelUp(props: Props): JSX.Element|null {
         <li>Draw 3 abilities from one of the decks listed on your adventurer card.</li>
           {props.contentSets.has(Expansion.horror) && <ul>
             <li>
-              <img className="inline_icon" src={'images/' + formatImg('horror', props.theme) + '.svg'} />:
+              <img className="inline_icon" src={'images/' + formatImg('horror', props.theme) + '.svg'} />
               You may also draw from the Influence deck.
             </li>
           </ul>}
@@ -92,13 +92,13 @@ function maybeRenderLevelUp(props: Props): JSX.Element|null {
   ];
   if (props.contentSets.has(Expansion.horror)) {
     levelUpOptions.push(<li>
-      <img className="inline_icon" src={'images/' + formatImg('horror', props.theme) + '.svg'} />:
+      <img className="inline_icon" src={'images/' + formatImg('horror', props.theme) + '.svg'} />
       Increase their Persona by 2.
     </li>);
   }
   if (props.contentSets.has(Expansion.future)) {
     levelUpOptions.push(<li>
-      <img className="inline_icon" src={'images/' + formatImg('synth', props.theme) + '.svg'} />:
+      <img className="inline_icon" src={'images/' + formatImg('synth', props.theme) + '.svg'} />
       Learn a new skill.
       {props.settings.showHelp && <ul>
         <li>Draw 3 skills and select one of them.</li>
@@ -106,7 +106,7 @@ function maybeRenderLevelUp(props: Props): JSX.Element|null {
         <li>Place the remaining 2 at the bottom of the skill deck.</li>
       </ul>}
     </li>, <li>
-      <img className="inline_icon" src={'images/' + formatImg('synth', props.theme) + '.svg'} />:
+      <img className="inline_icon" src={'images/' + formatImg('synth', props.theme) + '.svg'} />
       Level up an existing skill.
       {props.settings.showHelp && <ul>
         <li>Move the clip on one skill one position to the right.</li>

--- a/services/app/src/components/views/quest/cardtemplates/combat/Victory.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Victory.tsx
@@ -75,46 +75,52 @@ function maybeRenderLevelUp(props: Props): JSX.Element|null {
   if (!(props.victoryParameters.xp !== false && props.combat.levelUp)) {
     return null;
   }
+  const levelUpOptions = [
+    <li>Learn a new ability.
+      {props.settings.showHelp && <ul>
+        <li>Draw 3 abilities from one of the decks listed on your adventurer card.</li>
+          {props.contentSets.has(Expansion.horror) && <ul>
+            <li>
+              <img className="inline_icon" src={'images/' + formatImg('horror', props.theme) + '.svg'} />:
+              You may also draw from the Influence deck.
+            </li>
+          </ul>}
+        <li>Add 1 to your ability deck, and place the remaining 2 at the bottom of their deck.</li>
+        <li>You <i>may</i> choose to discard an ability.</li>
+      </ul>}
+    </li>,
+  ];
+  if (props.contentSets.has(Expansion.horror)) {
+    levelUpOptions.push(<li>
+      <img className="inline_icon" src={'images/' + formatImg('horror', props.theme) + '.svg'} />:
+      Increase their Persona by 2.
+    </li>);
+  }
+  if (props.contentSets.has(Expansion.future)) {
+    levelUpOptions.push(<li>
+      <img className="inline_icon" src={'images/' + formatImg('synth', props.theme) + '.svg'} />:
+      Learn a new skill.
+      {props.settings.showHelp && <ul>
+        <li>Draw 3 skills and select one of them.</li>
+        <li>Place it face up near your adventurer, and add a clip at the leftmost level position.</li>
+        <li>Place the remaining 2 at the bottom of the skill deck.</li>
+      </ul>}
+    </li>, <li>
+      <img className="inline_icon" src={'images/' + formatImg('synth', props.theme) + '.svg'} />:
+      Level up an existing skill.
+      {props.settings.showHelp && <ul>
+        <li>Move the clip on one skill one position to the right.</li>
+      </ul>}
+    </li>);
+  }
+
   return (
     <span>
       <h2>LEVEL UP! <img className="inline_icon" src={'images/' + formatImg('cards', props.theme) + '.svg'}></img></h2>
-      <p>All adventurers <i>may</i> (pick one):</p>
+      <p>All adventurers <i>may</i>{levelUpOptions.length > 1 ? ' (pick one):' : ':'}</p>
       <ul>
-        <li>Learn a new ability.
-          {props.settings.showHelp && <ul>
-            <li>Draw 3 abilities from one of the decks listed on your adventurer card.</li>
-              {props.contentSets.has(Expansion.horror) && <ul>
-                <li>
-                  <img className="inline_icon" src={'images/' + formatImg('horror', props.theme) + '.svg'} />
-                  <strong>{CONTENT_SET_FULL_NAMES.horror}:</strong> All adventurers may also draw from the Influence deck.
-                </li>
-              </ul>}
-            <li>Add 1 to your ability deck, and place the remaining 2 at the bottom of their deck.</li>
-            <li>You <i>may</i> choose to discard an ability.</li>
-          </ul>}
-        </li>
-        {props.contentSets.has(Expansion.horror) && <li>
-          <img className="inline_icon" src={'images/' + formatImg('horror', props.theme) + '.svg'} />
-          <strong>The Horror:</strong> Increase their Persona by 2.
-        </li>}
-        {props.contentSets.has(Expansion.future) && <li>
-          <img className="inline_icon" src={'images/' + formatImg('synth', props.theme) + '.svg'} />
-          <strong>The Future:</strong> Learn a new skill.
-          {props.settings.showHelp && <ul>
-            <li>Draw 3 skills and select one of them.</li>
-            <li>Place it face up near your adventurer, and add a clip at the leftmost level position.</li>
-            <li>Place the remaining 2 at the bottom of the skill deck.</li>
-          </ul>}
-        </li>}
-        {props.contentSets.has(Expansion.future) && <li>
-          <img className="inline_icon" src={'images/' + formatImg('synth', props.theme) + '.svg'} />
-          <strong>The Future:</strong> Level up a skill.
-          {props.settings.showHelp && <ul>
-            <li>Move the clip on one skill one position to the right.</li>
-          </ul>}
-        </li>}
+        {levelUpOptions}
       </ul>
-
     </span>
   );
 }


### PR DESCRIPTION
User-caught bug: "For leveling up after a battle it says "pick one" even if horror or future expansions are not checked"

Fixed that, also took the liberty of removing the "The Horror / The Future" leading text / just kept the icon, makes it look much cleaner and easier to digest

<img width="949" alt="Screen Shot 2019-08-05 at 21 27 53" src="https://user-images.githubusercontent.com/775657/62504815-3b6f4180-b7c8-11e9-8172-aca6d303f1d2.png">
<img width="976" alt="Screen Shot 2019-08-05 at 21 28 03" src="https://user-images.githubusercontent.com/775657/62504816-3b6f4180-b7c8-11e9-893b-0d7c8113a43f.png">
