### PR TITLE
Refactor quest saving/loading

### DIFF
--- a/services/app/src/actions/SavedQuests.tsx
+++ b/services/app/src/actions/SavedQuests.tsx
@@ -244,6 +244,7 @@ export function recreateNodeFromContext(xml: string, line: number, ctx: Template
   for (const k of Object.keys(ctx.scope._)) {
     ctx.scope._[k] = (ctx.scope._[k] as any).bind(ctx);
   }
+  console.log(ctx.scope._);
   return new ParserNode(elem, ctx, undefined, ctx.seed);
 }
 

--- a/services/app/src/actions/SavedQuests.tsx
+++ b/services/app/src/actions/SavedQuests.tsx
@@ -239,12 +239,9 @@ export function recreateNodeFromContext(xml: string, line: number, ctx: Template
     throw new Error(`Could not load line ${line} from XML`);
   }
 
-  // Functions do not get serialized; we must recreate them and then bind them to the context.
+  // Functions do not get serialized; we must recreate them.
   ctx.scope._ = regenScope();
-  for (const k of Object.keys(ctx.scope._)) {
-    ctx.scope._[k] = (ctx.scope._[k] as any).bind(ctx);
-  }
-  console.log(ctx.scope._);
+
   return new ParserNode(elem, ctx, undefined, ctx.seed);
 }
 

--- a/services/app/src/components/views/QuestPreviewContainer.tsx
+++ b/services/app/src/components/views/QuestPreviewContainer.tsx
@@ -2,7 +2,7 @@ import {connect} from 'react-redux';
 import Redux from 'redux';
 import {Quest} from 'shared/schema/Quests';
 import {SavedQuestSelectAction} from '../../actions/ActionTypes';
-import {toCard, toPrevious} from '../../actions/Card';
+import {toPrevious} from '../../actions/Card';
 import {setDialog} from '../../actions/Dialog';
 import {deleteSavedQuest, loadSavedQuest, saveQuestForOffline} from '../../actions/SavedQuests';
 import {openSnackbar} from '../../actions/Snackbar';
