### PR TITLE
fix #806

### DIFF
--- a/services/app/src/Style.scss
+++ b/services/app/src/Style.scss
@@ -734,7 +734,7 @@ body.android .dialog .textfield:focus-within {
         height: size(inputsquare) !important;
         padding: 0 !important;
         svg {
-          width: size(input);
+          max-width: size(input);
           height: size(input);
         }
         &:hover {


### PR DESCRIPTION
NEW:
<img width="272" alt="Screen Shot 2019-11-11 at 21 12 46" src="https://user-images.githubusercontent.com/775657/68636089-71f3e100-04c8-11ea-83c0-3dd90024c354.png">
OLD:
<img width="283" alt="Screen Shot 2019-11-11 at 21 12 37" src="https://user-images.githubusercontent.com/775657/68636117-7d470c80-04c8-11ea-837b-c7dc05e65aa8.png">
