### PR TITLE
Properly create a copy of lodash functions when evaluating context

### DIFF
--- a/shared/parse/Context.test.tsx
+++ b/shared/parse/Context.test.tsx
@@ -78,6 +78,16 @@ describe('Context', () => {
         expect(evaluateOp('pickRandom([1,2,3])', ctx, rng)).toEqual(expected);
       }
     });
+
+    test('restores an unbound copy of lodash functions', () => {
+      const ctx = defaultContext();
+      ctx.scope._.viewCount = (id: string) => {
+        return this.views[id] || 0;
+      };
+      evaluateOp('n = 5', ctx, () => 0.1);
+      expect(ctx.scope._.viewCount.name).not.toContain('bound');
+      expect(ctx.scope._.viewCount.hasOwnProperty('prototype')).toEqual(true);
+    });
   });
 
   describe('evaluateContentOps', () => {

--- a/shared/parse/Context.tsx
+++ b/shared/parse/Context.tsx
@@ -117,7 +117,7 @@ export function evaluateOp(op: string, ctx: Context, rng: () => number = Math.ra
   // Bind all scope functions, keeping a copy of the originals.
   // Note that .bind() returns a new (bound) function
   // that cannot be re-bound.
-  const origLodash: any = ctx.scope._;
+  const origLodash: any = {...ctx.scope._};
   for (const k of Object.keys(ctx.scope._)) {
     ctx.scope._[k] = (ctx.scope._[k] as any).bind(ctx);
   }

--- a/shared/parse/Context.tsx
+++ b/shared/parse/Context.tsx
@@ -136,6 +136,10 @@ export function evaluateOp(op: string, ctx: Context, rng: () => number = Math.ra
   } finally {
     // Replace bound scope functions with originals.
     ctx.scope._ = origLodash;
+
+    // Subsequent calls to evaluateOp should use a deterministic
+    // (but different) seed.
+    ctx.seed = generateSeed(ctx.seed);
   }
 
   if (evalResult === undefined) {


### PR DESCRIPTION
Fixes #800