@@ -36,7 +36,6 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
     },
     onPlaySaved(id: string, ts: number): void {
       dispatch(loadSavedQuest(id, ts));
-      dispatch(toCard({name: 'QUEST_CARD'}));
     },
     onSave(quest: Quest) {
       dispatch(saveQuestForOffline(quest));

--- a/services/app/src/components/views/quest/cardtemplates/Template.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.test.tsx
@@ -1,6 +1,7 @@
 import {defaultContext} from './Template';
 import {initialSettings} from 'app/reducers/Settings';
 import {initialMultiplayer} from 'app/reducers/Multiplayer';
+import {evaluateOp} from 'shared/parse/Context';
 
 describe('CardTemplates template', () => {
   describe('updateContext', () => {
@@ -25,11 +26,11 @@ describe('CardTemplates template', () => {
     test('viewCount gets the view count for a node id', () => {
       const ctx = defaultContext(() => return {});
       ctx.views['a'] = 5;
-      expect(ctx.scope._.viewCount('a')).toEqual(5);
+      expect(evaluateOp('_.viewCount("a")', ctx)).toEqual(5);
     });
     test ('viewCount handles unviewed nodes', () => {
       const ctx = defaultContext(() => return {});
-      expect(ctx.scope._.viewCount('a')).toEqual(0);
+      expect(evaluateOp('_.viewCount("a")', ctx)).toEqual(0);
     });
   });
 });

--- a/services/app/src/components/views/quest/cardtemplates/Template.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.tsx
@@ -155,10 +155,6 @@ export function defaultContext(getState: (() => AppStateWithHistory) = getStore(
     views: {},
   };
 
-  for (const k of Object.keys(newContext.scope._)) {
-    newContext.scope._[k] = (newContext.scope._[k] as any).bind(newContext);
-  }
-
   // Update random seed
   newContext.seed = generateSeed();
 

--- a/services/app/src/components/views/quest/cardtemplates/Template.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/Template.tsx
@@ -119,39 +119,34 @@ export function getCardTemplateTheme(node: ParserNode): CardThemeType {
   return 'light';
 }
 
-export function templateScope() {
-  return combatScope();
+export function populateScope(getState: (() => AppStateWithHistory) = getStore().getState) {
+  return {
+    contentSets(): {[content: string]: boolean} {
+      const {settings, multiplayer} = getState();
+      const result: any = {};
+      for (const cs of [...getContentSets(settings, multiplayer)]) {
+        result[cs] = true;
+      }
+      return result;
+    },
+    numAdventurers(): number {
+      return numAdventurers(getState().settings, getState().multiplayer);
+    },
+    viewCount(id: string): number {
+      return this.views[id] || 0;
+    },
+    ...combatScope(),
+  };
 }
 
 export function defaultContext(getState: (() => AppStateWithHistory) = getStore().getState): TemplateContext {
-  const populateScopeFn = () => {
-    return {
-      contentSets(): {[content: string]: boolean} {
-        const {settings, multiplayer} = getState();
-        const result: any = {};
-        for (const cs of [...getContentSets(settings, multiplayer)]) {
-          result[cs] = true;
-        }
-        return result;
-      },
-      numAdventurers(): number {
-        return numAdventurers(getState().settings, getState().multiplayer);
-      },
-      viewCount(id: string): number {
-        return this.views[id] || 0;
-      },
-      ...templateScope(),
-    };
-  };
-
   // Caution: Scope is the API for Quest Creators.
   // New endpoints should be added carefully b/c we'll have to support them.
   // Behind-the-scenes data can be added to the context outside of scope
   const newContext: TemplateContext = {
-    _templateScopeFn: populateScopeFn, // Used to refill template scope elsewhere (without dependencies)
     path: ([] as any),
     scope: {
-      _: populateScopeFn(),
+      _: populateScope(getState),
     },
     templates: {
       combat: EMPTY_COMBAT_STATE,

--- a/services/app/src/components/views/quest/cardtemplates/TemplateTypes.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/TemplateTypes.tsx
@@ -14,9 +14,6 @@ export type TemplatePhase = CombatPhase | RoleplayPhase | DecisionPhase;
 
 export interface TemplateContext extends Context {
   templates: TemplateState;
-
-  // Regenerate template scope (all of "_") with this function.
-  _templateScopeFn: () => any;
 }
 
 export class ParserNode extends Node<TemplateContext> {

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
@@ -184,9 +184,9 @@ describe('Combat actions', () => {
       expect(actions[2].node.ctx.templates.combat.mostRecentAttack.damage).toBeDefined();
       checkNodeIntegrity(startNode, actions[2].node);
     });
-    test('random damage changes significantly between rounds', () => {
+    test.only('random damage changes significantly between rounds', () => {
       const startNode = newCombatNode(TEST_NODE_EASIER); // Caution: this resets the multiplayer connection
-      startNode.ctx.seed = "abc";
+      startNode.ctx.templates.combat.seed = "abc";
       const conn = fakeConnection();
       const store = newMockStore({multiplayer: m.s2p5}, conn);
 

--- a/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Actions.test.tsx
@@ -184,7 +184,7 @@ describe('Combat actions', () => {
       expect(actions[2].node.ctx.templates.combat.mostRecentAttack.damage).toBeDefined();
       checkNodeIntegrity(startNode, actions[2].node);
     });
-    test.only('random damage changes significantly between rounds', () => {
+    test('random damage changes significantly between rounds', () => {
       const startNode = newCombatNode(TEST_NODE_EASIER); // Caution: this resets the multiplayer connection
       startNode.ctx.templates.combat.seed = "abc";
       const conn = fakeConnection();

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.tsx
@@ -15,7 +15,9 @@ export interface StateProps extends StatePropsBase {
   combat: CombatState;
   maxTier: number;
   numAliveAdventurers: number;
+  localAliveAdventurers: number;
   seed: string;
+  tier: number;
   contentSets: Set<keyof ContentSetsType>;
 }
 
@@ -39,7 +41,7 @@ export default function playerTier(props: Props): JSX.Element {
   let helpText: JSX.Element = (<span></span>);
   const damage = (props.combat.mostRecentAttack) ? props.combat.mostRecentAttack.damage : -1;
   const theHorror = (props.contentSets.has(Expansion.horror) === true);
-  const injured = props.node.ctx.templates.combat.numAliveAdventurers < props.adventurers;
+  const injured = props.localAliveAdventurers < props.adventurers;
 
   if (props.settings.showHelp) {
     helpText = (
@@ -60,32 +62,32 @@ export default function playerTier(props: Props): JSX.Element {
       <Picker
         label="Tier Sum"
         id="tier_sum"
-        onDelta={(i: number) => props.onTierSumDelta(props.node, props.node.ctx.templates.combat.tier, i)}
-        value={props.node.ctx.templates.combat.tier}>
+        onDelta={(i: number) => props.onTierSumDelta(props.node, props.tier, i)}
+        value={props.tier}>
         {props.settings.showHelp && 'The total tier of remaining enemies.'}
       </Picker>
       <Picker
         label="Adventurers"
         id="adventurers"
-        onDelta={(i: number) => props.onAdventurerDelta(props.node, props.settings, props.node.ctx.templates.combat.numAliveAdventurers, i)}
-        value={props.node.ctx.templates.combat.numAliveAdventurers}>
-        {props.settings.showHelp && (props.numAliveAdventurers === props.node.ctx.templates.combat.numAliveAdventurers)
+        onDelta={(i: number) => props.onAdventurerDelta(props.node, props.settings, props.localAliveAdventurers, i)}
+        value={props.localAliveAdventurers}>
+        {props.settings.showHelp && (props.numAliveAdventurers === props.localAliveAdventurers)
           ? <span>The number of adventurers &gt; 0 health.</span>
           : <span>Local adventurers &gt; 0 health.<br/>({props.numAliveAdventurers} across all devices)</span>
         }
       </Picker>
       {helpText}
       <Button
-        className={(props.numAliveAdventurers === 0 || props.node.ctx.templates.combat.tier === 0) ? 'subtle' : ''}
-        disabled={props.numAliveAdventurers <= 0 || props.node.ctx.templates.combat.tier <= 0}
+        className={(props.numAliveAdventurers === 0 || props.tier === 0) ? 'subtle' : ''}
+        disabled={props.numAliveAdventurers <= 0 || props.tier <= 0}
         onClick={() => (shouldRunDecision) ? props.onDecisionSetup(props.node, props.seed) : props.onNext(props.node, CombatPhase.prepare)}>Next</Button>
       <Button
-        className={(props.node.ctx.templates.combat.tier !== 0) ? 'subtle' : ''}
-        disabled={props.numAliveAdventurers <= 0 && props.node.ctx.templates.combat.tier > 0}
+        className={(props.tier !== 0) ? 'subtle' : ''}
+        disabled={props.numAliveAdventurers <= 0 && props.tier > 0}
         onClick={() => props.onVictory(props.node, props.settings, props.maxTier, props.seed)}>Victory (Tier = 0)</Button>
       <Button
         className={(props.numAliveAdventurers !== 0) ? 'subtle' : ''}
-        disabled={props.node.ctx.templates.combat.tier <= 0}
+        disabled={props.tier <= 0}
         onClick={() => props.onDefeat(props.node, props.settings, props.maxTier, props.seed)}>Defeat (Adventurers = 0)</Button>
     </Card>
   );

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTier.tsx
@@ -15,9 +15,7 @@ export interface StateProps extends StatePropsBase {
   combat: CombatState;
   maxTier: number;
   numAliveAdventurers: number;
-  localAliveAdventurers: number;
   seed: string;
-  tier: number;
   contentSets: Set<keyof ContentSetsType>;
 }
 
@@ -41,7 +39,7 @@ export default function playerTier(props: Props): JSX.Element {
   let helpText: JSX.Element = (<span></span>);
   const damage = (props.combat.mostRecentAttack) ? props.combat.mostRecentAttack.damage : -1;
   const theHorror = (props.contentSets.has(Expansion.horror) === true);
-  const injured = props.localAliveAdventurers < props.adventurers;
+  const injured = props.node.ctx.templates.combat.numAliveAdventurers < props.adventurers;
 
   if (props.settings.showHelp) {
     helpText = (
@@ -62,32 +60,32 @@ export default function playerTier(props: Props): JSX.Element {
       <Picker
         label="Tier Sum"
         id="tier_sum"
-        onDelta={(i: number) => props.onTierSumDelta(props.node, props.tier, i)}
-        value={props.tier}>
+        onDelta={(i: number) => props.onTierSumDelta(props.node, props.node.ctx.templates.combat.tier, i)}
+        value={props.node.ctx.templates.combat.tier}>
         {props.settings.showHelp && 'The total tier of remaining enemies.'}
       </Picker>
       <Picker
         label="Adventurers"
         id="adventurers"
-        onDelta={(i: number) => props.onAdventurerDelta(props.node, props.settings, props.localAliveAdventurers, i)}
-        value={props.localAliveAdventurers}>
-        {props.settings.showHelp && (props.numAliveAdventurers === props.localAliveAdventurers)
+        onDelta={(i: number) => props.onAdventurerDelta(props.node, props.settings, props.node.ctx.templates.combat.numAliveAdventurers, i)}
+        value={props.node.ctx.templates.combat.numAliveAdventurers}>
+        {props.settings.showHelp && (props.numAliveAdventurers === props.node.ctx.templates.combat.numAliveAdventurers)
           ? <span>The number of adventurers &gt; 0 health.</span>
           : <span>Local adventurers &gt; 0 health.<br/>({props.numAliveAdventurers} across all devices)</span>
         }
       </Picker>
       {helpText}
       <Button
-        className={(props.numAliveAdventurers === 0 || props.tier === 0) ? 'subtle' : ''}
-        disabled={props.numAliveAdventurers <= 0 || props.tier <= 0}
+        className={(props.numAliveAdventurers === 0 || props.node.ctx.templates.combat.tier === 0) ? 'subtle' : ''}
+        disabled={props.numAliveAdventurers <= 0 || props.node.ctx.templates.combat.tier <= 0}
         onClick={() => (shouldRunDecision) ? props.onDecisionSetup(props.node, props.seed) : props.onNext(props.node, CombatPhase.prepare)}>Next</Button>
       <Button
-        className={(props.tier !== 0) ? 'subtle' : ''}
-        disabled={props.numAliveAdventurers <= 0 && props.tier > 0}
+        className={(props.node.ctx.templates.combat.tier !== 0) ? 'subtle' : ''}
+        disabled={props.numAliveAdventurers <= 0 && props.node.ctx.templates.combat.tier > 0}
         onClick={() => props.onVictory(props.node, props.settings, props.maxTier, props.seed)}>Victory (Tier = 0)</Button>
       <Button
         className={(props.numAliveAdventurers !== 0) ? 'subtle' : ''}
-        disabled={props.tier <= 0}
+        disabled={props.node.ctx.templates.combat.tier <= 0}
         onClick={() => props.onDefeat(props.node, props.settings, props.maxTier, props.seed)}>Defeat (Adventurers = 0)</Button>
     </Card>
   );

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
@@ -37,7 +37,9 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
     throw Error('Incomplete props given');
   }
 
-  // Include the "live" state node for tier and adventurer count
+  const stateCombat = state.quest.node.ctx.templates.combat;
+
+  // Override with dynamic state for tier and adventurer count
   // Any combat param change (e.g. change in tier) causes a repaint
   return {
     ...mapStateToPropsBase(state, ownProps),
@@ -46,6 +48,8 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
     combat: node.ctx.templates.combat,
     maxTier,
     numAliveAdventurers: numAliveAdventurers(state.settings, node, state.multiplayer),
+    localAliveAdventurers: stateCombat.numAliveAdventurers,
+    tier: stateCombat.tier,
     contentSets: getContentSets(state.settings, state.multiplayer),
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
@@ -37,18 +37,15 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
     throw Error('Incomplete props given');
   }
 
-  const stateCombat = state.quest.node.ctx.templates.combat;
-
-  // Override with dynamic state for tier and adventurer count
+  // Include the "live" state node for tier and adventurer count
   // Any combat param change (e.g. change in tier) causes a repaint
   return {
     ...mapStateToPropsBase(state, ownProps),
+    node: state.quest.node,
     adventurers: numAdventurers(state.settings, state.multiplayer),
     combat: node.ctx.templates.combat,
     maxTier,
     numAliveAdventurers: numAliveAdventurers(state.settings, node, state.multiplayer),
-    localAliveAdventurers: stateCombat.numAliveAdventurers,
-    tier: stateCombat.tier,
     contentSets: getContentSets(state.settings, state.multiplayer),
   };
 };

--- a/services/app/src/components/views/quest/cardtemplates/combat/Scope.test.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/Scope.test.tsx
@@ -2,6 +2,7 @@ import {ENCOUNTERS} from 'app/Encounters';
 import {newMockStore} from 'app/Testing';
 import {initialSettings} from 'app/reducers/Settings';
 import {resolveCombat} from '../Params';
+import {evaluateOp} from 'shared/parse/Context';
 
 // We use defaultContext here instead of combatScope as the combat scope
 // depends on templates and content sets within the broader context.
@@ -12,9 +13,9 @@ describe('Combat State', () => {
     describe('randomEnemy', () => {
       test('returns a random enemy name', () => {
         const store = newMockStore({});
-        const scope = defaultContext(store.getState).scope;
-        expect(scope._.randomEnemy()).toEqual(jasmine.any(String));
-        expect(ENCOUNTERS[scope._.randomEnemy().toLowerCase()]).toBeDefined();
+        const ctx = defaultContext(store.getState);
+        expect(evaluateOp('_.randomEnemy()', ctx) ).toEqual(jasmine.any(String));
+        expect(ENCOUNTERS[evaluateOp('_.randomEnemy()', ctx).toLowerCase()]).toBeDefined();
       });
 
       test('only includes enemies in the currently enabled content sets', () => {
@@ -24,7 +25,7 @@ describe('Combat State', () => {
         for (let i = 0; i < 100; i++) {
           const ctx = defaultContext(store.getState);
           ctx.seed = i; // deterministic
-          const pick = ctx.scope._.randomEnemy();
+          const pick = evaluateOp('_.randomEnemy()', ctx) ;
           expect(ENCOUNTERS[Object.keys(ENCOUNTERS).filter((key) => ENCOUNTERS[key].name === pick)[0]].set).toMatch(/horror|base/);
         }
       });
@@ -33,16 +34,16 @@ describe('Combat State', () => {
         const store = newMockStore({});
         const ctx = defaultContext(store.getState);
         ctx.seed = 0;
-        expect(ctx.scope._.randomEnemy()).not.toEqual(ctx.scope._.randomEnemy());
+        expect(evaluateOp('_.randomEnemy()', ctx) ).not.toEqual(evaluateOp('_.randomEnemy()', ctx) );
       });
     });
 
     describe('randomEnemyOfTier', () => {
       const store = newMockStore({});
-      const scope = defaultContext(store.getState).scope;
+      const ctx = defaultContext(store.getState);
       test('returns a random enemy name', () => {
-        expect(scope._.randomEnemyOfTier(1)).toEqual(jasmine.any(String));
-        expect(ENCOUNTERS[scope._.randomEnemyOfTier(1).toLowerCase()]).toBeDefined();
+        expect(evaluateOp('_.randomEnemyOfTier(1)', ctx) ).toEqual(jasmine.any(String));
+        expect(ENCOUNTERS[evaluateOp('_.randomEnemyOfTier(1)', ctx) .toLowerCase()]).toBeDefined();
       });
       test('only includes enemies in the currently enabled content sets', () => {
         // Impossible to test absolutely; but we can test with high confidence.
@@ -51,7 +52,7 @@ describe('Combat State', () => {
         for (let i = 0; i < 100; i++) {
           const ctx = defaultContext(store.getState);
           ctx.seed = i; // deterministic
-          const pick = ctx.scope._.randomEnemyOfTier(1);
+          const pick = evaluateOp('_.randomEnemyOfTier(1)', ctx) ;
           expect(ENCOUNTERS[Object.keys(ENCOUNTERS).filter((key) => ENCOUNTERS[key].name === pick)[0]].set).toMatch(/horror|base/);
         }
       });
@@ -59,39 +60,39 @@ describe('Combat State', () => {
 
     describe('randomEnemyOfClass', () => {
       const store = newMockStore({});
-      const scope = defaultContext(store.getState).scope;
+      const ctx = defaultContext(store.getState);
       test('returns a random enemy name', () => {
-        expect(scope._.randomEnemyOfClass('bandit')).toEqual(jasmine.any(String));
-        expect(ENCOUNTERS[scope._.randomEnemyOfClass('bandit').toLowerCase()]).toBeDefined();
+        expect(evaluateOp('_.randomEnemyOfClass("bandit")', ctx) ).toEqual(jasmine.any(String));
+        expect(ENCOUNTERS[evaluateOp('_.randomEnemyOfClass("bandit")', ctx).toLowerCase()]).toBeDefined();
       });
       test('is capitalization agnostic', () => {
-        expect(scope._.randomEnemyOfClass('BANdit')).toEqual(jasmine.any(String));
-        expect(ENCOUNTERS[scope._.randomEnemyOfClass('Bandit').toLowerCase()]).toBeDefined();
+        expect(evaluateOp('_.randomEnemyOfClass("BANdit")', ctx) ).toEqual(jasmine.any(String));
+        expect(ENCOUNTERS[evaluateOp('_.randomEnemyOfClass("Bandit")', ctx).toLowerCase()]).toBeDefined();
       });
       test('does not include enemies in the horror set if horror set disabled', () => {
         const store = newMockStore({});
-        const scope = defaultContext(store.getState).scope;
-        expect(scope._.randomEnemyOfClass('horror')).not.toBeDefined();
+        const ctx = defaultContext(store.getState);
+        expect(evaluateOp('_.randomEnemyOfClass("horror")', ctx)).toEqual(null);
       });
       test('includes enemies in the horror set if horror set enabled', () => {
         const store = newMockStore({settings: {...initialSettings, contentSets: {horror: true}}});
-        const scope = defaultContext(store.getState).scope;
-        expect(scope._.randomEnemyOfClass('horror')).toBeDefined();
+        const ctx = defaultContext(store.getState);
+        expect(evaluateOp('_.randomEnemyOfClass("horror")', ctx)).not.toEqual(null);
       });
     });
 
     describe('randomEnemyOfClassTier', () => {
       test('returns a random enemy name', () => {
         const store = newMockStore({});
-        const scope = defaultContext(store.getState).scope;
-        expect(scope._.randomEnemyOfClassTier('undead', 1)).toEqual(jasmine.any(String));
-        expect(ENCOUNTERS[scope._.randomEnemyOfClassTier('undead', 1).toLowerCase()]).toBeDefined();
+        const ctx = defaultContext(store.getState);
+        expect(evaluateOp('_.randomEnemyOfClassTier("undead", 1)', ctx) ).toEqual(jasmine.any(String));
+        expect(ENCOUNTERS[evaluateOp('_.randomEnemyOfClassTier("undead", 1)', ctx) .toLowerCase()]).toBeDefined();
       });
       test('only includes enemies in the currently enabled content sets', () => {
         const store = newMockStore({settings: {...initialSettings, contentSets: {horror: true}}});
-        const scope = defaultContext(store.getState).scope;
-        expect(scope._.randomEnemyOfClassTier('undead', 1)).toEqual(jasmine.any(String));
-        expect(scope._.randomEnemyOfClassTier('synth', 1)).not.toBeDefined();
+        const ctx = defaultContext(store.getState);
+        expect(evaluateOp('_.randomEnemyOfClassTier("undead", 1)', ctx)).toEqual(jasmine.any(String));
+        expect(evaluateOp('_.randomEnemyOfClassTier("synth", 1)', ctx)).toEqual(null);
       });
     });
 
@@ -100,49 +101,49 @@ describe('Combat State', () => {
         const store = newMockStore();
         const ctx = defaultContext(store.getState);
         ctx.templates.combat = {numAliveAdventurers: 3};
-        expect(ctx.scope._.aliveAdventurers()).toEqual(3);
+        expect(evaluateOp("_.aliveAdventurers()", ctx)).toEqual(3);
       });
     });
 
     describe('currentCombatRound', () => {
       test('returns 0 on the first round / by default', () => {
         const store = newMockStore({});
-        const scope = defaultContext(store.getState).scope;
-        expect(scope._.currentCombatRound()).toEqual(0);
+        const ctx = defaultContext(store.getState);
+        expect(evaluateOp('_.currentCombatRound()', defaultContext())).toEqual(0);
       });
       test('return 1 on the second round', () => {
         const store = newMockStore();
         const ctx = defaultContext(store.getState);
         ctx.templates.combat = {roundCount: 1};
-        expect(ctx.scope._.currentCombatRound()).toEqual(1);
+        expect(evaluateOp('_.currentCombatRound()', ctx)).toEqual(1);
       });
     });
 
     describe('currentCombatTier', () => {
       test('returns 0 by default', () => {
         const store = newMockStore({});
-        const scope = defaultContext(store.getState).scope;
-        expect(scope._.currentCombatTier()).toEqual(0);
+        const ctx = defaultContext(store.getState);
+        expect(evaluateOp('_.currentCombatTier()', ctx)).toEqual(0);
       });
       test('returns the current combat tier', () => {
         const store = newMockStore();
         const ctx = defaultContext(store.getState);
         ctx.templates.combat = {tier: 7};
-        expect(ctx.scope._.currentCombatTier()).toEqual(7);
+        expect(evaluateOp('_.currentCombatTier()', ctx)).toEqual(7);
       });
     });
 
     describe('isCombatSurgeRound', () => {
       test('returns false if it is not a surge round / by default', () => {
         const store = newMockStore({});
-        const scope = defaultContext(store.getState).scope;
-        expect(scope._.isCombatSurgeRound()).toEqual(false);
+        const ctx = defaultContext(store.getState);
+        expect(evaluateOp('_.isCombatSurgeRound()', ctx)).toEqual(false);
       });
       test('returns true if it is a surge round', () => {
         const store = newMockStore();
         const ctx = defaultContext(store.getState);
         ctx.templates.combat = {roundCount: 4, surgePeriod: 4};
-        expect(ctx.scope._.isCombatSurgeRound()).toEqual(true);
+        expect(evaluateOp('_.isCombatSurgeRound()', ctx)).toEqual(true);
       });
     });
   });

--- a/services/app/src/reducers/Quest.tsx
+++ b/services/app/src/reducers/Quest.tsx
@@ -18,7 +18,6 @@ export const initialQuestState: QuestState = {
     title: '',
   }),
   node: new ParserNode(cheerio.load('<quest></quest>')('quest'), {
-    _templateScopeFn: () => ({}),
     path: ([] as any),
     scope: {_: {}},
     templates: {

--- a/shared/parse/Context.tsx
+++ b/shared/parse/Context.tsx
@@ -48,16 +48,17 @@ export function defaultContext(populateScope: (() => any) = (() => ({}))): Conte
   const newContext: Context = {
     path: ([] as any),
     scope: {
+      // Lodash functions are UNBOUND - binding to the context is done dynamically
+      // within evaluateOp so that we don't have to keep track of unbound copies
+      // of the functions elsewhere.
+      //
+      // Do not rely on calling these methods directly, as they will not return
+      // the correct values.
       _: populateScope(),
     },
     seed: generateSeed(),
     views: {},
   };
-
-  for (const k of Object.keys(newContext.scope._)) {
-    newContext.scope._[k] = (newContext.scope._[k] as any).bind(newContext);
-  }
-
   return newContext;
 }
 
@@ -77,7 +78,7 @@ export function evaluateContentOps(content: string, ctx: Context): string {
   for (const m of matches) {
     const op = parseOpString(m);
     if (op) {
-      const evalResult = evaluateOp(op, ctx.scope, rng);
+      const evalResult = evaluateOp(op, ctx, rng);
       if (evalResult || evalResult === 0) {
         result += evalResult;
       }
@@ -92,7 +93,7 @@ export function evaluateContentOps(content: string, ctx: Context): string {
 // Attempts to evaluate op using ctx.
 // If the evaluation is successful, the context is modified as determined by the op.
 // If the last operation does not assign a value, the result is returned.
-export function evaluateOp(op: string, scope: any, rng: () => number = Math.random): any {
+export function evaluateOp(op: string, ctx: Context, rng: () => number = Math.random): any {
   let parsed;
   let evalResult;
 
@@ -113,9 +114,17 @@ export function evaluateOp(op: string, scope: any, rng: () => number = Math.rand
     pickRandom(a: {_data: any[]}) { return a._data[Math.floor(random(a._data.length))]; },
   }, {override: true});
 
+  // Bind all scope functions, keeping a copy of the originals.
+  // Note that .bind() returns a new (bound) function
+  // that cannot be re-bound.
+  const origLodash: any = ctx.scope._;
+  for (const k of Object.keys(ctx.scope._)) {
+    ctx.scope._[k] = (ctx.scope._[k] as any).bind(ctx);
+  }
+
   try {
     parsed = MathJS.parse(HtmlDecode(op));
-    evalResult = parsed.compile().eval(scope);
+    evalResult = parsed.compile().eval(ctx.scope);
   } catch (err) {
     const message = err.message + ' Op: (' + op + ')';
     if (self && self.document && window && window.onerror) {
@@ -124,6 +133,13 @@ export function evaluateOp(op: string, scope: any, rng: () => number = Math.rand
     } else {
       throw new Error(message);
     }
+  } finally {
+    // Replace bound scope functions with originals.
+    ctx.scope._ = origLodash;
+  }
+
+  if (evalResult === undefined) {
+    return null;
   }
 
   // Only return the result IF it doesn't assign a value as its last action.
@@ -181,12 +197,6 @@ export function updateContext<C extends Context>(node: Cheerio, ctx: C, action?:
   }
   if (action !== undefined && action !== null) {
     newContext.path.push(action);
-  }
-
-  // Copy over all scope functions and bind them
-  newContext.scope._ = ctx.scope._;
-  for (const k of Object.keys(newContext.scope._)) {
-    newContext.scope._[k] = (newContext.scope._[k] as any).bind(newContext);
   }
 
   // Update random seed (using the previous seed)

--- a/shared/parse/Node.test.tsx
+++ b/shared/parse/Node.test.tsx
@@ -279,20 +279,14 @@ describe('Node', () => {
       )).toEqual(['<p>5</p>', '<p>7</p>']);
     });
 
-    test('increments scope._.views.<id>', () => {
+    test('increments views.<id>', () => {
       const ctx = defaultContext();
       let result = new Node(cheerio.load('<roleplay id="foo"><p>[roll]</p></roleplay>')('roleplay'), ctx);
       expect(result.ctx.views).toEqual({foo: 1});
-      expect(result.ctx.scope._.viewCount('foo')).toEqual(1);
-      expect(result.ctx.scope._.viewCount('bar')).toEqual(0);
       result = new Node(cheerio.load('<roleplay id="foo"><p>[roll]</p></roleplay>')('roleplay'), result.ctx);
       expect(result.ctx.views).toEqual({foo: 2});
-      expect(result.ctx.scope._.viewCount('foo')).toEqual(2);
-      expect(result.ctx.scope._.viewCount('bar')).toEqual(0);
       result = new Node(cheerio.load('<roleplay id="bar"><p>[roll]</p></roleplay>')('roleplay'), result.ctx);
       expect(result.ctx.views).toEqual({foo: 2, bar: 1});
-      expect(result.ctx.scope._.viewCount('foo')).toEqual(2);
-      expect(result.ctx.scope._.viewCount('bar')).toEqual(1);
     });
 
     test('renders deterministically when a seed is given', () => {

--- a/shared/parse/Node.tsx
+++ b/shared/parse/Node.tsx
@@ -120,6 +120,7 @@ export class Node<C extends Context> {
         }
       }) || null;
     }
+
     return (next) ? new (this.constructor as any)(next, this.ctx, key, nextSeed) : null;
   }
 
@@ -275,7 +276,7 @@ export class Node<C extends Context> {
 
     try {
       // Operate on copied scope - checking for enablement should never change the current context.
-      const visible = evaluateOp(ifExpr, Clone(this.ctx.scope), this.rng);
+      const visible = evaluateOp(ifExpr, Clone(this.ctx), this.rng);
       // We check for truthiness here, so nonzero numbers are true, etc.
       return Boolean(visible);
     } catch (e) {

--- a/shared/parse/Node.tsx
+++ b/shared/parse/Node.tsx
@@ -120,7 +120,6 @@ export class Node<C extends Context> {
         }
       }) || null;
     }
-
     return (next) ? new (this.constructor as any)(next, this.ctx, key, nextSeed) : null;
   }
 


### PR DESCRIPTION
Part of #742. Next step will be to apply this same approach to resolving network diffs in multiplayer.

- Changes quest saving and loading from "re-trace a path from the start" to "re-load a snapshot of the context at the node where the save was created". This is much more performant and much more resistant to bugs that may arise due to changes in how nodes are evaluated and rendered.
- This new quest saving/loading strategy means we must no longer support user-defined functions within op nodes. However, this is completely unused in all quests in the prod DB, so I don't think that's any great loss.
- Part of this change affects how our provided functions are bound; instead of being bound at creation time (and every time the node is copied), they are instead bound at op evaluation time. This may actually improve performance, but it also simplifies sites where contexts are constructed and results in a much simpler `ctx.scope` overall (no need to pass around a template scope generator any more!)
- The "legacy" load code remains to allow for users to still load their old quests; however, we should aim to stop supporting this path after a few months.