### PR TITLE
Add aliveAdventurers() stub to playtest worker

### DIFF
--- a/services/quests/src/playtest/PlaytestWorker.tsx
+++ b/services/quests/src/playtest/PlaytestWorker.tsx
@@ -21,6 +21,9 @@ function mockContext() {
       numAdventurers(): number {
         return 3;
       },
+      aliveAdventurers(): number {
+        return 3;
+      },
       viewCount(id: string): number {
         return this.views[id] || 0;
       },


### PR DESCRIPTION
Exists in actual code, but was missing in the playtester. This fixes errors where users include it in their quest.