### PR TITLE
(WIP) Refactor: rm card.phase, externalize _history reducer

### DIFF
--- a/services/app/src/actions/ActionTypes.tsx
+++ b/services/app/src/actions/ActionTypes.tsx
@@ -6,8 +6,8 @@ import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes'
 import {
   AudioDataState,
   AudioState,
-  CardState,
   CardName,
+  CardState,
   CheckoutState,
   DialogIDType,
   IUserFeedback,
@@ -73,7 +73,7 @@ export interface NavigateAction extends Redux.Action {
 
 export interface ReturnAction extends Redux.Action {
   type: 'RETURN';
-  matchFn?: (c:CardName, n:ParserNode) => boolean;
+  matchFn?: (c: CardName, n: ParserNode) => boolean;
   before: boolean;
 }
 

--- a/services/app/src/actions/ActionTypes.tsx
+++ b/services/app/src/actions/ActionTypes.tsx
@@ -6,9 +6,8 @@ import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes'
 import {
   AudioDataState,
   AudioState,
-  CardName,
-  CardPhase,
   CardState,
+  CardName,
   CheckoutState,
   DialogIDType,
   IUserFeedback,
@@ -74,9 +73,8 @@ export interface NavigateAction extends Redux.Action {
 
 export interface ReturnAction extends Redux.Action {
   type: 'RETURN';
-  to: CardState;
+  matchFn?: (c:CardName, n:ParserNode) => boolean;
   before: boolean;
-  skip?: Array<{name: CardName, phase: CardPhase}>; // Skip any occurrences of these cards
 }
 
 export interface QuestExitAction extends Redux.Action {

--- a/services/app/src/actions/Card.test.tsx
+++ b/services/app/src/actions/Card.test.tsx
@@ -31,7 +31,7 @@ describe('Card action', () => {
 
   describe('toPrevious', () => {
     test('returns a RETURN action', () => {
-      Action(toPrevious).expect({name: 'QUEST_CARD'}).toDispatch(jasmine.objectContaining({type: 'RETURN'}));
+      Action(toPrevious).expect({matchFn: (c, n) => c === 'QUEST_CARD'}).toDispatch(jasmine.objectContaining({type: 'RETURN'}));
     });
   });
 

--- a/services/app/src/actions/Card.tsx
+++ b/services/app/src/actions/Card.tsx
@@ -20,18 +20,23 @@ export const toCard = remoteify(function toCard(a: ToCardArgs, dispatch: Redux.D
   const state = (getState !== undefined) ? getState() : getStore().getState();
   const questId = (state.quest && state.quest.details && state.quest.details.id) || null;
   const vibration = state.settings && state.settings.vibration;
+
   if (nav && nav.vibrate && vibration) {
-    // TODO long vibration on combat phase timer
     nav.vibrate((a.vibrateLong) ? VIBRATION_LONG_MS : VIBRATION_SHORT_MS);
   }
+
   if (!a.noHistory) {
     dispatch({type: 'PUSH_HISTORY'});
   }
 
   const keylist: string[] = [a.name];
-  const line = state.quest && state.quest.node && state.quest.node.elem.attr('data-line');
-  if (line !== undefined) {
-    keylist.push('L' + line);
+  if (state.quest && state.quest.node) { // In tests, quest.node may not be set up
+    const line = state.quest.node.elem.attr('data-line');
+    if (line !== undefined) {
+      keylist.push('L' + line);
+    }
+    keylist.push(state.quest.node.ctx.templates.combat.phase);
+    keylist.push(state.quest.node.ctx.templates.decision.phase);
   }
   if (a.keySuffix) {
     keylist.push(a.keySuffix);

--- a/services/app/src/actions/Card.tsx
+++ b/services/app/src/actions/Card.tsx
@@ -1,9 +1,10 @@
 import * as Redux from 'redux';
-import {CombatPhase, NAV_CARD_STORAGE_KEY, VIBRATION_LONG_MS, VIBRATION_SHORT_MS} from '../Constants';
+import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
+import {NAV_CARD_STORAGE_KEY, VIBRATION_LONG_MS, VIBRATION_SHORT_MS} from '../Constants';
 import {getNavigator} from '../Globals';
 import {getStorageString} from '../LocalStorage';
 import {remoteify} from '../multiplayer/Remoteify';
-import {AppStateWithHistory, CardName, CardPhase} from '../reducers/StateTypes';
+import {AppStateWithHistory, CardName} from '../reducers/StateTypes';
 import {getStore} from '../Store';
 import {NavigateAction} from './ActionTypes';
 
@@ -12,7 +13,7 @@ export interface ToCardArgs {
   name: CardName;
   noHistory?: boolean;
   overrideDebounce?: boolean;
-  phase?: CardPhase;
+  vibrateLong?: boolean;
 }
 export const toCard = remoteify(function toCard(a: ToCardArgs, dispatch: Redux.Dispatch<any>, getState?: () => AppStateWithHistory): ToCardArgs {
   const nav = getNavigator();
@@ -20,20 +21,14 @@ export const toCard = remoteify(function toCard(a: ToCardArgs, dispatch: Redux.D
   const questId = (state.quest && state.quest.details && state.quest.details.id) || null;
   const vibration = state.settings && state.settings.vibration;
   if (nav && nav.vibrate && vibration) {
-    if (a.phase === CombatPhase.timer) {
-      nav.vibrate(VIBRATION_LONG_MS);
-    } else {
-      nav.vibrate(VIBRATION_SHORT_MS);
-    }
+    // TODO long vibration on combat phase timer
+    nav.vibrate((a.vibrateLong) ? VIBRATION_LONG_MS : VIBRATION_SHORT_MS);
   }
   if (!a.noHistory) {
     dispatch({type: 'PUSH_HISTORY'});
   }
 
   const keylist: string[] = [a.name];
-  if (a.phase) {
-    keylist.push(a.phase);
-  }
   const line = state.quest && state.quest.node && state.quest.node.elem.attr('data-line');
   if (line !== undefined) {
     keylist.push('L' + line);
@@ -48,19 +43,12 @@ export const toCard = remoteify(function toCard(a: ToCardArgs, dispatch: Redux.D
 
 interface ToPreviousArgs {
   before?: boolean;
-  name?: CardName;
-  phase?: CardPhase;
-  skip?: Array<{name: CardName, phase?: CardPhase}>;
+  matchFn?: (c: CardName, n: ParserNode) => boolean;
 }
 export const toPrevious = remoteify(function toPrevious(a: ToPreviousArgs, dispatch: Redux.Dispatch<any>): ToPreviousArgs {
   dispatch({
     before: Boolean(a.before),
-    skip: a.skip,
-    to: {
-      name: a.name,
-      phase: a.phase,
-      ts: Date.now(),
-    },
+    matchFn: a.matchFn,
     type: 'RETURN',
   });
 

--- a/services/app/src/actions/User.tsx
+++ b/services/app/src/actions/User.tsx
@@ -167,7 +167,6 @@ export function getUserBadges(): TReduxThunk<Promise<any>> {
   return (dispatch) => {
     return fetchUserBadges()
     .then((badges: Badge[]) => {
-      console.log(badges);
       return dispatch({type: 'USER_BADGES', badges});
     })
     .catch(() => dispatch({type: 'USER_BADGES', badges: []}));

--- a/services/app/src/audio/ThemeManager.test.tsx
+++ b/services/app/src/audio/ThemeManager.test.tsx
@@ -184,7 +184,6 @@ describe('ThemeManager', () => {
     for(let k of Object.keys(ns)) {
       ns[k].playOnce.calls.reset();
     }
-    console.log('HEAVY');
     am.setIntensity(36);
     let heavys = 0;
     for(let k of Object.keys(ns)) {

--- a/services/app/src/components/Compositor.tsx
+++ b/services/app/src/components/Compositor.tsx
@@ -141,10 +141,16 @@ export default class Compositor extends React.Component<Props, {}> {
   }
 
   public shouldComponentUpdate(nextProps: Props) {
+    // Don't update the main UI if we're on the same card key
+    if (this.props.card.key === nextProps.card.key) {
+      return false;
+    }
+
     // Don't update the main UI if we're just syncing state
     if (nextProps.multiplayer && nextProps.multiplayer.syncing) {
       return false;
     }
+
     return true;
   }
 

--- a/services/app/src/components/Compositor.tsx
+++ b/services/app/src/components/Compositor.tsx
@@ -92,7 +92,7 @@ export default class Compositor extends React.Component<Props, {}> {
         if (!this.props.quest || !this.props.quest.node) {
           throw new Error('QUEST_CARD without quest/node');
         }
-        return renderCardTemplate(this.props.card, this.props.quest.node, this.props.settings);
+        return renderCardTemplate(this.props.quest.node, this.props.settings);
       case 'QUEST_END':
         return <QuestEndContainer />;
       case 'GM_CARD':

--- a/services/app/src/components/CompositorContainer.tsx
+++ b/services/app/src/components/CompositorContainer.tsx
@@ -25,7 +25,7 @@ const mapStateToProps = (state: AppStateWithHistory): StateProps => {
     quest: state.quest,
     settings: state.settings,
     snackbar: state.snackbar,
-    theme: getCardTemplateTheme(state.card),
+    theme: getCardTemplateTheme(state.quest.node),
     transition,
   };
 };

--- a/services/app/src/components/base/Audio.test.tsx
+++ b/services/app/src/components/base/Audio.test.tsx
@@ -29,8 +29,7 @@ describe('Audio', () => {
     const props: Props = {
       themeManager: fakeThemeManager(),
       audio: {...initialAudioState},
-      cardName: 'QUEST_CARD';
-      cardPhase: 'DRAW_ENEMIES';
+      inCombat: true,
       enabled: true,
       disableAudio: jasmine.createSpy('disableAudio'),
       onLoadChange: jasmine.createSpy('onLoadChange'),
@@ -72,8 +71,7 @@ describe('Audio', () => {
         timestamp: 0,
         ...audioOverrides,
       },
-      cardName: 'QUEST_CARD',
-      cardPhase: 'DRAW_ENEMIES',
+      inCombat: true,
     };
   }
   test('plays audio when nonzero intensity in combat node', () => {
@@ -84,7 +82,7 @@ describe('Audio', () => {
 
   test('mutes audio when exiting combat node', () => {
     const {props, a} = setup(activeProps());
-    a.setProps(tick({cardName: 'QUEST_CARD', cardPhase: 'ROLEPLAY'}, 1));
+    a.setProps(tick({inCombat: false}, 1));
     expect(props.themeManager.pause).toHaveBeenCalledTimes(1);
   });
 

--- a/services/app/src/components/base/Audio.tsx
+++ b/services/app/src/components/base/Audio.tsx
@@ -1,13 +1,12 @@
 import {ThemeManager} from 'app/audio/ThemeManager';
 import {AUDIO_COMMAND_DEBOUNCE_MS, INIT_DELAY} from 'app/Constants';
-import {AudioState, CardName, CardPhase} from 'app/reducers/StateTypes';
+import {AudioState} from 'app/reducers/StateTypes';
 import * as React from 'react';
 
 export interface StateProps {
   themeManager: ThemeManager|null;
   audio: AudioState;
-  cardName: CardName;
-  cardPhase: CardPhase|null;
+  inCombat: boolean;
   enabled: boolean;
 }
 
@@ -97,7 +96,7 @@ export default class Audio extends React.Component<Props, {}> {
     }
 
     // If we're outside of combat, pause music
-    if (nextProps.cardName !== 'QUEST_CARD' || nextProps.cardPhase === null || nextProps.cardPhase === 'ROLEPLAY') {
+    if (nextProps.inCombat) {
       console.log('Pausing music (outside of combat)');
       return tm.pause();
     }

--- a/services/app/src/components/base/Audio.tsx
+++ b/services/app/src/components/base/Audio.tsx
@@ -96,7 +96,7 @@ export default class Audio extends React.Component<Props, {}> {
     }
 
     // If we're outside of combat, pause music
-    if (nextProps.inCombat) {
+    if (!nextProps.inCombat) {
       console.log('Pausing music (outside of combat)');
       return tm.pause();
     }

--- a/services/app/src/components/base/AudioContainer.tsx
+++ b/services/app/src/components/base/AudioContainer.tsx
@@ -11,8 +11,7 @@ const mapStateToProps = (state: AppState): StateProps => {
   return {
     themeManager: (state.audioData || {}).themeManager || null,
     audio: state.audio || initialAudioState,
-    cardName: state.card ? state.card.name : 'SPLASH_CARD',
-    cardPhase: state.card ? state.card.phase : null,
+    inCombat: (state.quest.node.getTag() === 'combat'),
     enabled: state.settings.audioEnabled,
   };
 };

--- a/services/app/src/components/base/AudioContainer.tsx
+++ b/services/app/src/components/base/AudioContainer.tsx
@@ -11,7 +11,7 @@ const mapStateToProps = (state: AppState): StateProps => {
   return {
     themeManager: (state.audioData || {}).themeManager || null,
     audio: state.audio || initialAudioState,
-    inCombat: (state.quest.node.getTag() === 'combat'),
+    inCombat: state.quest.node.inCombat(),
     enabled: state.settings.audioEnabled,
   };
 };

--- a/services/app/src/components/base/Card.tsx
+++ b/services/app/src/components/base/Card.tsx
@@ -14,6 +14,7 @@ import {URLS} from '../../Constants';
 import {getDevicePlatform, openWindow} from '../../Globals';
 import {AppStateWithHistory, CardName, CardThemeType, SettingsType, UserState} from '../../reducers/StateTypes';
 import {getStore} from '../../Store';
+import {ParserNode} from '../views/quest/cardtemplates/TemplateTypes';
 
 // If onMenuSelect or onReturn is not set, default dispatch behavior is used.
 export interface Props extends React.Props<any> {
@@ -65,7 +66,7 @@ class Card extends React.Component<Props, IState> {
         break;
       case 'HOME':
         if (!this.props.inQuest) {
-          return dispatch(toPrevious({name: 'SPLASH_CARD', before: false}));
+          return dispatch(toPrevious({matchFn: (c: CardName, n: ParserNode) => c === 'SPLASH_CARD', before: false}));
         }
         return dispatch(setDialog('EXIT_QUEST'));
       case 'ACCOUNT':

--- a/services/app/src/components/base/DialogsContainer.tsx
+++ b/services/app/src/components/base/DialogsContainer.tsx
@@ -12,7 +12,8 @@ import {openSnackbar} from '../../actions/Snackbar';
 import {fetchQuestXML, submitUserFeedback} from '../../actions/Web';
 import {MIN_FEEDBACK_LENGTH} from '../../Constants';
 import {getCounters} from '../../multiplayer/Counters';
-import {AppState, ContentSetsType, FeedbackType, QuestState, SavedQuestMeta, SettingsType, UserState} from '../../reducers/StateTypes';
+import {AppState, CardName, ContentSetsType, FeedbackType, QuestState, SavedQuestMeta, SettingsType, UserState} from '../../reducers/StateTypes';
+import {ParserNode} from '../views/quest/cardtemplates/TemplateTypes';
 import Dialogs, {DispatchProps, StateProps} from './Dialogs';
 
 const mapStateToProps = (state: AppState): StateProps => {
@@ -50,12 +51,12 @@ export const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps
     onExitMultiplayer: () => {
       dispatch(multiplayerDisconnect());
       dispatch(setDialog(null));
-      dispatch(toPrevious({name: 'SPLASH_CARD', before: false}));
+      dispatch(toPrevious({matchFn: (c: CardName, n: ParserNode) => c === 'SPLASH_CARD', before: false}));
     },
     onExitQuest: (quest: QuestState, settings: SettingsType, user: UserState, text: string): Promise<any> => {
       dispatch(setDialog(null));
       dispatch(exitQuest({}));
-      dispatch(toPrevious({name: 'SPLASH_CARD', before: false}));
+      dispatch(toPrevious({matchFn: (c: CardName, n: ParserNode) => c === 'SPLASH_CARD', before: false}));
       if (text && text.length > 0) {
         return dispatch(submitUserFeedback({quest, settings, user, text, type: 'feedback', anonymous: false, rating: null})) as any;
       }

--- a/services/app/src/components/views/AccountContainer.tsx
+++ b/services/app/src/components/views/AccountContainer.tsx
@@ -7,6 +7,7 @@ import {getUserBadges, getUserFeedBacks} from '../../actions/User';
 import {NAV_CARDS} from '../../Constants';
 import {AppState, CardName} from '../../reducers/StateTypes';
 import Account, {IDispatchProps, IStateProps} from './Account';
+import {ParserNode} from './quest/cardtemplates/TemplateTypes';
 
 const mapStateToProps = (state: AppState): IStateProps => {
   return {
@@ -19,7 +20,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): IDispatchProps =>  (
   getUserBadges: () => dispatch(getUserBadges()),
   onReturn: () => {
     dispatch(toPrevious({
-      skip: NAV_CARDS.map((c) => ({name: c as CardName})),
+      matchFn: (c: CardName, n: ParserNode) => NAV_CARDS.indexOf(c) === -1,
     }));
   },
   onQuestSelect(quest: Quest): void {

--- a/services/app/src/components/views/CheckoutDoneContainer.tsx
+++ b/services/app/src/components/views/CheckoutDoneContainer.tsx
@@ -1,8 +1,9 @@
 import {connect} from 'react-redux';
 import Redux from 'redux';
 import {toPrevious} from '../../actions/Card';
-import {AppState} from '../../reducers/StateTypes';
+import {AppState, CardName} from '../../reducers/StateTypes';
 import CheckoutDone, {DispatchProps, StateProps} from './CheckoutDone';
+import {ParserNode} from './quest/cardtemplates/TemplateTypes';
 
 const mapStateToProps = (state: AppState): StateProps => {
   return {
@@ -13,7 +14,7 @@ const mapStateToProps = (state: AppState): StateProps => {
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
     onHome: (): void => {
-      dispatch(toPrevious({name: 'TUTORIAL_QUESTS'}));
+      dispatch(toPrevious({matchFn: (c: CardName, n: ParserNode) => c === 'TUTORIAL_QUESTS'}));
     },
   };
 };

--- a/services/app/src/components/views/SearchContainer.tsx
+++ b/services/app/src/components/views/SearchContainer.tsx
@@ -8,6 +8,7 @@ import {search} from '../../actions/Search';
 import {getContentSets} from '../../actions/Settings';
 import {NAV_CARDS} from '../../Constants';
 import {AppStateWithHistory, CardName, SearchParams, SettingsType} from '../../reducers/StateTypes';
+import {ParserNode} from './quest/cardtemplates/TemplateTypes';
 import Search, {DispatchProps, StateProps} from './Search';
 
 const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProps>): StateProps => {
@@ -37,7 +38,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
     },
     onReturn(): void {
       dispatch(toPrevious({
-        skip: NAV_CARDS.map((c) => ({name: c as CardName})),
+        matchFn: (c: CardName, n: ParserNode) => NAV_CARDS.indexOf(c) === -1,
       }));
     },
   };

--- a/services/app/src/components/views/quest/QuestEndContainer.tsx
+++ b/services/app/src/components/views/quest/QuestEndContainer.tsx
@@ -7,9 +7,10 @@ import {ensureLogin} from 'app/actions/User';
 import {submitUserFeedback} from 'app/actions/Web';
 import {getDevicePlatform} from 'app/Globals';
 import {logEvent} from 'app/Logging';
-import {AppState, MultiplayerState, QuestState, SettingsType, UserState} from 'app/reducers/StateTypes';
+import {AppState, CardName, MultiplayerState, QuestState, SettingsType, UserState} from 'app/reducers/StateTypes';
 import {connect} from 'react-redux';
 import Redux from 'redux';
+import {ParserNode} from './cardtemplates/TemplateTypes';
 import QuestEnd, {DispatchProps, StateProps} from './QuestEnd';
 
 declare var window: any;
@@ -48,7 +49,9 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       }
 
       if (!multiplayer.session) {
-        dispatch(toPrevious({skip: [{name: 'QUEST_CARD'}, {name: 'QUEST_SETUP'}]}));
+        dispatch(toPrevious({
+          matchFn: (c: CardName, n: ParserNode) => c !== 'QUEST_CARD' && c !== 'QUEST_SETUP',
+        }));
         dispatch(exitQuest({}));
       } else {
         dispatch(setMultiplayerStatus({

--- a/services/app/src/components/views/quest/cardtemplates/Template.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.tsx
@@ -1,6 +1,6 @@
 import {getContentSets, numAdventurers} from 'app/actions/Settings';
 import {CombatPhase, DecisionPhase} from 'app/Constants';
-import {AppStateWithHistory, CardState, CardThemeType, SettingsType} from 'app/reducers/StateTypes';
+import {AppStateWithHistory, CardThemeType, SettingsType} from 'app/reducers/StateTypes';
 import {getStore} from 'app/Store';
 import * as React from 'react';
 import Redux from 'redux';
@@ -42,17 +42,23 @@ export function initCardTemplate(node: ParserNode) {
   };
 }
 
-export function renderCardTemplate(card: CardState, node: ParserNode, settings: SettingsType): JSX.Element {
-  const phase = card.phase || 'ROLEPLAY';
-  switch (phase) {
-    case 'ROLEPLAY':
-      return <RoleplayContainer node={node}/>;
+function renderDecisionTemplate(node: ParserNode): JSX.Element {
+  const dp = node.ctx.templates.decision.phase;
+  switch (dp) {
     case DecisionPhase.prepare:
       return <PrepareDecisionContainer node={node}/>;
     case DecisionPhase.timer:
       return <DecisionTimerContainer node={node}/>;
     case DecisionPhase.resolve:
       return <ResolveDecisionContainer node={node}/>;
+    default:
+      throw new Error('Unknown decision phase ' + dp);
+  }
+}
+
+function renderCombatTemplate(node: ParserNode, settings: SettingsType): JSX.Element {
+  const cp = node.ctx.templates.combat.phase;
+  switch (cp) {
     case CombatPhase.drawEnemies:
       return <DrawEnemiesContainer node={node}/>;
     case CombatPhase.prepare:
@@ -80,33 +86,32 @@ export function renderCardTemplate(card: CardState, node: ParserNode, settings: 
       return <MidCombatRoleplayContainer node={node}/>;
     case CombatPhase.midCombatDecision:
     case CombatPhase.midCombatDecisionTimer:
-      return renderCardTemplate({...card, phase: node.ctx.templates.decision.phase}, node, settings);
+      return renderDecisionTemplate(node);
     default:
-      throw new Error('Unknown template for card phase ' + card.phase);
+      throw new Error('Unknown combat phase ' + cp);
   }
 }
 
-export function getCardTemplateTheme(card: CardState): CardThemeType {
-  switch (card.phase || 'ROLEPLAY') {
-    case CombatPhase.drawEnemies:
-    case CombatPhase.prepare:
-    case CombatPhase.timer:
-    case CombatPhase.surge:
-    case CombatPhase.resolveAbilities:
-    case CombatPhase.resolveDamage:
-    case CombatPhase.victory:
-    case CombatPhase.defeat:
-    case CombatPhase.midCombatRoleplay:
-    case CombatPhase.midCombatDecision:
-    case CombatPhase.midCombatDecisionTimer:
-      return 'dark';
-    case 'ROLEPLAY':
-    case DecisionPhase.prepare:
-    case DecisionPhase.timer:
-    case DecisionPhase.resolve:
+export function renderCardTemplate(node: ParserNode, settings: SettingsType): JSX.Element {
+  const tag = node.getTag();
+  switch (tag) {
+    case 'roleplay':
+      return <RoleplayContainer node={node}/>;
+    case 'combat':
+      return renderCombatTemplate(node, settings);
+    case 'decision':
+      return renderDecisionTemplate(node);
     default:
-      return 'light';
+      throw new Error('Unknown tag ' + tag);
   }
+}
+
+export function getCardTemplateTheme(node: ParserNode): CardThemeType {
+  if (node.getTag() === 'combat') {
+    // TODO handle mid combat roleplay
+    return 'dark';
+  }
+  return 'light';
 }
 
 export function templateScope() {

--- a/services/app/src/components/views/quest/cardtemplates/Template.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.tsx
@@ -82,8 +82,6 @@ function renderCombatTemplate(node: ParserNode, settings: SettingsType): JSX.Ele
       return <VictoryContainer node={node}/>;
     case CombatPhase.defeat:
       return <DefeatContainer node={node}/>;
-    case CombatPhase.midCombatRoleplay:
-      return <MidCombatRoleplayContainer node={node}/>;
     case CombatPhase.midCombatDecision:
     case CombatPhase.midCombatDecisionTimer:
       return renderDecisionTemplate(node);
@@ -92,11 +90,19 @@ function renderCombatTemplate(node: ParserNode, settings: SettingsType): JSX.Ele
   }
 }
 
+function renderRoleplayTemplate(node: ParserNode): JSX.Element {
+  if (node.ctx.templates.combat.phase === CombatPhase.midCombatRoleplay) {
+    return <MidCombatRoleplayContainer node={node}/>;
+  } else {
+    return <RoleplayContainer node={node}/>;
+  }
+}
+
 export function renderCardTemplate(node: ParserNode, settings: SettingsType): JSX.Element {
   const tag = node.getTag();
   switch (tag) {
     case 'roleplay':
-      return <RoleplayContainer node={node}/>;
+      return renderRoleplayTemplate(node);
     case 'combat':
       return renderCombatTemplate(node, settings);
     case 'decision':
@@ -107,8 +113,7 @@ export function renderCardTemplate(node: ParserNode, settings: SettingsType): JS
 }
 
 export function getCardTemplateTheme(node: ParserNode): CardThemeType {
-  if (node.getTag() === 'combat') {
-    // TODO handle mid combat roleplay
+  if (node.inCombat()) {
     return 'dark';
   }
   return 'light';

--- a/services/app/src/components/views/quest/cardtemplates/TemplateTypes.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/TemplateTypes.tsx
@@ -19,4 +19,8 @@ export interface TemplateContext extends Context {
   _templateScopeFn: () => any;
 }
 
-export class ParserNode extends Node<TemplateContext> {}
+export class ParserNode extends Node<TemplateContext> {
+  public inCombat(): boolean {
+    return this.getTag() === 'combat' || this.ctx.templates.combat.phase === CombatPhase.midCombatDecision || this.ctx.templates.combat.phase === CombatPhase.midCombatRoleplay;
+  }
+}

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
@@ -69,13 +69,8 @@ describe('Combat actions', () => {
     const actions = Action(initCombat, {settings: s.basic}).execute({node: TEST_NODE.clone()});
 
     test('triggers nav to combat start', () => {
-      expect(actions[2]).toEqual(jasmine.objectContaining({
-        to: jasmine.objectContaining({
-          name: 'QUEST_CARD',
-          phase: CombatPhase.drawEnemies,
-        }),
-        type: 'NAVIGATE',
-      }));
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual(CombatPhase.drawEnemies);
+      expect(actions.filter((a) => a.type === 'NAVIGATE').length).toEqual(1);
       checkNodeIntegrity(null, null); // skip
     });
 
@@ -444,7 +439,7 @@ describe('Combat actions', () => {
       </combat>`)('combat'), defaultContext());
       const actions = Action(handleResolvePhase).execute({node});
       expect(actions[1].type).toEqual('QUEST_NODE');
-      expect(actions[2].to.phase).toEqual(CombatPhase.resolveAbilities);
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual(CombatPhase.resolveAbilities);
       checkNodeIntegrity(node, actions[1].node);
     });
 
@@ -459,7 +454,7 @@ describe('Combat actions', () => {
       </combat>`)('combat'), defaultContext());
       const actions = Action(handleResolvePhase).execute({node});
       expect(actions[1].type).toEqual('QUEST_NODE');
-      expect(actions[2].to.phase).toEqual(CombatPhase.resolveAbilities);
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual(CombatPhase.resolveAbilities);
       checkNodeIntegrity(node, actions[1].node);
     });
 
@@ -477,7 +472,7 @@ describe('Combat actions', () => {
       node = Action(initCombat as any).execute({node: node.clone(), settings: s.basic})[1].node;
       const actions = Action(handleResolvePhase).execute({node});
       expect(actions[1].node.elem.text()).toEqual('expected');
-      expect(actions[2].to.phase).toEqual(CombatPhase.midCombatRoleplay);
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual(CombatPhase.midCombatRoleplay);
 
       // We expect node integrity to be broken when moving from combat to roleplay.
       checkNodeIntegrity(null, null);

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.tsx
@@ -282,19 +282,21 @@ export const handleResolvePhase = remoteify(function handleResolvePhase(a: Handl
   if (!a.node) {
     a.node = getState().quest.node;
   }
-  const node = a.node.clone();
+  let node = a.node.clone();
 
   // Handles resolution, with a hook for if a <choice on="round"/> tag is specified.
   // Note that handling new combat nodes within a "round" handler has undefined
   // behavior and should be prevented when compiled.
   const roundNode = node.getNext('round');
-  dispatch({type: 'PUSH_HISTORY'});
   if (roundNode !== null) {
-    roundNode.ctx.templates.combat.phase = CombatPhase.midCombatRoleplay;
+    node = roundNode;
+    node.ctx.templates.combat.phase = CombatPhase.midCombatRoleplay;
   } else {
     node.ctx.templates.combat.phase = CombatPhase.resolveAbilities;
   }
-  dispatch({type: 'QUEST_NODE', node: roundNode} as QuestNodeAction);
+
+  dispatch({type: 'PUSH_HISTORY'});
+  dispatch({type: 'QUEST_NODE', node} as QuestNodeAction);
   dispatch(toCard({name: 'QUEST_CARD', overrideDebounce: true, noHistory: true}));
   return {};
 });
@@ -315,7 +317,7 @@ export const handleCombatTimerStart = remoteify(function handleCombatTimerStart(
   node.ctx.templates.combat.phase = CombatPhase.timer;
   dispatch({type: 'PUSH_HISTORY'});
   dispatch({type: 'QUEST_NODE', node} as QuestNodeAction);
-  dispatch(toCard({name: 'QUEST_CARD'}));
+  dispatch(toCard({name: 'QUEST_CARD', vibrateLong: true}));
   dispatch(audioSet({peakIntensity: 1}));
 
   // If we have no local alive adventurers but we're playing multiplayer, automatically put the timer in hold state.

--- a/services/app/src/components/views/quest/cardtemplates/combat/DefeatContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/DefeatContainer.tsx
@@ -1,7 +1,7 @@
 import {toPrevious} from 'app/actions/Card';
 import {event} from 'app/actions/Quest';
 import {CombatPhase} from 'app/Constants';
-import {AppStateWithHistory} from 'app/reducers/StateTypes';
+import {AppStateWithHistory, CardName} from 'app/reducers/StateTypes';
 import {connect} from 'react-redux';
 import Redux from 'redux';
 import {ParserNode} from '../TemplateTypes';
@@ -24,7 +24,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       dispatch(event({node, evt}));
     },
     onRetry: () => {
-      dispatch(toPrevious({name: 'QUEST_CARD', phase: CombatPhase.drawEnemies, before: true}));
+      dispatch(toPrevious({matchFn: (c: CardName, n: ParserNode) => n.getTag() === 'combat' && n.ctx.templates.combat.phase === CombatPhase.drawEnemies, before: true}));
     },
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/combat/DrawEnemies.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/DrawEnemies.tsx
@@ -16,7 +16,7 @@ export interface StateProps extends StatePropsBase {
 }
 
 export interface DispatchProps {
-  onNext: (phase: CombatPhase) => void;
+  onNext: (node: ParserNode, phase: CombatPhase) => void;
   onTierSumDelta: (node: ParserNode, current: number, delta: number) => void;
 }
 
@@ -67,7 +67,7 @@ export default function drawEnemies(props: Props): JSX.Element {
       </p>
       {enemies}
       {helpText}
-      <Button onClick={() => props.onNext(CombatPhase.prepare)}>Next</Button>
+      <Button onClick={() => props.onNext(props.node, CombatPhase.prepare)}>Next</Button>
       <AudioControlsContainer />
     </Card>
   );

--- a/services/app/src/components/views/quest/cardtemplates/combat/DrawEnemiesContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/DrawEnemiesContainer.tsx
@@ -1,4 +1,3 @@
-import {toCard} from 'app/actions/Card';
 import {CombatPhase} from 'app/Constants';
 import {AppStateWithHistory} from 'app/reducers/StateTypes';
 import {connect} from 'react-redux';
@@ -6,6 +5,7 @@ import Redux from 'redux';
 import {ParserNode} from '../TemplateTypes';
 import {
   tierSumDelta,
+  toCombatPhase,
 } from './Actions';
 import DrawEnemies, {DispatchProps, StateProps} from './DrawEnemies';
 import {mapStateToProps as mapStateToPropsBase} from './Types';
@@ -22,8 +22,8 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: {node: ParserNode
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
-    onNext: (phase: CombatPhase) => {
-      dispatch(toCard({name: 'QUEST_CARD', phase}));
+    onNext: (node: ParserNode, phase: CombatPhase) => {
+      dispatch(toCombatPhase({node, phase}));
     },
     onTierSumDelta: (node: ParserNode, current: number, delta: number) => {
       dispatch(tierSumDelta({node, current, delta}));

--- a/services/app/src/components/views/quest/cardtemplates/combat/MidCombatRoleplayContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/MidCombatRoleplayContainer.tsx
@@ -1,6 +1,6 @@
 import {toPrevious} from 'app/actions/Card';
 import {CombatPhase} from 'app/Constants';
-import {AppStateWithHistory, SettingsType} from 'app/reducers/StateTypes';
+import {AppStateWithHistory, CardName, SettingsType} from 'app/reducers/StateTypes';
 import {connect} from 'react-redux';
 import Redux from 'redux';
 import {
@@ -21,7 +21,7 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
     }
     const tier = combatContext.tier;
     histIdx--;
-    const phase = state._history[histIdx].card.phase;
+    const phase = state._history[histIdx].quest.node.ctx.templates.combat.phase;
     if (tier && phase !== null && phase === CombatPhase.prepare) {
       maxTier = Math.max(maxTier, tier);
     }
@@ -42,11 +42,11 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       dispatch(midCombatChoice({node, settings, index, maxTier, seed}));
     },
     onRetry: () => {
-      dispatch(toPrevious({name: 'QUEST_CARD', phase: CombatPhase.drawEnemies, before: true}));
+      dispatch(toPrevious({matchFn: (c: CardName, n: ParserNode) => n.getTag() === 'combat' && n.ctx.templates.combat.phase === CombatPhase.drawEnemies, before: true}));
     },
     onReturn: () => {
       // Return to the "Ready for Combat?" card instead of doing the timed round again.
-      dispatch(toPrevious({before: false, skip: [{name: 'QUEST_CARD', phase: CombatPhase.timer}]}));
+      dispatch(toPrevious({before: false, matchFn: (c: CardName, n: ParserNode) => n.ctx.templates.combat.phase !== CombatPhase.timer}));
     },
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.tsx
@@ -25,7 +25,7 @@ export interface DispatchProps {
   onAdventurerDelta: (node: ParserNode, settings: SettingsType, current: number, delta: number) => void;
   onDecisionSetup: (node: ParserNode, seed: string) => void;
   onDefeat: (node: ParserNode, settings: SettingsType, maxTier: number, seed: string) => void;
-  onNext: (phase: CombatPhase) => void;
+  onNext: (node: ParserNode, phase: CombatPhase) => void;
   onTierSumDelta: (node: ParserNode, current: number, delta: number) => void;
   onVictory: (node: ParserNode, settings: SettingsType, maxTier: number, seed: string) => void;
 }
@@ -80,7 +80,7 @@ export default function playerTier(props: Props): JSX.Element {
       <Button
         className={(props.numAliveAdventurers === 0 || props.tier === 0) ? 'subtle' : ''}
         disabled={props.numAliveAdventurers <= 0 || props.tier <= 0}
-        onClick={() => (shouldRunDecision) ? props.onDecisionSetup(props.node, props.seed) : props.onNext(CombatPhase.prepare)}>Next</Button>
+        onClick={() => (shouldRunDecision) ? props.onDecisionSetup(props.node, props.seed) : props.onNext(props.node, CombatPhase.prepare)}>Next</Button>
       <Button
         className={(props.tier !== 0) ? 'subtle' : ''}
         disabled={props.numAliveAdventurers <= 0 && props.tier > 0}

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
@@ -1,4 +1,3 @@
-import {toCard} from 'app/actions/Card';
 import {getContentSets, numAdventurers, numAliveAdventurers, numPlayers} from 'app/actions/Settings';
 import {CombatPhase} from 'app/Constants';
 import {logEvent} from 'app/Logging';
@@ -11,6 +10,7 @@ import {
   handleCombatEnd,
   setupCombatDecision,
   tierSumDelta,
+  toCombatPhase,
 } from './Actions';
 import PlayerTier, {DispatchProps, StateProps} from './PlayerTier';
 import {mapStateToProps as mapStateToPropsBase} from './Types';
@@ -26,8 +26,8 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
     }
     const tier = combatContext.tier;
     histIdx--;
-    const phase = state._history[histIdx].card.phase;
-    if (tier && phase !== null && phase === CombatPhase.prepare) {
+    const phase = state._history[histIdx].quest.node.ctx.templates.combat.phase;
+    if (tier && phase === CombatPhase.prepare) {
       maxTier = Math.max(maxTier, tier);
     }
   }
@@ -71,8 +71,8 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       });
       dispatch(handleCombatEnd({node, settings, victory: false, maxTier, seed}));
     },
-    onNext: (phase: CombatPhase) => {
-      dispatch(toCard({name: 'QUEST_CARD', phase}));
+    onNext: (node: ParserNode, phase: CombatPhase) => {
+      dispatch(toCombatPhase({node, phase}));
     },
     onTierSumDelta: (node: ParserNode, current: number, delta: number) => {
       dispatch(tierSumDelta({node, current, delta}));

--- a/services/app/src/components/views/quest/cardtemplates/combat/Resolve.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Resolve.tsx
@@ -4,6 +4,7 @@ import {CombatPhase} from 'app/Constants';
 import {ContentSetsType} from 'app/reducers/StateTypes';
 import * as React from 'react';
 import {CONTENT_SET_FULL_NAMES, Expansion} from 'shared/schema/Constants';
+import {ParserNode} from '../TemplateTypes';
 import {StateProps as StatePropsBase} from './Types';
 
 export interface StateProps extends StatePropsBase {
@@ -12,7 +13,7 @@ export interface StateProps extends StatePropsBase {
 }
 
 export interface DispatchProps {
-  onNext: (phase: CombatPhase) => void;
+  onNext: (node: ParserNode, phase: CombatPhase) => void;
   onReturn: () => void;
 }
 
@@ -62,7 +63,7 @@ export default function resolve(props: Props): JSX.Element {
           <div className="rolls">{renderedRolls}</div>
         </div>
       }
-      <Button onClick={() => props.onNext(CombatPhase.resolveDamage)}>Next</Button>
+      <Button onClick={() => props.onNext(props.node, CombatPhase.resolveDamage)}>Next</Button>
     </Card>
   );
 }

--- a/services/app/src/components/views/quest/cardtemplates/combat/ResolveContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/ResolveContainer.tsx
@@ -1,9 +1,11 @@
-import {toCard, toPrevious} from 'app/actions/Card';
+import {toPrevious} from 'app/actions/Card';
 import {getContentSets} from 'app/actions/Settings';
 import {CombatPhase} from 'app/Constants';
-import {AppStateWithHistory} from 'app/reducers/StateTypes';
+import {AppStateWithHistory, CardName} from 'app/reducers/StateTypes';
 import {connect} from 'react-redux';
 import Redux from 'redux';
+import {ParserNode} from '../TemplateTypes';
+import {toCombatPhase} from './Actions';
 import Resolve, {DispatchProps, StateProps} from './Resolve';
 import {mapStateToProps as mapStateToPropsBase} from './Types';
 
@@ -17,12 +19,12 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
-    onNext: (phase: CombatPhase) => {
-      dispatch(toCard({name: 'QUEST_CARD', phase}));
+    onNext: (node: ParserNode, phase: CombatPhase) => {
+      dispatch(toCombatPhase({node, phase}));
     },
     onReturn: () => {
       // Return to the "Ready for Combat?" card instead of doing the timed round again.
-      dispatch(toPrevious({before: false, skip: [{name: 'QUEST_CARD', phase: CombatPhase.timer}]}));
+      dispatch(toPrevious({before: false, matchFn: (c: CardName, n: ParserNode) => n.ctx.templates.combat.phase !== CombatPhase.timer}));
     },
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/combat/SurgeContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/SurgeContainer.tsx
@@ -1,6 +1,6 @@
 import {toPrevious} from 'app/actions/Card';
 import {CombatPhase} from 'app/Constants';
-import {AppStateWithHistory} from 'app/reducers/StateTypes';
+import {AppStateWithHistory, CardName} from 'app/reducers/StateTypes';
 import {connect} from 'react-redux';
 import Redux from 'redux';
 import {ParserNode} from '../TemplateTypes';
@@ -18,7 +18,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
     onReturn: () => {
       // Return to the "Ready for Combat?" card instead of doing the timed round again.
-      dispatch(toPrevious({before: false, skip: [{name: 'QUEST_CARD', phase: CombatPhase.timer}]}));
+      dispatch(toPrevious({before: false, matchFn: (c: CardName, n: ParserNode) => n.ctx.templates.combat.phase !== CombatPhase.timer}));
     },
     onSurgeNext: (node: ParserNode) => {
       dispatch(handleResolvePhase({node}));

--- a/services/app/src/components/views/quest/cardtemplates/combat/Types.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Types.tsx
@@ -69,7 +69,7 @@ export function mapStateToProps(state: AppStateWithHistory, ownProps: Partial<St
     players: numPlayers(state.settings, state.multiplayer),
     settings: state.settings,
     seed: (node && node.ctx.seed) || '',
-    theme: getCardTemplateTheme(state.card),
+    theme: getCardTemplateTheme(state.quest.node),
     multiplayer: state.multiplayer,
   };
 }

--- a/services/app/src/components/views/quest/cardtemplates/combat/Victory.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Victory.tsx
@@ -76,7 +76,7 @@ function maybeRenderLevelUp(props: Props): JSX.Element|null {
     return null;
   }
   const levelUpOptions = [
-    <li>Learn a new ability.
+    <li key="base_level">Learn a new ability.
       {props.settings.showHelp && <ul>
         <li>Draw 3 abilities from one of the decks listed on your adventurer card.</li>
           {props.contentSets.has(Expansion.horror) && <ul>
@@ -91,13 +91,13 @@ function maybeRenderLevelUp(props: Props): JSX.Element|null {
     </li>,
   ];
   if (props.contentSets.has(Expansion.horror)) {
-    levelUpOptions.push(<li>
+    levelUpOptions.push(<li key="horror_level">
       <img className="inline_icon" src={'images/' + formatImg('horror', props.theme) + '.svg'} />
       Increase their Persona by 2.
     </li>);
   }
   if (props.contentSets.has(Expansion.future)) {
-    levelUpOptions.push(<li>
+    levelUpOptions.push(<li key="future_level">
       <img className="inline_icon" src={'images/' + formatImg('synth', props.theme) + '.svg'} />
       Learn a new skill.
       {props.settings.showHelp && <ul>

--- a/services/app/src/components/views/quest/cardtemplates/combat/VictoryContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/VictoryContainer.tsx
@@ -33,7 +33,7 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
     ...mapStateToPropsBase(state, ownProps),
     combat,
     victoryParameters,
-    theme: getCardTemplateTheme(state.card),
+    theme: getCardTemplateTheme(state.quest.node),
     contentSets: getContentSets(state.settings, state.multiplayer),
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/decision/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Actions.test.tsx
@@ -262,7 +262,6 @@ describe('Decision actions', () => {
   describe('toDecisionCard', () => {
     test('goes to MID_COMBAT_DECISION if in combat', () => {
       const actions = Action(toDecisionCard, {card: {phase: CombatPhase.midCombatDecision}}).execute({node: TEST_NODE_COMBAT});
-      console.log(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat);
       expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual(CombatPhase.midCombatDecision);
     });
     test('does pass-thru to toCard if not in combat', () => {

--- a/services/app/src/components/views/quest/cardtemplates/decision/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Actions.test.tsx
@@ -49,6 +49,9 @@ const TEST_NODE_NO_INTERRUPTED = new ParserNode(cheerio.load(`
     <event on="failure"></event>
   </decision>`)('decision'), defaultContext());
 
+const TEST_NODE_COMBAT = new ParserNode(cheerio.load(`
+  <combat></combat>`)('combat'), defaultContext());
+
 
 // Parsed from TEST_NODE
 const testDecision = (requiredSuccesses: number) => {
@@ -73,7 +76,7 @@ describe('Decision actions', () => {
     }).execute({node: copyNode.clone()})[1].node;
     const decision = extractDecision(node);
     decision.selected = decision.leveledChecks[0];
-    node.ctx.templates.combat = {decisionPhase: DecisionPhase.resolve}; // Ignored if non-combat, used if mid-combat
+    node.ctx.templates.decision.phase = DecisionPhase.resolve; // Ignored if non-combat, used if mid-combat
     return node;
   }
   describe('extractDecision', () => {
@@ -100,7 +103,7 @@ describe('Decision actions', () => {
         multiplayer: m.s2p5,
       }).execute({node});
       expect(extractDecision(actions[1].node)).toEqual(testDecision(3));
-      expect(actions[2].to).toEqual(jasmine.objectContaining({phase: DecisionPhase.prepare}));
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.decision.phase).toEqual(DecisionPhase.prepare);
     });
     test('requires fewer successes than total alive player count (multiplayer)', () => {
       const actions = Action(initDecision, {
@@ -108,7 +111,7 @@ describe('Decision actions', () => {
         multiplayer: m.s2p2a1,
       }).execute({node: TEST_NODE.clone()});
       expect(extractDecision(actions[1].node)).toEqual(testDecision(1));
-      expect(actions[2].to).toEqual(jasmine.objectContaining({phase: DecisionPhase.prepare}));
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.decision.phase).toEqual(DecisionPhase.prepare);
     });
     test('requires fewer successes than maxrolls', () => {
       const actions = Action(initDecision, {
@@ -116,7 +119,7 @@ describe('Decision actions', () => {
         multiplayer: m.s2p5,
       }).execute({node: TEST_NODE_MAX_1.clone()});
       expect(extractDecision(actions[1].node)).toEqual(testDecision(1));
-      expect(actions[2].to).toEqual(jasmine.objectContaining({phase: DecisionPhase.prepare}));
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.decision.phase).toEqual(DecisionPhase.prepare);
     });
   });
   describe('computeSuccesses', () => {
@@ -215,25 +218,25 @@ describe('Decision actions', () => {
         settings: s.basic,
         multiplayer: m.s2p5
       }).execute({node: setup(), roll: 10});
-      expect(actions[2].to.phase).toEqual(DecisionPhase.resolve);
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.decision.phase).toEqual(DecisionPhase.resolve);
     });
     test('mid-combat decision remains in combat when resolving', () => {
       const actions = Action(handleDecisionRoll, {
         card: {phase: CombatPhase.midCombatDecision},
         settings: s.basic,
         multiplayer: m.s2p5
-      }).execute({node: setup(), roll: 10});
-      expect(actions[2].to).toEqual(jasmine.objectContaining({phase: CombatPhase.midCombatDecision}));
-      expect(actions[1].node.ctx.templates.combat.decisionPhase).toEqual(DecisionPhase.resolve);
+      }).execute({node: TEST_NODE_COMBAT, roll: 10});
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual(CombatPhase.midCombatDecision);
+      expect(actions[1].node.ctx.templates.decision.phase).toEqual(DecisionPhase.resolve);
     });
     test('mid-combat decision remains in combat when resolving', () => {
       const actions = Action(handleDecisionRoll, {
         card: {phase: CombatPhase.midCombatDecision},
         settings: s.basic,
         multiplayer: m.s2p5
-      }).execute({node: setup(), roll: 10});
-      expect(actions[2].to).toEqual(jasmine.objectContaining({phase: CombatPhase.midCombatDecision}));
-      expect(actions[1].node.ctx.templates.combat.decisionPhase).toEqual(DecisionPhase.resolve);
+      }).execute({node: TEST_NODE_COMBAT, roll: 10});
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual(CombatPhase.midCombatDecision);
+      expect(actions[1].node.ctx.templates.decision.phase).toEqual(DecisionPhase.resolve);
     });
     test('goes to interrupted state when non-combat decision has interrupted event', () => {
       const node = setup();
@@ -258,12 +261,13 @@ describe('Decision actions', () => {
   });
   describe('toDecisionCard', () => {
     test('goes to MID_COMBAT_DECISION if in combat', () => {
-      const actions = Action(toDecisionCard, {card: {phase: CombatPhase.midCombatDecision}}).execute({node: setup()});
-      expect(actions[2].to).toEqual(jasmine.objectContaining({phase: CombatPhase.midCombatDecision}));
+      const actions = Action(toDecisionCard, {card: {phase: CombatPhase.midCombatDecision}}).execute({node: TEST_NODE_COMBAT});
+      console.log(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat);
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual(CombatPhase.midCombatDecision);
     });
     test('does pass-thru to toCard if not in combat', () => {
       const actions = Action(toDecisionCard, {card: {phase: ''}}).execute({node: setup() name: 'QUEST_CARD', phase: DecisionPhase.resolve});
-      expect(actions[1].to).toEqual(jasmine.objectContaining({phase: DecisionPhase.resolve}));
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.decision.phase).toEqual(DecisionPhase.resolve);
     });
   });
 });

--- a/services/app/src/components/views/quest/cardtemplates/decision/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Actions.tsx
@@ -2,7 +2,7 @@ import {QuestNodeAction} from 'app/actions/ActionTypes';
 import {toCard, ToCardArgs} from 'app/actions/Card';
 import {event} from 'app/actions/Quest';
 import {numAliveAdventurers, numPlayers} from 'app/actions/Settings';
-import {DecisionPhase, PLAYER_TIME_MULT} from 'app/Constants';
+import {CombatPhase, DecisionPhase, PLAYER_TIME_MULT} from 'app/Constants';
 import {remoteify} from 'app/multiplayer/Remoteify';
 import {AppStateWithHistory, MultiplayerState, SettingsType} from 'app/reducers/StateTypes';
 import Redux from 'redux';
@@ -298,6 +298,10 @@ export const toDecisionCard = remoteify(function toDecisionCard(a: ToDecisionCar
     a.node = getState().quest.node;
   }
   const node = a.node.clone();
+  if (node.inCombat()) {
+    console.log('setting combat phase');
+    node.ctx.templates.combat.phase = CombatPhase.midCombatDecision;
+  }
   node.ctx.templates.decision.phase = a.phase;
   dispatch({type: 'PUSH_HISTORY'});
   dispatch({type: 'QUEST_NODE', node} as QuestNodeAction);

--- a/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecision.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecision.tsx
@@ -13,7 +13,7 @@ const pluralize = require('pluralize');
 
 export interface DispatchProps {
   onRoll: (node: ParserNode, roll: number) => void;
-  onCombatDecisionEnd: () => void;
+  onCombatDecisionEnd: (node: ParserNode) => void;
   onReturn: () => void;
 }
 
@@ -45,7 +45,7 @@ export default function resolveDecision(props: Props): JSX.Element {
           ? <Callout icon={formatImg('adventurer', props.theme, false)}>{instruction}</Callout>
           : <p>Nothing happens.</p>
         }
-        <Button onClick={() => props.onCombatDecisionEnd()}>Next</Button>
+        <Button onClick={() => props.onCombatDecisionEnd(props.node)}>Next</Button>
       </Card>
     );
   }

--- a/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecisionContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/ResolveDecisionContainer.tsx
@@ -1,9 +1,9 @@
-import {toCard} from 'app/actions/Card';
 import {toPrevious} from 'app/actions/Card';
-import {CombatPhase, DecisionPhase} from 'app/Constants';
-import {AppStateWithHistory} from 'app/reducers/StateTypes';
+import {CombatPhase} from 'app/Constants';
+import {AppStateWithHistory, CardName} from 'app/reducers/StateTypes';
 import {connect} from 'react-redux';
 import Redux from 'redux';
+import {toCombatPhase} from '../combat/Actions';
 import {ParserNode} from '../TemplateTypes';
 import {handleDecisionRoll} from './Actions';
 import ResolveDecision, {DispatchProps} from './ResolveDecision';
@@ -17,16 +17,13 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
   return {
     onReturn: () => {
       // Return to the Prepare Decision card instead of going back to the timer.
-      dispatch(toPrevious({before: false, skip: [
-        {name: 'QUEST_CARD', phase: DecisionPhase.timer},
-        {name: 'QUEST_CARD', phase: CombatPhase.midCombatDecisionTimer},
-      ]}));
+      dispatch(toPrevious({before: false, matchFn: (c: CardName, n: ParserNode) => n.ctx.templates.combat.phase !== CombatPhase.midCombatDecisionTimer}));
     },
     onRoll: (node: ParserNode, roll: number) => {
       dispatch(handleDecisionRoll({node, roll}));
     },
-    onCombatDecisionEnd: () => {
-      dispatch(toCard({name: 'QUEST_CARD', phase: CombatPhase.prepare}));
+    onCombatDecisionEnd: (node: ParserNode) => {
+      dispatch(toCombatPhase({node, phase: CombatPhase.prepare}));
     },
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/decision/Types.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/decision/Types.tsx
@@ -65,6 +65,6 @@ export function mapStateToProps(state: AppStateWithHistory, ownProps: Partial<St
     node,
     settings: state.settings,
     rng: seedrandom.alea((node && node.ctx.seed) || ''),
-    theme: getCardTemplateTheme(state.card),
+    theme: getCardTemplateTheme(state.quest.node),
   };
 }

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.test.tsx
@@ -57,12 +57,12 @@ describe('Roleplay actions', () => {
 
     test('goes to win screen on **win**', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 0, maxTier: 0, seed: ''});
-      expect(actions[2].to.phase).toEqual(CombatPhase.victory);
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual(CombatPhase.victory);
     });
 
     test('goes to lose screen on **lose**', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 1, maxTier: 0, seed: ''});
-      expect(actions[2].to.phase).toEqual(CombatPhase.defeat);
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual(CombatPhase.defeat);
     });
 
     test('ends quest on **end** and zeros audio', () => {
@@ -74,30 +74,34 @@ describe('Roleplay actions', () => {
     test('goes to next round when pnode.getNext() falls outside of combat scope', () => {
       const rp2 = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 3, maxTier: 0, seed: ''})[1].node;
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: rp2, index: 0, maxTier: 0, seed: ''});
-      expect(actions[2].to.phase).toEqual('RESOLVE_ABILITIES');
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual('RESOLVE_ABILITIES');
     });
 
     test('handles gotos that point to outside of combat and zeros audio', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 4, maxTier: 0, seed: ''});
-      expect(actions[2].to.phase).toEqual('ROLEPLAY');
+      const node = actions.filter((a) => a.type === 'QUEST_NODE')[0].node;
+      expect(node.inCombat()).toEqual(false);
+      expect(node.getTag()).toEqual('roleplay');
       expect(actions[1].node.elem.text()).toEqual('Outside Roleplay');
       expect(actions[3].type).toEqual('AUDIO_SET');
     });
 
     test('handles GOTOs that point to other roleplaying inside of the same combat', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 5, maxTier: 0, seed: ''});
-      expect(actions[2].to.phase).toEqual(CombatPhase.midCombatRoleplay);
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual(CombatPhase.midCombatRoleplay);
       expect(actions[1].node.elem.text()).toEqual('rp2');
     });
 
     test('renders as combat for RPs inside of same combat', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 3, maxTier: 0, seed: ''});
-      expect(actions[2].to.phase).toEqual(CombatPhase.midCombatRoleplay);
+      expect(actions.filter((a) => a.type === 'QUEST_NODE')[0].node.ctx.templates.combat.phase).toEqual(CombatPhase.midCombatRoleplay);
     });
 
     test('renders as roleplay upon goto to element inside of win/lose event and zeros audio', () => {
       const actions = Action(midCombatChoice).execute({settings: TEST_SETTINGS, node: newMidCombatNode(), index: 6, maxTier: 0, seed: ''});
-      expect(actions[2].to.phase).toEqual('ROLEPLAY');
+      const node = actions.filter((a) => a.type === 'QUEST_NODE')[0].node;
+      expect(node.inCombat()).toEqual(false);
+      expect(node.getTag()).toEqual('roleplay');
       expect(actions[3].type).toEqual('AUDIO_SET');
     });
   });

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/Actions.tsx
@@ -17,7 +17,7 @@ export function initRoleplay(node: ParserNode) {
     // content.
     dispatch({type: 'PUSH_HISTORY'});
     dispatch({type: 'QUEST_NODE', node} as QuestNodeAction);
-    dispatch(toCard({name: 'QUEST_CARD', phase: 'ROLEPLAY', noHistory: true}));
+    dispatch(toCard({name: 'QUEST_CARD', noHistory: true}));
   };
 }
 
@@ -102,6 +102,7 @@ export const midCombatChoice = remoteify(function midCombatChoice(a: MidCombatCh
   const {nextNode, state} = getNextMidCombatNode(a.node, a.index);
   switch (state) {
     case 'ENDCOMBAT':
+      nextNode.ctx.templates.combat.phase = CombatPhase.drawEnemies;
       dispatch(loadNode(nextNode));
       dispatch(audioSet({intensity: 0}));
       break;
@@ -121,13 +122,15 @@ export const midCombatChoice = remoteify(function midCombatChoice(a: MidCombatCh
       break;
     case 'ENDROUND':
       dispatch({type: 'PUSH_HISTORY'});
+      nextNode.ctx.templates.combat.phase = CombatPhase.resolveAbilities;
       dispatch({type: 'QUEST_NODE', node: nextNode} as QuestNodeAction);
-      dispatch(toCard({name: 'QUEST_CARD', phase: CombatPhase.resolveAbilities, overrideDebounce: true, noHistory: true}));
+      dispatch(toCard({name: 'QUEST_CARD', overrideDebounce: true, noHistory: true}));
       break;
     default: // in-combat roleplay continues
       dispatch({type: 'PUSH_HISTORY'});
+      nextNode.ctx.templates.combat.phase = CombatPhase.midCombatRoleplay;
       dispatch({type: 'QUEST_NODE', node: nextNode} as QuestNodeAction);
-      dispatch(toCard({name: 'QUEST_CARD', phase: CombatPhase.midCombatRoleplay, overrideDebounce: true, noHistory: true}));
+      dispatch(toCard({name: 'QUEST_CARD', overrideDebounce: true, noHistory: true}));
       break;
   }
   return remoteArgs;

--- a/services/app/src/components/views/quest/cardtemplates/roleplay/RoleplayContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/roleplay/RoleplayContainer.tsx
@@ -1,7 +1,7 @@
 import {toPrevious} from 'app/actions/Card';
 import {choice} from 'app/actions/Quest';
 import {CombatPhase} from 'app/Constants';
-import {AppStateWithHistory, SettingsType} from 'app/reducers/StateTypes';
+import {AppStateWithHistory, CardName, SettingsType} from 'app/reducers/StateTypes';
 import {connect} from 'react-redux';
 import Redux from 'redux';
 import {ParserNode} from '../TemplateTypes';
@@ -30,7 +30,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       dispatch(choice({node, index}));
     },
     onRetry: () => {
-      dispatch(toPrevious({name: 'QUEST_CARD', phase: CombatPhase.drawEnemies, before: true}));
+      dispatch(toPrevious({matchFn: (c: CardName, n: ParserNode) => n.ctx.templates.combat.phase === CombatPhase.drawEnemies, before: true}));
     },
   };
 };

--- a/services/app/src/reducers/Card.tsx
+++ b/services/app/src/reducers/Card.tsx
@@ -8,7 +8,6 @@ import {CardName, CardState} from './StateTypes';
 export const initialCardState: CardState = {
   key: '',
   name: 'SPLASH_CARD' as CardName,
-  phase: null,
   questId: '',
   ts: 0,
 };

--- a/services/app/src/reducers/CombinedReducers.test.tsx
+++ b/services/app/src/reducers/CombinedReducers.test.tsx
@@ -3,5 +3,5 @@ import combinedReducers from './CombinedReducers';
 import {AppStateWithHistory} from './StateTypes';
 
 describe('CombinedReducers', () => {
-  // TODO
+  test.skip('TODO', () => { /* TODO */ });
 });

--- a/services/app/src/reducers/CombinedReducers.test.tsx
+++ b/services/app/src/reducers/CombinedReducers.test.tsx
@@ -3,39 +3,5 @@ import combinedReducers from './CombinedReducers';
 import {AppStateWithHistory} from './StateTypes';
 
 describe('CombinedReducers', () => {
-  describe('PUSH_HISTORY', () => {
-    test.skip('appends returnable state to _history', () => { /* TODO */ });
-  });
-  describe('RETURN', () => {
-    function setup(overrides?: AppStateWithHistory) {
-      return Reducer(combinedReducers).withState({
-        _committed: {},
-        _history: [{
-          commitID: 5,
-          card: {name: 'QUEST_CARD'},
-        }],
-        commitID: 6,
-        card: {name: 'SPLASH_CARD'},
-        ...overrides
-      });
-    }
-
-    test.skip('pops history until node type present in RETURN is seen', () => { /* TODO */ });
-    test.skip('pops history once if RETURN without target node', () => { /* TODO */ });
-    test.skip('skips specified card types', () => { /* TODO */ });
-    test('persists non-returnable state and overrides returnable state', () => {
-      const result = setup().execute({type: 'RETURN'});
-      expect(result).toEqual(jasmine.objectContaining({
-          commitID: 6, // Persists
-          card: {name: 'QUEST_CARD'} // Does not persist
-        }));
-    });
-    test('does nothing when no history', () => {
-      const result = setup({_history: []}).execute({type: 'RETURN'});
-      expect(result).toEqual(jasmine.objectContaining({
-          commitID: 6,
-          card: {name: 'SPLASH_CARD'}
-        }));
-    })
-  });
+  // TODO
 });

--- a/services/app/src/reducers/CombinedReducers.tsx
+++ b/services/app/src/reducers/CombinedReducers.tsx
@@ -1,12 +1,11 @@
 import Redux from 'redux';
-import {ReturnAction} from '../actions/ActionTypes';
-import {getHistoryApi, getNavigator} from '../Globals';
 import {audio} from './Audio';
 import {audioData} from './AudioData';
 import {card} from './Card';
 import {checkout} from './Checkout';
 import {commitID} from './CommitID';
 import {dialog} from './Dialog';
+import {history} from './History';
 import {multiplayer} from './Multiplayer';
 import {quest} from './Quest';
 import {saved} from './Saved';
@@ -14,7 +13,7 @@ import {search} from './Search';
 import {serverstatus} from './ServerStatus';
 import {settings} from './Settings';
 import {snackbar} from './Snackbar';
-import {AppState, AppStateBase, AppStateWithHistory} from './StateTypes';
+import {AppState, AppStateWithHistory} from './StateTypes';
 import {user} from './User';
 import {userquests} from './UserQuests';
 
@@ -39,123 +38,14 @@ function combinedReduce(state: AppStateWithHistory, action: Redux.Action): AppSt
   };
 }
 
-function isReturnState(state: AppStateBase, action: ReturnAction): boolean {
-  const matchesName = state.card.name === action.to.name;
-  const matchesPhase = (action.to.phase && state.card && action.to.phase === state.card.phase);
-  return (matchesName && (!action.to.phase || matchesPhase)) || false;
-}
-
 export default function combinedReducerWithHistory(state: AppStateWithHistory, action: Redux.Action): AppStateWithHistory {
-  let stateHistory: AppStateBase[] = [];
-
-  // Manage CommitID transactions
+  // Run global reducers
   state = commitID(state, action, combinedReduce);
-
-  if (state !== undefined) {
-    if (state._history === undefined) {
-      state._history = [];
-    }
-
-    // TODO: Convert history into a separate reducer.
-    // If action is "Return", pop history accordingly
-    if (action.type === 'RETURN') {
-      // Backing all the way out of the Android app should kill it
-      if (state._history.length === 0) {
-        const navigator = getNavigator();
-        if (navigator.app) {
-            navigator.app.exitApp();
-        } else if (navigator.device) {
-            navigator.device.exitApp();
-        }
-        return state;
-      }
-
-      let pastStateIdx: number = state._history.length - 1;
-      const returnAction = action as ReturnAction;
-      if (returnAction.to && (returnAction.to.name || returnAction.to.phase)) {
-        while (pastStateIdx > 0 && !isReturnState(state._history[pastStateIdx], returnAction)) {
-          pastStateIdx--;
-        }
-      } else if (returnAction.skip) {
-        // Skip past any explicitly blacklisted card types
-        while (pastStateIdx > 0) {
-          let skipCard: boolean = false;
-          for (const s of returnAction.skip) {
-            if (s.name === state._history[pastStateIdx].card.name && (!s.phase || s.phase === state._history[pastStateIdx].card.phase)) {
-              skipCard = true;
-              break;
-            }
-          }
-          if (!skipCard) {
-            break;
-          }
-          pastStateIdx--;
-        }
-      }
-
-      if (returnAction.before) {
-        pastStateIdx--;
-      }
-
-      // If we're going back to a point where the quest is no longer defined, clear the URL hash
-      if (pastStateIdx === 0 ||
-         (state._history[pastStateIdx - 1] && state._history[pastStateIdx - 1].quest && state._history[pastStateIdx - 1].quest.details.id === '')) {
-        getHistoryApi().pushState(null, '', '#');
-      }
-
-      return {
-        ...state._history[pastStateIdx],
-        _committed: state._committed,
-        _history: state._history.slice(0, pastStateIdx),
-        _return: true,
-        // things that should persist / not be rewound:
-        audioData: state.audioData,
-        commitID: state.commitID,
-        multiplayer: state.multiplayer,
-        saved: state.saved,
-        search: state.search,
-        serverstatus: state.serverstatus,
-        settings: state.settings,
-        user: state.user,
-        snackbar: state.snackbar,
-        userQuests: state.userQuests,
-      } as AppStateWithHistory;
-    } else if (action.type === 'CLEAR_HISTORY') {
-      return {
-        ...state,
-        _history: [],
-      };
-    }
-
-    // Create a new array (objects may be shared)
-    stateHistory = state._history.slice();
-
-    if (action.type === 'PUSH_HISTORY') {
-      // Save a copy of existing state to _history, excluding non-historical fields.
-      stateHistory.push({
-        ...state,
-        _committed: undefined,
-        _history: undefined,
-        _return: undefined,
-        audioData: undefined,
-        commitID: undefined,
-        multiplayer: undefined,
-        saved: undefined,
-        search: undefined,
-        serverstatus: undefined,
-        settings: undefined,
-        user: undefined,
-        snackbar: undefined,
-        userQuests: undefined,
-      } as AppStateBase);
-    }
-  }
+  state = history(state, action);
 
   // Run the reducers on the new action
   return {
     ...combinedReduce(state, action),
     _committed: (state && state._committed),
-    _history: stateHistory,
-    _return: false,
   } as AppStateWithHistory;
 }

--- a/services/app/src/reducers/CombinedReducers.tsx
+++ b/services/app/src/reducers/CombinedReducers.tsx
@@ -13,12 +13,18 @@ import {search} from './Search';
 import {serverstatus} from './ServerStatus';
 import {settings} from './Settings';
 import {snackbar} from './Snackbar';
-import {AppState, AppStateWithHistory} from './StateTypes';
+import {AppStateWithHistory} from './StateTypes';
 import {user} from './User';
 import {userquests} from './UserQuests';
 
-function combinedReduce(state: AppStateWithHistory, action: Redux.Action): AppState {
+export default function combinedReduce(state: AppStateWithHistory, action: Redux.Action): AppStateWithHistory {
   state = state || ({} as AppStateWithHistory);
+
+  // Run global reducers
+  state = commitID(state, action, combinedReduce);
+  state = history(state, action);
+
+  // Run the reducers on the new action
   return {
     audio: audio(state.audio, action),
     audioData: audioData(state.audioData, action),
@@ -35,17 +41,10 @@ function combinedReduce(state: AppStateWithHistory, action: Redux.Action): AppSt
     snackbar: snackbar(state.snackbar, action),
     user: user(state.user, action),
     userQuests: userquests(state.userQuests, action),
-  };
-}
 
-export default function combinedReducerWithHistory(state: AppStateWithHistory, action: Redux.Action): AppStateWithHistory {
-  // Run global reducers
-  state = commitID(state, action, combinedReduce);
-  state = history(state, action);
-
-  // Run the reducers on the new action
-  return {
-    ...combinedReduce(state, action),
+    // These attributes are handled by the global reducers; persist them.
+    _history: (state && state._history),
+    _return: (state && state._return),
     _committed: (state && state._committed),
   } as AppStateWithHistory;
 }

--- a/services/app/src/reducers/History.test.tsx
+++ b/services/app/src/reducers/History.test.tsx
@@ -1,0 +1,41 @@
+import {Reducer} from '../Testing';
+import history from './CombinedReducers';
+import {AppStateWithHistory} from './StateTypes';
+
+describe('History reducer', () => {
+  describe('PUSH_HISTORY', () => {
+    test.skip('appends returnable state to _history', () => { /* TODO */ });
+  });
+  describe('RETURN', () => {
+    function setup(overrides?: AppStateWithHistory) {
+      return Reducer(history).withState({
+        _committed: {},
+        _history: [{
+          commitID: 5,
+          card: {name: 'QUEST_CARD'},
+        }],
+        commitID: 6,
+        card: {name: 'SPLASH_CARD'},
+        ...overrides
+      });
+    }
+
+    test.skip('pops history until node type present in RETURN is seen', () => { /* TODO */ });
+    test.skip('pops history once if RETURN without target node', () => { /* TODO */ });
+    test.skip('skips specified card types', () => { /* TODO */ });
+    test('persists non-returnable state and overrides returnable state', () => {
+      const result = setup().execute({type: 'RETURN'});
+      expect(result).toEqual(jasmine.objectContaining({
+          commitID: 6, // Persists
+          card: {name: 'QUEST_CARD'} // Does not persist
+        }));
+    });
+    test('does nothing when no history', () => {
+      const result = setup({_history: []}).execute({type: 'RETURN'});
+      expect(result).toEqual(jasmine.objectContaining({
+          commitID: 6,
+          card: {name: 'SPLASH_CARD'}
+        }));
+    })
+  });
+});

--- a/services/app/src/reducers/History.tsx
+++ b/services/app/src/reducers/History.tsx
@@ -4,15 +4,10 @@ import {getHistoryApi, getNavigator} from '../Globals';
 import {AppStateBase, AppStateWithHistory} from './StateTypes';
 
 export function history(state: AppStateWithHistory, action: Redux.Action): AppStateWithHistory {
-  if (state === undefined) {
-    return state;
-  }
-
   if (state._history === undefined) {
     state._history = [];
   }
 
-  // TODO: Convert history into a separate reducer.
   // If action is "Return", pop history accordingly
   if (action.type === 'RETURN') {
     // Backing all the way out of the Android app should kill it

--- a/services/app/src/reducers/History.tsx
+++ b/services/app/src/reducers/History.tsx
@@ -1,0 +1,93 @@
+import Redux from 'redux';
+import {ReturnAction} from '../actions/ActionTypes';
+import {getHistoryApi, getNavigator} from '../Globals';
+import {AppStateBase, AppStateWithHistory} from './StateTypes';
+
+export function history(state: AppStateWithHistory, action: Redux.Action): AppStateWithHistory {
+  if (state === undefined) {
+    return state;
+  }
+
+  if (state._history === undefined) {
+    state._history = [];
+  }
+
+  // TODO: Convert history into a separate reducer.
+  // If action is "Return", pop history accordingly
+  if (action.type === 'RETURN') {
+    // Backing all the way out of the Android app should kill it
+    if (state._history.length === 0) {
+      const navigator = getNavigator();
+      if (navigator.app) {
+          navigator.app.exitApp();
+      } else if (navigator.device) {
+          navigator.device.exitApp();
+      }
+      return state;
+    }
+
+    let pastStateIdx: number = state._history.length - 1;
+    const returnAction = action as ReturnAction;
+    if (returnAction.matchFn) {
+      while (pastStateIdx > 0 && !returnAction.matchFn(state._history[pastStateIdx].card.name, state._history[pastStateIdx].quest.node)) {
+        pastStateIdx--;
+      }
+    }
+
+    if (returnAction.before) {
+      pastStateIdx--;
+    }
+
+    // If we're going back to a point where the quest is no longer defined, clear the URL hash
+    if (pastStateIdx === 0 ||
+       (state._history[pastStateIdx - 1] && state._history[pastStateIdx - 1].quest && state._history[pastStateIdx - 1].quest.details.id === '')) {
+      getHistoryApi().pushState(null, '', '#');
+    }
+
+    return {
+      ...state._history[pastStateIdx],
+      _committed: state._committed,
+      _history: state._history.slice(0, pastStateIdx),
+      _return: true,
+      // things that should persist / not be rewound:
+      audioData: state.audioData,
+      commitID: state.commitID,
+      multiplayer: state.multiplayer,
+      saved: state.saved,
+      search: state.search,
+      serverstatus: state.serverstatus,
+      settings: state.settings,
+      user: state.user,
+      snackbar: state.snackbar,
+      userQuests: state.userQuests,
+    } as AppStateWithHistory;
+  }
+
+  if (action.type === 'CLEAR_HISTORY') {
+    return {...state, _return: false, _history: []};
+  }
+
+  // Create a new array (objects may be shared)
+  const stateHistory: AppStateBase[] = state._history.slice();
+
+  if (action.type === 'PUSH_HISTORY') {
+    // Save a copy of existing state to _history, excluding non-historical fields.
+    stateHistory.push({
+      ...state,
+      _committed: undefined,
+      _history: undefined,
+      _return: undefined,
+      audioData: undefined,
+      commitID: undefined,
+      multiplayer: undefined,
+      saved: undefined,
+      search: undefined,
+      serverstatus: undefined,
+      settings: undefined,
+      user: undefined,
+      snackbar: undefined,
+      userQuests: undefined,
+    } as AppStateBase);
+  }
+  return {...state, _return: false, _history: stateHistory};
+}

--- a/services/app/src/reducers/StateTypes.tsx
+++ b/services/app/src/reducers/StateTypes.tsx
@@ -5,7 +5,6 @@ import {Badge, ContentRating, Expansion, Genre, Language, Partition} from 'share
 import {Quest} from 'shared/schema/Quests';
 import {AudioNode} from '../audio/AudioNode';
 import {ThemeManager} from '../audio/ThemeManager';
-import {TemplatePhase} from '../components/views/quest/cardtemplates/TemplateTypes';
 import {ParserNode} from '../components/views/quest/cardtemplates/TemplateTypes';
 
 export interface AnnouncementState {
@@ -139,14 +138,12 @@ export type CardName =
   'REMOTE_PLAY_CONNECT' |
   'REMOTE_PLAY_LOBBY' |
   'ACCOUNT';
-export type CardPhase = TemplatePhase;
 
 export interface CardState {
   questId: string;
   name: CardName;
   ts: number;
   key: string;
-  phase: CardPhase|null;
   overrideDebounce?: boolean;
 }
 


### PR DESCRIPTION
- Breaks out the actions that operate on `_history` from `CombinedReducers.tsx` to `History.tsx`, for clarity.
- Removes `state.card.phase` attribute, and instead moves all logic handling combat/decision phase to look at `ParserNode.ctx.templates.(combat|decision).phase`. 
- Refactors `toPrevious` action to instead pass a `matchFn` as a way of identifying a matching card in the history.
- Adds an `inCombat` method to `ParserNode` to more easily assess whether the current card should be considered a combat state.

This is the last of a series of refactors in preparation for regenerating the current state of a quest solely from the `ParserNode` and the quest's XML, which is an attempt to fix the major source of errors as in #742.