### PR TITLE
Show fatal on quest creator 404

### DIFF
--- a/services/quests/src/actions/Quest.tsx
+++ b/services/quests/src/actions/Quest.tsx
@@ -101,7 +101,7 @@ function loadQuestFromDrive(fileId: string, edittime: Date): Promise<LoadResult>
       edittime,
     };
   }, (json: any) => {
-    throw new Error(json.result.error);
+    throw new Error(json.result.error.message);
   });
 }
 
@@ -278,6 +278,11 @@ export function loadQuest(user: UserState, docid?: string, edittime: Date = new 
         });
       })
       .then((result: LoadResult) => {
+        if (result.data === '' && Object.keys(result.metadata).length === 0) {
+          // Even new quests have data/metadata.
+          throw new Error('Could not load quest. Try looking for it at https://drive.google.com/drive/search?q=.quest');
+        }
+
         window.location.hash = docid;
         const md = new EditableString('md', result.data);
         const notes = new EditableString('notes', result.notes);


### PR DESCRIPTION
Cause quest-not-found error to show fatal screen rather than allowing users to overwrite missing quest with empty data.

Fixes #778