### PR TITLE
Fix touch tracking on combat timer, add some tests

### DIFF
--- a/services/app/src/components/multiplayer/MultiplayerAffector.test.tsx
+++ b/services/app/src/components/multiplayer/MultiplayerAffector.test.tsx
@@ -1,4 +1,65 @@
+import {newMockStore} from '../../Testing';
+import {configure, shallow} from 'enzyme';
+import * as React from 'react';
+import MultiplayerAffector, {Props} from './MultiplayerAffector';
+import Adapter from 'enzyme-adapter-react-16';
+configure({ adapter: new Adapter() });
+
 describe('MultiplayerAffector', () => {
+  function setup(overrides: Partial<Props> = {}): Env {
+    const store = newMockStore();
+    const props: Props = {
+      id: "test",
+      abortOnScroll: true,
+      children: null,
+      className: "",
+      includeLocalInteractions: true,
+      onInteraction: jest.fn(),
+      lazy: true,
+      onEvent: jest.fn(),
+      onSubscribe: jest.fn(),
+  	  onUnsubscribe: jest.fn(),
+      ...overrides,
+    };
+    return {store, props, a: shallow(<MultiplayerAffector {...(props as any as Props)} />, undefined)};
+  }
+
+  beforeEach(() => {
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame.mockRestore();
+  });
+
   test.skip('Publishes interactions for remote clients', () => { /* TODO */ });
   test.skip('Publishes interaction with children that suppress events', () => { /* TODO */ });
+  
+  test('resizes touch position to 0-1000', () => {
+    const {a, props} = setup();
+    a.instance().onRef({
+      offsetHeight: 500, 
+      offsetWidth: 100,
+      addEventListener: jest.fn(), 
+      getBoundingClientRect: () => {return {left: 0, top: 0};},
+    });
+    a.instance().processInput("mousemove", {"a": [12,50]});
+    expect(props.onEvent).toHaveBeenCalledWith(jasmine.objectContaining({
+      positions: {"a": [120, 100]},
+    }));
+  });
+
+  test('wraps negative X touch position', () => {
+    const {a, props} = setup();
+    a.instance().onRef({
+      offsetHeight: 100, 
+      offsetWidth: 100,
+      addEventListener: jest.fn(), 
+      getBoundingClientRect: () => {return {left: 0, top: 0};},
+    });
+    a.instance().processInput("mousemove", {"a": [-50,50]});
+    expect(props.onEvent).toHaveBeenCalledWith(jasmine.objectContaining({
+      positions: {"a": [500, 500]},
+    }));
+  });
 });

--- a/services/app/src/components/multiplayer/MultiplayerAffector.tsx
+++ b/services/app/src/components/multiplayer/MultiplayerAffector.tsx
@@ -111,10 +111,17 @@ export default class MultiplayerAffector extends React.Component<Props, {}> {
     this.processInput('touchend', {});
   }
 
-  private processInput(type: string, positions: {[id: string]: number[]}) {
+  public processInput(type: string, positions: {[id: string]: number[]}) {
     for (const k of Object.keys(positions)) {
       positions[k][0] = Math.floor((positions[k][0] - this.boundingRect.left) / this.ref.offsetWidth * 1000);
       positions[k][1] = Math.floor((positions[k][1] - this.boundingRect.top) / this.ref.offsetHeight * 1000);
+
+      // For unknown reasons, clientX may sometimes appear to be -100vw from its correct position.
+      // As a result we instead track the mod of the position.
+      if (positions[k][0] < 0) {
+        positions[k][0] += 1000;
+      }
+
     }
     const e: InteractionEvent = {type: 'INTERACTION', positions, id: this.props.id || '', event: type};
 


### PR DESCRIPTION
Fixes #749 

I couldn't find the real reason why `clientX` was returning negative values, but taking the mod of the clientX based on the width of the viewport effectively fixes the problem.