### PR TITLE
Use live node state for numAliveAdventurers in Resolve Damage card

### DIFF
--- a/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
+++ b/services/app/src/components/views/quest/cardtemplates/combat/PlayerTierContainer.tsx
@@ -47,7 +47,7 @@ const mapStateToProps = (state: AppStateWithHistory, ownProps: Partial<StateProp
     adventurers: numAdventurers(state.settings, state.multiplayer),
     combat: node.ctx.templates.combat,
     maxTier,
-    numAliveAdventurers: numAliveAdventurers(state.settings, node, state.multiplayer),
+    numAliveAdventurers: numAliveAdventurers(state.settings, state.quest.node, state.multiplayer),
     localAliveAdventurers: stateCombat.numAliveAdventurers,
     tier: stateCombat.tier,
     contentSets: getContentSets(state.settings, state.multiplayer),


### PR DESCRIPTION
Fixes #793 

The bug was caused because `props.numAliveAdventurers` does not update when user input changes the current card state (that requires fetching the actual state instead of the props passed at initial card render time).

