### PR TITLE
Refactor Combat & Decision phases

### DIFF
--- a/services/api/src/models/Feedback.ts
+++ b/services/api/src/models/Feedback.ts
@@ -45,7 +45,9 @@ function formatUserMetadata(user: User | null) {
   if (!user || !user.created || !user.loginCount) {
     return '';
   }
-  return `User joined on ${user.created} and has logged in ${user.loginCount} time(s)`;
+  return `User joined on ${user.created} and has logged in ${
+    user.loginCount
+  } time(s)`;
 }
 
 function mailFeedbackToAdmin(
@@ -69,7 +71,9 @@ function mailFeedbackToAdmin(
     message += `
       <p>Quest: ${quest.title}</p>
       <p>Author email: <a href="mailto:${quest.email}">${quest.email}</a></p>
-      <p>Quest creator link: <a href="https://quests.expeditiongame.com/#${feedback.questid}">https://quests.expeditiongame.com/#${feedback.questid}</a></p>
+      <p>Quest creator link: <a href="https://quests.expeditiongame.com/#${
+        feedback.questid
+      }">https://quests.expeditiongame.com/#${feedback.questid}</a></p>
     `;
     if (feedback.questline > 0) {
       message += `<p>Quest Line #: ${feedback.questline}</p>`;
@@ -176,10 +180,14 @@ function mailFirstRating(
     message += `<p>User feedback:</p><p>"${feedback.text}"</p>`;
   }
   if (feedback.email && !feedback.anonymous) {
-    message += `<p>Reviewer email: <a href="mailto:${feedback.email}">${feedback.email}</a></p>`;
+    message += `<p>Reviewer email: <a href="mailto:${feedback.email}">${
+      feedback.email
+    }</a></p>`;
   }
   message += `<p>${formatUserMetadata(user)}</p>`;
-  message += `<p>Link to edit quest: <a href="https://quests.expeditiongame.com/#${feedback.questid}">https://quests.expeditiongame.com/#${feedback.questid}</a></p>`;
+  message += `<p>Link to edit quest: <a href="https://quests.expeditiongame.com/#${
+    feedback.questid
+  }">https://quests.expeditiongame.com/#${feedback.questid}</a></p>`;
   return mail.send(emails, subject, message);
 }
 
@@ -212,7 +220,9 @@ function mailNewRating(
     }">https://quests.expeditiongame.com/#${feedback.questid}</a></p>
   `;
   if (feedback.email && !feedback.anonymous) {
-    message += `<p>Reviewer email: <a href="mailto:${feedback.email}">${feedback.email}</a></p>`;
+    message += `<p>Reviewer email: <a href="mailto:${feedback.email}">${
+      feedback.email
+    }</a></p>`;
   }
   message += `<p>${formatUserMetadata(user)}</p>`;
   return mail.send(emails, subject, message);

--- a/services/api/src/models/Quests.ts
+++ b/services/api/src/models/Quests.ts
@@ -190,7 +190,9 @@ function mailNewQuestToAdmin(mail: MailService, quest: Quest) {
   // If this is a newly published quest, email us!
   // We don't care if this fails.
   const to = ['team+newquest@fabricate.io'];
-  const subject = `Please review! New quest published: ${quest.title} (${quest.partition}, ${quest.language})`;
+  const subject = `Please review! New quest published: ${quest.title} (${
+    quest.partition
+  }, ${quest.language})`;
   const message = `Summary: ${quest.summary}.\n
     By ${quest.author} (${quest.email}),
     for ${quest.minplayers} - ${quest.maxplayers} players
@@ -267,7 +269,9 @@ export function publishQuest(
       const updateValues: Partial<Quest> = {
         ...quest.withoutDefaults(),
         published: new Date(),
-        publishedurl: `http://quests.expeditiongame.com/raw/${quest.partition}/${quest.id}/${quest.questversion}`,
+        publishedurl: `http://quests.expeditiongame.com/raw/${
+          quest.partition
+        }/${quest.id}/${quest.questversion}`,
         questversion:
           (instance.get('questversion') || quest.questversion || 0) + 1,
         tombstone: null as any, // Remove tombstone; need null instead of undefined to trigger Sequelize update override

--- a/services/api/src/multiplayer/Handlers.ts
+++ b/services/api/src/multiplayer/Handlers.ts
@@ -328,7 +328,9 @@ export function websocketSession(
   }
 
   console.log(
-    `Client ${params.client} connected to session ${params.session} with secret ${params.secret}`,
+    `Client ${params.client} connected to session ${
+      params.session
+    } with secret ${params.secret}`,
   );
 
   // Setup chaos handlers (if configured)

--- a/services/app/src/actions/Card.tsx
+++ b/services/app/src/actions/Card.tsx
@@ -1,4 +1,5 @@
 import * as Redux from 'redux';
+import {CombatPhase} from '../components/views/quest/cardtemplates/combat/Types';
 import {NAV_CARD_STORAGE_KEY, VIBRATION_LONG_MS, VIBRATION_SHORT_MS} from '../Constants';
 import {getNavigator} from '../Globals';
 import {getStorageString} from '../LocalStorage';
@@ -20,7 +21,7 @@ export const toCard = remoteify(function toCard(a: ToCardArgs, dispatch: Redux.D
   const questId = (state.quest && state.quest.details && state.quest.details.id) || null;
   const vibration = state.settings && state.settings.vibration;
   if (nav && nav.vibrate && vibration) {
-    if (a.phase === 'TIMER') {
+    if (a.phase === CombatPhase.timer) {
       nav.vibrate(VIBRATION_LONG_MS);
     } else {
       nav.vibrate(VIBRATION_SHORT_MS);

--- a/services/app/src/actions/SavedQuests.tsx
+++ b/services/app/src/actions/SavedQuests.tsx
@@ -141,7 +141,7 @@ function recreateNodeThroughCombat(node: ParserNode, i: number, path: string|num
     roundCount: 0,
     tier,
     phase: CombatPhase.drawEnemies,
-    decisionPhase: DecisionPhase.prepareDecision,
+    decisionPhase: DecisionPhase.prepare,
     surgePeriod: 4,
     decisionPeriod: 4,
     damageMultiplier: 1,

--- a/services/app/src/actions/SavedQuests.tsx
+++ b/services/app/src/actions/SavedQuests.tsx
@@ -2,6 +2,8 @@ import * as Redux from 'redux';
 import {fetchLocal} from 'shared/requests';
 import {Quest} from 'shared/schema/Quests';
 import {getEnemiesAndTier} from '../components/views/quest/cardtemplates/combat/Actions';
+import {CombatPhase} from '../components/views/quest/cardtemplates/combat/Types';
+import {DecisionPhase} from '../components/views/quest/cardtemplates/decision/Types';
 import {getNextMidCombatNode} from '../components/views/quest/cardtemplates/roleplay/Actions';
 import {defaultContext} from '../components/views/quest/cardtemplates/Template';
 import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
@@ -138,7 +140,8 @@ function recreateNodeThroughCombat(node: ParserNode, i: number, path: string|num
     numAliveAdventurers: 0,
     roundCount: 0,
     tier,
-    decisionPhase: 'PREPARE_DECISION',
+    phase: CombatPhase.drawEnemies,
+    decisionPhase: DecisionPhase.prepareDecision,
     surgePeriod: 4,
     decisionPeriod: 4,
     damageMultiplier: 1,

--- a/services/app/src/components/views/quest/cardtemplates/Params.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Params.tsx
@@ -1,7 +1,7 @@
 import {AppStateWithHistory} from 'app/reducers/StateTypes';
 import {generateCombatTemplate} from './combat/Actions';
-import {CombatState} from './combat/Types';
-import {DecisionState, EMPTY_DECISION_STATE} from './decision/Types';
+import {CombatPhase, CombatState} from './combat/Types';
+import {DecisionPhase, DecisionState, EMPTY_DECISION_STATE} from './decision/Types';
 import {ParserNode} from './TemplateTypes';
 
 export function resolveParams(node: ParserNode|undefined, getState: () => AppStateWithHistory): {node: ParserNode, decision: DecisionState, combat: CombatState} {
@@ -27,6 +27,7 @@ export function resolveCombat(node: ParserNode|undefined): CombatState {
       maxRoundDamage: 0,
       roundCount: 0,
       seed: '',
-      decisionPhase: 'PREPARE_DECISION',
+      phase: CombatPhase.drawEnemies,
+      decisionPhase: DecisionPhase.prepareDecision,
     };
 }

--- a/services/app/src/components/views/quest/cardtemplates/Params.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Params.tsx
@@ -28,6 +28,6 @@ export function resolveCombat(node: ParserNode|undefined): CombatState {
       roundCount: 0,
       seed: '',
       phase: CombatPhase.drawEnemies,
-      decisionPhase: DecisionPhase.prepareDecision,
+      decisionPhase: DecisionPhase.prepare,
     };
 }

--- a/services/app/src/components/views/quest/cardtemplates/Template.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.tsx
@@ -46,11 +46,11 @@ export function renderCardTemplate(card: CardState, node: ParserNode, settings: 
   switch (phase) {
     case 'ROLEPLAY':
       return <RoleplayContainer node={node}/>;
-    case DecisionPhase.prepareDecision:
+    case DecisionPhase.prepare:
       return <PrepareDecisionContainer node={node}/>;
-    case DecisionPhase.decisionTimer:
+    case DecisionPhase.timer:
       return <DecisionTimerContainer node={node}/>;
-    case DecisionPhase.resolveDecision:
+    case DecisionPhase.resolve:
       return <ResolveDecisionContainer node={node}/>;
     case CombatPhase.drawEnemies:
       return <DrawEnemiesContainer node={node}/>;
@@ -80,7 +80,7 @@ export function renderCardTemplate(card: CardState, node: ParserNode, settings: 
     case CombatPhase.midCombatDecision:
     case CombatPhase.midCombatDecisionTimer:
       const combat = node.ctx.templates.combat;
-      return renderCardTemplate({...card, phase: ((combat) ? combat.decisionPhase : DecisionPhase.prepareDecision)}, node, settings);
+      return renderCardTemplate({...card, phase: ((combat) ? combat.decisionPhase : DecisionPhase.prepare)}, node, settings);
     default:
       throw new Error('Unknown template for card phase ' + card.phase);
   }
@@ -101,9 +101,9 @@ export function getCardTemplateTheme(card: CardState): CardThemeType {
     case CombatPhase.midCombatDecisionTimer:
       return 'dark';
     case 'ROLEPLAY':
-    case DecisionPhase.prepareDecision:
-    case DecisionPhase.decisionTimer:
-    case DecisionPhase.resolveDecision:
+    case DecisionPhase.prepare:
+    case DecisionPhase.timer:
+    case DecisionPhase.resolve:
     default:
       return 'light';
   }

--- a/services/app/src/components/views/quest/cardtemplates/Template.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.tsx
@@ -15,11 +15,13 @@ import ResolveContainer from './combat/ResolveContainer';
 import {combatScope} from './combat/Scope';
 import SurgeContainer from './combat/SurgeContainer';
 import TimerCardContainer from './combat/TimerCardContainer';
+import {CombatPhase} from './combat/Types';
 import VictoryContainer from './combat/VictoryContainer';
 import {initDecision} from './decision/Actions';
 import DecisionTimerContainer from './decision/DecisionTimerContainer';
 import PrepareDecisionContainer from './decision/PrepareDecisionContainer';
 import ResolveDecisionContainer from './decision/ResolveDecisionContainer';
+import {DecisionPhase} from './decision/Types';
 import {initRoleplay} from './roleplay/Actions';
 import RoleplayContainer from './roleplay/RoleplayContainer';
 import {ParserNode, TemplateContext} from './TemplateTypes';
@@ -44,15 +46,15 @@ export function renderCardTemplate(card: CardState, node: ParserNode, settings: 
   switch (phase) {
     case 'ROLEPLAY':
       return <RoleplayContainer node={node}/>;
-    case 'PREPARE_DECISION':
+    case DecisionPhase.prepareDecision:
       return <PrepareDecisionContainer node={node}/>;
-    case 'DECISION_TIMER':
+    case DecisionPhase.decisionTimer:
       return <DecisionTimerContainer node={node}/>;
-    case 'RESOLVE_DECISION':
+    case DecisionPhase.resolveDecision:
       return <ResolveDecisionContainer node={node}/>;
-    case 'DRAW_ENEMIES':
+    case CombatPhase.drawEnemies:
       return <DrawEnemiesContainer node={node}/>;
-    case 'PREPARE':
+    case CombatPhase.prepare:
       // Must handle conditional display of timer vs no timer here to
       // allow for timer length changes on the "prepare" card to dynamically
       // change which screen is shown.
@@ -61,24 +63,24 @@ export function renderCardTemplate(card: CardState, node: ParserNode, settings: 
       } else {
         return <PrepareTimerContainer node={node}/>;
       }
-    case 'TIMER':
+    case CombatPhase.timer:
       return <TimerCardContainer node={node}/>;
-    case 'SURGE':
+    case CombatPhase.surge:
       return <SurgeContainer node={node}/>;
-    case 'RESOLVE_ABILITIES':
+    case CombatPhase.resolveAbilities:
       return <ResolveContainer node={node}/>;
-    case 'RESOLVE_DAMAGE':
+    case CombatPhase.resolveDamage:
       return <PlayerTierContainer node={node}/>;
-    case 'VICTORY':
+    case CombatPhase.victory:
       return <VictoryContainer node={node}/>;
-    case 'DEFEAT':
+    case CombatPhase.defeat:
       return <DefeatContainer node={node}/>;
-    case 'MID_COMBAT_ROLEPLAY':
+    case CombatPhase.midCombatRoleplay:
       return <MidCombatRoleplayContainer node={node}/>;
-    case 'MID_COMBAT_DECISION':
-    case 'MID_COMBAT_DECISION_TIMER':
+    case CombatPhase.midCombatDecision:
+    case CombatPhase.midCombatDecisionTimer:
       const combat = node.ctx.templates.combat;
-      return renderCardTemplate({...card, phase: ((combat) ? combat.decisionPhase : 'PREPARE_DECISION')}, node, settings);
+      return renderCardTemplate({...card, phase: ((combat) ? combat.decisionPhase : DecisionPhase.prepareDecision)}, node, settings);
     default:
       throw new Error('Unknown template for card phase ' + card.phase);
   }
@@ -86,22 +88,22 @@ export function renderCardTemplate(card: CardState, node: ParserNode, settings: 
 
 export function getCardTemplateTheme(card: CardState): CardThemeType {
   switch (card.phase || 'ROLEPLAY') {
-    case 'DRAW_ENEMIES':
-    case 'PREPARE':
-    case 'TIMER':
-    case 'SURGE':
-    case 'RESOLVE_ABILITIES':
-    case 'RESOLVE_DAMAGE':
-    case 'VICTORY':
-    case 'DEFEAT':
-    case 'MID_COMBAT_ROLEPLAY':
-    case 'MID_COMBAT_DECISION':
-    case 'MID_COMBAT_DECISION_TIMER':
+    case CombatPhase.drawEnemies:
+    case CombatPhase.prepare:
+    case CombatPhase.timer:
+    case CombatPhase.surge:
+    case CombatPhase.resolveAbilities:
+    case CombatPhase.resolveDamage:
+    case CombatPhase.victory:
+    case CombatPhase.defeat:
+    case CombatPhase.midCombatRoleplay:
+    case CombatPhase.midCombatDecision:
+    case CombatPhase.midCombatDecisionTimer:
       return 'dark';
     case 'ROLEPLAY':
-    case 'PREPARE_DECISION':
-    case 'DECISION_TIMER':
-    case 'RESOLVE_DECISION':
+    case DecisionPhase.prepareDecision:
+    case DecisionPhase.decisionTimer:
+    case DecisionPhase.resolveDecision:
     default:
       return 'light';
   }

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
@@ -4,6 +4,7 @@ import {Action, newMockStore} from 'app/Testing';
 import {fakeConnection} from 'app/multiplayer/Testing';
 import {getMultiplayerConnection} from 'app/multiplayer/Connection';
 import {defaultContext} from '../Template';
+import {CombatPhase} from './Types';
 import {ParserNode} from '../TemplateTypes';
 import {
   adventurerDelta,
@@ -71,7 +72,7 @@ describe('Combat actions', () => {
       expect(actions[2]).toEqual(jasmine.objectContaining({
         to: jasmine.objectContaining({
           name: 'QUEST_CARD',
-          phase: 'DRAW_ENEMIES',
+          phase: CombatPhase.drawEnemies,
         }),
         type: 'NAVIGATE',
       }));
@@ -442,7 +443,7 @@ describe('Combat actions', () => {
       </combat>`)('combat'), defaultContext());
       const actions = Action(handleResolvePhase).execute({node});
       expect(actions[1].type).toEqual('QUEST_NODE');
-      expect(actions[2].to.phase).toEqual('RESOLVE_ABILITIES');
+      expect(actions[2].to.phase).toEqual(CombatPhase.resolveAbilities);
       checkNodeIntegrity(node, actions[1].node);
     });
 
@@ -457,7 +458,7 @@ describe('Combat actions', () => {
       </combat>`)('combat'), defaultContext());
       const actions = Action(handleResolvePhase).execute({node});
       expect(actions[1].type).toEqual('QUEST_NODE');
-      expect(actions[2].to.phase).toEqual('RESOLVE_ABILITIES');
+      expect(actions[2].to.phase).toEqual(CombatPhase.resolveAbilities);
       checkNodeIntegrity(node, actions[1].node);
     });
 
@@ -475,7 +476,7 @@ describe('Combat actions', () => {
       node = Action(initCombat as any).execute({node: node.clone(), settings: s.basic})[1].node;
       const actions = Action(handleResolvePhase).execute({node});
       expect(actions[1].node.elem.text()).toEqual('expected');
-      expect(actions[2].to.phase).toEqual('MID_COMBAT_ROLEPLAY');
+      expect(actions[2].to.phase).toEqual(CombatPhase.midCombatRoleplay);
 
       // We expect node integrity to be broken when moving from combat to roleplay.
       checkNodeIntegrity(null, null);

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
@@ -221,7 +221,7 @@ describe('Combat actions', () => {
       expect(Object.keys(hist).length).toBeGreaterThan(1);
 
       // Same damage should happen not more than half the time.
-      expect(Object.keys(hist).map((k) => hist[k]).reduce((a, b) => Math.max(a,b))).toBeLessThan(TRIALS/2);
+      expect(Object.keys(hist).map((k) => hist[k]).reduce((a, b) => Math.max(a,b))).not.toBeGreaterThan(TRIALS/2);
       checkNodeIntegrity(startNode, node);
     });
     test('generates rolls according to player count', () => {

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
@@ -53,7 +53,7 @@ export function generateCombatTemplate(settings: SettingsType, node?: ParserNode
 
   return {
     phase: CombatPhase.drawEnemies,
-    decisionPhase: DecisionPhase.prepareDecision,
+    decisionPhase: DecisionPhase.prepare,
     enemies,
     numAliveAdventurers: numLocalAdventurers(settings, mp),
     roundCount: 0,
@@ -488,7 +488,7 @@ export const setupCombatDecision = remoteify(function setupCombatDecision(a: Set
   const settings = getState().settings;
   const mp = getState().multiplayer;
   combat.phase = CombatPhase.midCombatDecision;
-  combat.decisionPhase = DecisionPhase.prepareDecision;
+  combat.decisionPhase = DecisionPhase.prepare;
   const arng = seedrandom.alea(a.seed);
   node.ctx.templates.decision = {
     leveledChecks: generateLeveledChecks(numAliveAdventurers(settings, node, mp), arng),

--- a/services/app/src/components/views/quest/cardtemplates/combat/DefeatContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/DefeatContainer.tsx
@@ -6,7 +6,7 @@ import Redux from 'redux';
 import {resolveCombat} from '../Params';
 import {ParserNode} from '../TemplateTypes';
 import Defeat, {DispatchProps, StateProps} from './Defeat';
-import {mapStateToProps as mapStateToPropsBase} from './Types';
+import {CombatPhase, mapStateToProps as mapStateToPropsBase} from './Types';
 
 const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProps>): StateProps => {
   // Override with dynamic state for tier and adventurer count
@@ -24,7 +24,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       dispatch(event({node, evt}));
     },
     onRetry: () => {
-      dispatch(toPrevious({name: 'QUEST_CARD', phase: 'DRAW_ENEMIES', before: true}));
+      dispatch(toPrevious({name: 'QUEST_CARD', phase: CombatPhase.drawEnemies, before: true}));
     },
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/combat/DrawEnemies.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/DrawEnemies.test.tsx
@@ -3,7 +3,7 @@ describe('DRAW_ENEMIES', () => {
   test('renders all enemies in props', () => {
     /*
     const combat = newCombat(TEST_NODE);
-    const {enzymeWrapper} = setup('DRAW_ENEMIES', {combat});
+    const {enzymeWrapper} = setup(CombatPhase.drawEnemies, {combat});
     expect(enzymeWrapper.find('h2.draw_enemies').map((e) => e.text())).toEqual([
       'Thief (Tier I )',
       'Brigand (Tier I )',

--- a/services/app/src/components/views/quest/cardtemplates/combat/DrawEnemies.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/DrawEnemies.tsx
@@ -66,7 +66,7 @@ export default function drawEnemies(props: Props): JSX.Element {
       </p>
       {enemies}
       {helpText}
-      <Button onClick={() => props.onNext('PREPARE')}>Next</Button>
+      <Button onClick={() => props.onNext(CombatPhase.prepare)}>Next</Button>
       <AudioControlsContainer />
     </Card>
   );

--- a/services/app/src/components/views/quest/cardtemplates/combat/MidCombatRoleplayContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/MidCombatRoleplayContainer.tsx
@@ -8,6 +8,7 @@ import {
 import {ParserNode} from '../TemplateTypes';
 import MidCombatRoleplay, {DispatchProps, StateProps} from './MidCombatRoleplay';
 import {mapStateToProps as mapStateToPropsBase} from './Types';
+import {CombatPhase} from './Types';
 
 const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProps>): StateProps => {
   let maxTier = 0;
@@ -21,7 +22,7 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
     const tier = combatContext.tier;
     histIdx--;
     const phase = state._history[histIdx].card.phase;
-    if (tier && phase !== null && phase === 'PREPARE') {
+    if (tier && phase !== null && phase === CombatPhase.prepare) {
       maxTier = Math.max(maxTier, tier);
     }
   }
@@ -41,11 +42,11 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       dispatch(midCombatChoice({node, settings, index, maxTier, seed}));
     },
     onRetry: () => {
-      dispatch(toPrevious({name: 'QUEST_CARD', phase: 'DRAW_ENEMIES', before: true}));
+      dispatch(toPrevious({name: 'QUEST_CARD', phase: CombatPhase.drawEnemies, before: true}));
     },
     onReturn: () => {
       // Return to the "Ready for Combat?" card instead of doing the timed round again.
-      dispatch(toPrevious({before: false, skip: [{name: 'QUEST_CARD', phase: 'TIMER'}]}));
+      dispatch(toPrevious({before: false, skip: [{name: 'QUEST_CARD', phase: CombatPhase.timer}]}));
     },
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.tsx
@@ -79,7 +79,7 @@ export default function playerTier(props: Props): JSX.Element {
       <Button
         className={(props.numAliveAdventurers === 0 || props.tier === 0) ? 'subtle' : ''}
         disabled={props.numAliveAdventurers <= 0 || props.tier <= 0}
-        onClick={() => (shouldRunDecision) ? props.onDecisionSetup(props.node, props.seed) : props.onNext('PREPARE')}>Next</Button>
+        onClick={() => (shouldRunDecision) ? props.onDecisionSetup(props.node, props.seed) : props.onNext(CombatPhase.prepare)}>Next</Button>
       <Button
         className={(props.tier !== 0) ? 'subtle' : ''}
         disabled={props.numAliveAdventurers <= 0 && props.tier > 0}

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
@@ -28,7 +28,7 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
     const tier = combatContext.tier;
     histIdx--;
     const phase = state._history[histIdx].card.phase;
-    if (tier && phase !== null && phase === 'PREPARE') {
+    if (tier && phase !== null && phase === CombatPhase.prepare) {
       maxTier = Math.max(maxTier, tier);
     }
   }

--- a/services/app/src/components/views/quest/cardtemplates/combat/Resolve.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Resolve.tsx
@@ -3,8 +3,7 @@ import Card from 'app/components/base/Card';
 import {ContentSetsType} from 'app/reducers/StateTypes';
 import * as React from 'react';
 import {CONTENT_SET_FULL_NAMES, Expansion} from 'shared/schema/Constants';
-import {CombatPhase} from './Types';
-import {StateProps as StatePropsBase} from './Types';
+import {CombatPhase, StateProps as StatePropsBase} from './Types';
 
 export interface StateProps extends StatePropsBase {
   mostRecentRolls?: number[];
@@ -62,7 +61,7 @@ export default function resolve(props: Props): JSX.Element {
           <div className="rolls">{renderedRolls}</div>
         </div>
       }
-      <Button onClick={() => props.onNext('RESOLVE_DAMAGE')}>Next</Button>
+      <Button onClick={() => props.onNext(CombatPhase.resolveDamage)}>Next</Button>
     </Card>
   );
 }

--- a/services/app/src/components/views/quest/cardtemplates/combat/ResolveContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/ResolveContainer.tsx
@@ -5,8 +5,7 @@ import {connect} from 'react-redux';
 import Redux from 'redux';
 import {resolveCombat} from '../Params';
 import Resolve, {DispatchProps, StateProps} from './Resolve';
-import {CombatPhase} from './Types';
-import {mapStateToProps as mapStateToPropsBase} from './Types';
+import {CombatPhase, mapStateToProps as mapStateToPropsBase} from './Types';
 
 const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProps>): StateProps => {
   return {
@@ -23,7 +22,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
     },
     onReturn: () => {
       // Return to the "Ready for Combat?" card instead of doing the timed round again.
-      dispatch(toPrevious({before: false, skip: [{name: 'QUEST_CARD', phase: 'TIMER'}]}));
+      dispatch(toPrevious({before: false, skip: [{name: 'QUEST_CARD', phase: CombatPhase.timer}]}));
     },
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/combat/SurgeContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/SurgeContainer.tsx
@@ -6,13 +6,13 @@ import {
   handleResolvePhase,
 } from './Actions';
 import Surge, {DispatchProps} from './Surge';
-import {mapStateToProps} from './Types';
+import {CombatPhase, mapStateToProps} from './Types';
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
     onReturn: () => {
       // Return to the "Ready for Combat?" card instead of doing the timed round again.
-      dispatch(toPrevious({before: false, skip: [{name: 'QUEST_CARD', phase: 'TIMER'}]}));
+      dispatch(toPrevious({before: false, skip: [{name: 'QUEST_CARD', phase: CombatPhase.timer}]}));
     },
     onSurgeNext: (node: ParserNode) => {
       dispatch(handleResolvePhase({node}));

--- a/services/app/src/components/views/quest/cardtemplates/combat/Types.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Types.tsx
@@ -17,6 +17,7 @@ export interface MidCombatPhase {
   numAliveAdventurers: number;
   roundCount: number;
   tier: number;
+  phase: CombatPhase;
   decisionPhase: DecisionPhase;
   // Combat needs its own seed so as not to interfere
   // with replay/multiplayer seed on main node.
@@ -39,17 +40,19 @@ export interface CombatDifficultySettings {
 
 export interface CombatState extends CombatDifficultySettings, MidCombatPhase, EndCombatPhase {}
 
-export type CombatPhase = 'DRAW_ENEMIES'
-  | 'PREPARE'
-  | 'TIMER'
-  | 'SURGE'
-  | 'RESOLVE_ABILITIES'
-  | 'RESOLVE_DAMAGE'
-  | 'VICTORY'
-  | 'DEFEAT'
-  | 'MID_COMBAT_ROLEPLAY'
-  | 'MID_COMBAT_DECISION'
-  | 'MID_COMBAT_DECISION_TIMER'; // Timer must be separate to allow skip of timer during onReturn.
+export enum CombatPhase {
+  drawEnemies = 'DRAW_ENEMIES',
+  prepare = 'PREPARE',
+  timer = 'TIMER', // Timer must be separate to allow skip of timer during onReturn.
+  surge = 'SURGE',
+  resolveAbilities = 'RESOLVE_ABILITIES',
+  resolveDamage = 'RESOLVE_DAMAGE',
+  victory = 'VICTORY',
+  defeat = 'DEFEAT',
+  midCombatRoleplay = 'MID_COMBAT_ROLEPLAY',
+  midCombatDecision = 'MID_COMBAT_DECISION',
+  midCombatDecisionTimer = 'MID_COMBAT_DECISION_TIMER',
+}
 
 export interface StateProps {
   node: ParserNode;

--- a/services/app/src/components/views/quest/cardtemplates/decision/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Actions.test.tsx
@@ -72,7 +72,7 @@ describe('Decision actions', () => {
     }).execute({node: copyNode.clone()})[1].node;
     const decision = extractDecision(node);
     decision.selected = decision.leveledChecks[0];
-    node.ctx.templates.combat = {decisionPhase: DecisionPhase.resolveDecision}; // Ignored if non-combat, used if mid-combat
+    node.ctx.templates.combat = {decisionPhase: DecisionPhase.resolve}; // Ignored if non-combat, used if mid-combat
     return node;
   }
   describe('extractDecision', () => {
@@ -99,7 +99,7 @@ describe('Decision actions', () => {
         multiplayer: m.s2p5,
       }).execute({node});
       expect(extractDecision(actions[1].node)).toEqual(testDecision(3));
-      expect(actions[2].to).toEqual(jasmine.objectContaining({phase: DecisionPhase.prepareDecision}));
+      expect(actions[2].to).toEqual(jasmine.objectContaining({phase: DecisionPhase.prepare}));
     });
     test('requires fewer successes than total alive player count (multiplayer)', () => {
       const actions = Action(initDecision, {
@@ -107,7 +107,7 @@ describe('Decision actions', () => {
         multiplayer: m.s2p2a1,
       }).execute({node: TEST_NODE.clone()});
       expect(extractDecision(actions[1].node)).toEqual(testDecision(1));
-      expect(actions[2].to).toEqual(jasmine.objectContaining({phase: DecisionPhase.prepareDecision}));
+      expect(actions[2].to).toEqual(jasmine.objectContaining({phase: DecisionPhase.prepare}));
     });
     test('requires fewer successes than maxrolls', () => {
       const actions = Action(initDecision, {
@@ -115,7 +115,7 @@ describe('Decision actions', () => {
         multiplayer: m.s2p5,
       }).execute({node: TEST_NODE_MAX_1.clone()});
       expect(extractDecision(actions[1].node)).toEqual(testDecision(1));
-      expect(actions[2].to).toEqual(jasmine.objectContaining({phase: DecisionPhase.prepareDecision}));
+      expect(actions[2].to).toEqual(jasmine.objectContaining({phase: DecisionPhase.prepare}));
     });
   });
   describe('computeSuccesses', () => {
@@ -214,7 +214,7 @@ describe('Decision actions', () => {
         settings: s.basic,
         multiplayer: m.s2p5
       }).execute({node: setup(), roll: 10});
-      expect(actions[2].to.phase).toEqual(DecisionPhase.resolveDecision);
+      expect(actions[2].to.phase).toEqual(DecisionPhase.resolve);
     });
     test('mid-combat decision remains in combat when resolving', () => {
       const actions = Action(handleDecisionRoll, {
@@ -223,7 +223,7 @@ describe('Decision actions', () => {
         multiplayer: m.s2p5
       }).execute({node: setup(), roll: 10});
       expect(actions[2].to).toEqual(jasmine.objectContaining({phase: CombatPhase.midCombatDecision}));
-      expect(actions[1].node.ctx.templates.combat.decisionPhase).toEqual(DecisionPhase.resolveDecision);
+      expect(actions[1].node.ctx.templates.combat.decisionPhase).toEqual(DecisionPhase.resolve);
     });
     test('mid-combat decision remains in combat when resolving', () => {
       const actions = Action(handleDecisionRoll, {
@@ -232,7 +232,7 @@ describe('Decision actions', () => {
         multiplayer: m.s2p5
       }).execute({node: setup(), roll: 10});
       expect(actions[2].to).toEqual(jasmine.objectContaining({phase: CombatPhase.midCombatDecision}));
-      expect(actions[1].node.ctx.templates.combat.decisionPhase).toEqual(DecisionPhase.resolveDecision);
+      expect(actions[1].node.ctx.templates.combat.decisionPhase).toEqual(DecisionPhase.resolve);
     });
     test('goes to interrupted state when non-combat decision has interrupted event', () => {
       const node = setup();
@@ -261,8 +261,8 @@ describe('Decision actions', () => {
       expect(actions[2].to).toEqual(jasmine.objectContaining({phase: CombatPhase.midCombatDecision}));
     });
     test('does pass-thru to toCard if not in combat', () => {
-      const actions = Action(toDecisionCard, {card: {phase: ''}}).execute({node: setup() name: 'QUEST_CARD', phase: DecisionPhase.resolveDecision});
-      expect(actions[1].to).toEqual(jasmine.objectContaining({phase: DecisionPhase.resolveDecision}));
+      const actions = Action(toDecisionCard, {card: {phase: ''}}).execute({node: setup() name: 'QUEST_CARD', phase: DecisionPhase.resolve});
+      expect(actions[1].to).toEqual(jasmine.objectContaining({phase: DecisionPhase.resolve}));
     });
   });
 });

--- a/services/app/src/components/views/quest/cardtemplates/decision/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Actions.tsx
@@ -49,7 +49,7 @@ export const initDecision = remoteify(function initDecision(a: InitDecisionArgs,
   };
   dispatch({type: 'PUSH_HISTORY'});
   dispatch({type: 'QUEST_NODE', node: a.node} as QuestNodeAction);
-  dispatch(toCard({name: 'QUEST_CARD', phase: DecisionPhase.prepareDecision, noHistory: true}));
+  dispatch(toCard({name: 'QUEST_CARD', phase: DecisionPhase.prepare, noHistory: true}));
   return {};
 });
 
@@ -271,7 +271,7 @@ export const handleDecisionRoll = remoteify(function handleDecisionRoll(a: Handl
   if (getState().card.phase === CombatPhase.midCombatDecision) {
     const {node} = resolveParams(a.node, getState);
     pushDecisionRoll(node, a.roll, getState);
-    dispatch(toDecisionCard({phase: DecisionPhase.resolveDecision, node}));
+    dispatch(toDecisionCard({phase: DecisionPhase.resolve, node}));
     return {
       roll: a.roll,
     };
@@ -288,7 +288,7 @@ export const handleDecisionRoll = remoteify(function handleDecisionRoll(a: Handl
   } else {
     dispatch({type: 'PUSH_HISTORY'});
     dispatch({type: 'QUEST_NODE', node: a.node} as QuestNodeAction);
-    dispatch(toCard({name: 'QUEST_CARD', phase: DecisionPhase.resolveDecision, noHistory: true, keySuffix: Date.now().toString()}));
+    dispatch(toCard({name: 'QUEST_CARD', phase: DecisionPhase.resolve, noHistory: true, keySuffix: Date.now().toString()}));
   }
   return {
     roll: a.roll,
@@ -300,7 +300,7 @@ interface ToDecisionCardArgs extends Partial<ToCardArgs> {
   phase: DecisionPhase;
 }
 export const toDecisionCard = remoteify(function toDecisionCard(a: ToDecisionCardArgs, dispatch: Redux.Dispatch<any>, getState: () => AppStateWithHistory): ToDecisionCardArgs {
-  const phase = a.phase || DecisionPhase.prepareDecision;
+  const phase = a.phase || DecisionPhase.prepare;
   const statePhase = getState().card.phase;
   if (statePhase !== CombatPhase.midCombatDecision && statePhase !== CombatPhase.midCombatDecisionTimer && a.name !== undefined) {
     const a2: ToCardArgs = {
@@ -319,7 +319,7 @@ export const toDecisionCard = remoteify(function toDecisionCard(a: ToDecisionCar
   dispatch({type: 'QUEST_NODE', node} as QuestNodeAction);
   dispatch(toCard({
     name: 'QUEST_CARD',
-    phase: (a.phase === DecisionPhase.decisionTimer) ? CombatPhase.midCombatDecisionTimer : CombatPhase.midCombatDecision,
+    phase: (a.phase === DecisionPhase.timer) ? CombatPhase.midCombatDecisionTimer : CombatPhase.midCombatDecision,
     keySuffix: a.phase + (decision.rolls || '').toString(),
     noHistory: true,
   }));

--- a/services/app/src/components/views/quest/cardtemplates/decision/DecisionTimerContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/DecisionTimerContainer.tsx
@@ -18,7 +18,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
     onSelect: (node: ParserNode, selected: LeveledSkillCheck, elapsedMillis: number) => {
       dispatch(handleDecisionSelect({node, elapsedMillis, selected}));
-      dispatch(toDecisionCard({name: 'QUEST_CARD', phase: DecisionPhase.resolveDecision, noHistory: true}));
+      dispatch(toDecisionCard({name: 'QUEST_CARD', phase: DecisionPhase.resolve, noHistory: true}));
     },
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/decision/DecisionTimerContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/DecisionTimerContainer.tsx
@@ -5,7 +5,7 @@ import {LeveledSkillCheck} from '../decision/Types';
 import {ParserNode} from '../TemplateTypes';
 import {handleDecisionSelect, skillTimeMillis, toDecisionCard} from './Actions';
 import DecisionTimer, {DispatchProps, StateProps} from './DecisionTimer';
-import {mapStateToProps as mapStateToPropsBase} from './Types';
+import {DecisionPhase, mapStateToProps as mapStateToPropsBase} from './Types';
 
 const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProps>): StateProps => {
   return {
@@ -18,7 +18,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
     onSelect: (node: ParserNode, selected: LeveledSkillCheck, elapsedMillis: number) => {
       dispatch(handleDecisionSelect({node, elapsedMillis, selected}));
-      dispatch(toDecisionCard({name: 'QUEST_CARD', phase: 'RESOLVE_DECISION', noHistory: true}));
+      dispatch(toDecisionCard({name: 'QUEST_CARD', phase: DecisionPhase.resolveDecision, noHistory: true}));
     },
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/decision/PrepareDecisionContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/PrepareDecisionContainer.tsx
@@ -7,7 +7,7 @@ import {DecisionPhase, mapStateToProps} from './Types';
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
     onStartTimer: () => {
-      dispatch(toDecisionCard({name: 'QUEST_CARD', phase: DecisionPhase.decisionTimer}));
+      dispatch(toDecisionCard({name: 'QUEST_CARD', phase: DecisionPhase.timer}));
     },
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/decision/PrepareDecisionContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/PrepareDecisionContainer.tsx
@@ -2,12 +2,12 @@ import {connect} from 'react-redux';
 import Redux from 'redux';
 import {toDecisionCard} from './Actions';
 import PrepareDecision, {DispatchProps} from './PrepareDecision';
-import {mapStateToProps} from './Types';
+import {DecisionPhase, mapStateToProps} from './Types';
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
     onStartTimer: () => {
-      dispatch(toDecisionCard({name: 'QUEST_CARD', phase: 'DECISION_TIMER'}));
+      dispatch(toDecisionCard({name: 'QUEST_CARD', phase: DecisionPhase.decisionTimer}));
     },
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecisionContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecisionContainer.tsx
@@ -13,7 +13,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
     onReturn: () => {
       // Return to the Prepare Decision card instead of going back to the timer.
       dispatch(toPrevious({before: false, skip: [
-        {name: 'QUEST_CARD', phase: DecisionPhase.decisionTimer},
+        {name: 'QUEST_CARD', phase: DecisionPhase.timer},
         {name: 'QUEST_CARD', phase: CombatPhase.midCombatDecisionTimer},
       ]}));
     },

--- a/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecisionContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecisionContainer.tsx
@@ -2,25 +2,26 @@ import {toCard} from 'app/actions/Card';
 import {toPrevious} from 'app/actions/Card';
 import {connect} from 'react-redux';
 import Redux from 'redux';
+import {CombatPhase} from '../combat/Types';
 import {ParserNode} from '../TemplateTypes';
 import {handleDecisionRoll} from './Actions';
 import ResolveDecision, {DispatchProps} from './ResolveDecision';
-import {mapStateToProps} from './Types';
+import {DecisionPhase, mapStateToProps} from './Types';
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
     onReturn: () => {
       // Return to the Prepare Decision card instead of going back to the timer.
       dispatch(toPrevious({before: false, skip: [
-        {name: 'QUEST_CARD', phase: 'DECISION_TIMER'},
-        {name: 'QUEST_CARD', phase: 'MID_COMBAT_DECISION_TIMER'},
+        {name: 'QUEST_CARD', phase: DecisionPhase.decisionTimer},
+        {name: 'QUEST_CARD', phase: CombatPhase.midCombatDecisionTimer},
       ]}));
     },
     onRoll: (node: ParserNode, roll: number) => {
       dispatch(handleDecisionRoll({node, roll}));
     },
     onCombatDecisionEnd: () => {
-      dispatch(toCard({name: 'QUEST_CARD', phase: 'PREPARE'}));
+      dispatch(toCard({name: 'QUEST_CARD', phase: CombatPhase.prepare}));
     },
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/decision/Types.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Types.tsx
@@ -37,9 +37,9 @@ export interface OutcomeContent {
 export const EMPTY_OUTCOME: OutcomeContent = {type: 'retry', text: '', instructions: []};
 
 export enum DecisionPhase {
-  prepareDecision = 'PREPARE_DECISION',
-  decisionTimer = 'DECISION_TIMER',
-  resolveDecision = 'RESOLVE_DECISION',
+  prepare = 'PREPARE_DECISION',
+  timer = 'DECISION_TIMER',
+  resolve = 'RESOLVE_DECISION',
 }
 export interface DecisionState {
   leveledChecks: LeveledSkillCheck[];

--- a/services/app/src/components/views/quest/cardtemplates/decision/Types.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Types.tsx
@@ -36,7 +36,11 @@ export interface OutcomeContent {
 }
 export const EMPTY_OUTCOME: OutcomeContent = {type: 'retry', text: '', instructions: []};
 
-export type DecisionPhase = 'PREPARE_DECISION' | 'DECISION_TIMER' | 'RESOLVE_DECISION';
+export enum DecisionPhase {
+  prepareDecision = 'PREPARE_DECISION',
+  decisionTimer = 'DECISION_TIMER',
+  resolveDecision = 'RESOLVE_DECISION',
+}
 export interface DecisionState {
   leveledChecks: LeveledSkillCheck[];
   selected: LeveledSkillCheck|null;

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.test.tsx
@@ -7,6 +7,7 @@ import {
 import {midCombatChoice} from '../roleplay/Actions';
 import {defaultContext} from '../Template';
 import {ParserNode} from '../TemplateTypes';
+import {CombatPhase} from '../combat/Types';
 
 const cheerio = require('cheerio');
 
@@ -56,12 +57,12 @@ describe('Roleplay actions', () => {
 
     test('goes to win screen on **win**', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 0, maxTier: 0, seed: ''});
-      expect(actions[2].to.phase).toEqual('VICTORY');
+      expect(actions[2].to.phase).toEqual(CombatPhase.victory);
     });
 
     test('goes to lose screen on **lose**', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 1, maxTier: 0, seed: ''});
-      expect(actions[2].to.phase).toEqual('DEFEAT');
+      expect(actions[2].to.phase).toEqual(CombatPhase.defeat);
     });
 
     test('ends quest on **end** and zeros audio', () => {
@@ -85,13 +86,13 @@ describe('Roleplay actions', () => {
 
     test('handles GOTOs that point to other roleplaying inside of the same combat', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 5, maxTier: 0, seed: ''});
-      expect(actions[2].to.phase).toEqual('MID_COMBAT_ROLEPLAY');
+      expect(actions[2].to.phase).toEqual(CombatPhase.midCombatRoleplay);
       expect(actions[1].node.elem.text()).toEqual('rp2');
     });
 
     test('renders as combat for RPs inside of same combat', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 3, maxTier: 0, seed: ''});
-      expect(actions[2].to.phase).toEqual('MID_COMBAT_ROLEPLAY');
+      expect(actions[2].to.phase).toEqual(CombatPhase.midCombatRoleplay);
     });
 
     test('renders as roleplay upon goto to element inside of win/lose event and zeros audio', () => {

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
@@ -6,6 +6,7 @@ import {remoteify} from 'app/multiplayer/Remoteify';
 import {AppStateWithHistory, SettingsType} from 'app/reducers/StateTypes';
 import Redux from 'redux';
 import {findCombatParent, handleCombatEnd} from '../combat/Actions';
+import {CombatPhase} from '../combat/Types';
 import {ParserNode} from '../TemplateTypes';
 
 export function initRoleplay(node: ParserNode) {
@@ -121,12 +122,12 @@ export const midCombatChoice = remoteify(function midCombatChoice(a: MidCombatCh
     case 'ENDROUND':
       dispatch({type: 'PUSH_HISTORY'});
       dispatch({type: 'QUEST_NODE', node: nextNode} as QuestNodeAction);
-      dispatch(toCard({name: 'QUEST_CARD', phase: 'RESOLVE_ABILITIES', overrideDebounce: true, noHistory: true}));
+      dispatch(toCard({name: 'QUEST_CARD', phase: CombatPhase.resolveAbilities, overrideDebounce: true, noHistory: true}));
       break;
     default: // in-combat roleplay continues
       dispatch({type: 'PUSH_HISTORY'});
       dispatch({type: 'QUEST_NODE', node: nextNode} as QuestNodeAction);
-      dispatch(toCard({name: 'QUEST_CARD', phase: 'MID_COMBAT_ROLEPLAY', overrideDebounce: true, noHistory: true}));
+      dispatch(toCard({name: 'QUEST_CARD', phase: CombatPhase.midCombatRoleplay, overrideDebounce: true, noHistory: true}));
       break;
   }
   return remoteArgs;

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/RoleplayContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/RoleplayContainer.tsx
@@ -3,6 +3,7 @@ import {choice} from 'app/actions/Quest';
 import {AppStateWithHistory, SettingsType} from 'app/reducers/StateTypes';
 import {connect} from 'react-redux';
 import Redux from 'redux';
+import {CombatPhase} from '../combat/Types';
 import {ParserNode} from '../TemplateTypes';
 import Roleplay, {DispatchProps, Props, StateProps} from './Roleplay';
 
@@ -29,7 +30,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       dispatch(choice({node, index}));
     },
     onRetry: () => {
-      dispatch(toPrevious({name: 'QUEST_CARD', phase: 'DRAW_ENEMIES', before: true}));
+      dispatch(toPrevious({name: 'QUEST_CARD', phase: CombatPhase.drawEnemies, before: true}));
     },
   };
 };


### PR DESCRIPTION
- Combat & Decision phases are now enums
- Instead of repeated code to generate and set combat template context if not set, rely on Params' `resolveParams` which does the same thing.
- Include combat phase in the combat template context; this allows for a further refactor to centralize the logic that chooses what phase of combat/decision/etc. to render, which is itself a requirement for refactoring the save/sync logic to be able to resume just from a snapshot of node context.