### PR TITLE
Add target SDK version of 28 to android build cfg

### DIFF
--- a/services/app/config.xml
+++ b/services/app/config.xml
@@ -27,6 +27,7 @@
         <param name="REVERSED_CLIENT_ID" value="io.fabricate.expedition" />
     </gap:plugin>
     <preference name="android-minSdkVersion" value="22" />
+    <preference name="android-targetSdkVersion" value="28" />
     <preference name="deployment-target" value="10.0.0" />
     <preference name="DisallowOverscroll" value="true" />
     <preference name="webviewbounce" value="false" />


### PR DESCRIPTION
"starting November 1, 2019, updates to apps and games on Google Play will be required to target Android 9 (API level 28) or higher. After this date, the Play Console will prevent you from submitting new APKs with a targetSdkVersion less than 28."

If not explicitly set, cordova will set a default target SDK version based on the version of cordova installed (see https://cordova.apache.org/docs/en/latest/config_ref/#preference)