### PR TITLE
Convert dev server to SSL / HTTPS

### DIFF
--- a/services/api/src/Routes.ts
+++ b/services/api/src/Routes.ts
@@ -57,7 +57,11 @@ export function installRoutes(db: Database, router: express.Router) {
     res: express.Response,
     next: express.NextFunction,
   ) {
-    if (Config.get('API_URL_BASE').indexOf('beta') !== -1 && res.header) {
+    if (
+      Config.get('API_URL_BASE').indexOf('beta') !== -1 &&
+      res.header &&
+      req.get('origin')
+    ) {
       res.header('Access-Control-Allow-Origin', req.get('origin'));
     }
     next();

--- a/services/api/src/Routes.ts
+++ b/services/api/src/Routes.ts
@@ -52,12 +52,12 @@ export function installRoutes(db: Database, router: express.Router) {
     next();
   }
 
-  function devACAO(
+  function betaACAO(
     req: express.Request,
     res: express.Response,
     next: express.NextFunction,
   ) {
-    if (Config.get('NODE_ENV') === 'dev' && res.header) {
+    if (Config.get('API_URL_BASE').indexOf('beta') !== -1 && res.header) {
       res.header('Access-Control-Allow-Origin', req.get('origin'));
     }
     next();
@@ -74,30 +74,30 @@ export function installRoutes(db: Database, router: express.Router) {
     res.sendStatus(200);
   });
 
-  router.get('/healthcheck', limitCors, devACAO, Handlers.healthCheck);
-  router.get('/announcements', limitCors, devACAO, Handlers.announcement);
-  router.get('/qc/announcements', limitCors, devACAO, Handlers.qcAnnouncement);
+  router.get('/healthcheck', limitCors, betaACAO, Handlers.healthCheck);
+  router.get('/announcements', limitCors, betaACAO, Handlers.announcement);
+  router.get('/qc/announcements', limitCors, betaACAO, Handlers.qcAnnouncement);
   router.post(
     '/analytics/:category/:action',
     limitCors,
-    devACAO,
+    betaACAO,
     (req, res) => {
       Handlers.postAnalyticsEvent(db, req, res);
     },
   );
-  router.post('/quests', limitCors, devACAO, (req, res) => {
+  router.post('/quests', limitCors, betaACAO, (req, res) => {
     Handlers.search(db, req, res);
   });
-  router.post('/save/quest/:id', limitCors, devACAO, (req, res) => {
+  router.post('/save/quest/:id', limitCors, betaACAO, (req, res) => {
     Handlers.saveQuestData(db, req, res);
   });
-  router.get('/qdl/:quest/:edittime', limitCors, devACAO, (req, res) => {
+  router.get('/qdl/:quest/:edittime', limitCors, betaACAO, (req, res) => {
     Handlers.loadQuestData(db, req, res);
   });
   router.get(
     '/raw/:partition/:quest/:version',
     limitCors,
-    devACAO,
+    betaACAO,
     (req, res) => {
       Handlers.questXMLHandler(db, req, res);
     },
@@ -106,7 +106,7 @@ export function installRoutes(db: Database, router: express.Router) {
     '/publish/:id',
     publishLimiter,
     limitCors,
-    devACAO,
+    betaACAO,
     requireAuth,
     (req, res) => {
       Handlers.publish(db, Mail, req, res);
@@ -115,16 +115,16 @@ export function installRoutes(db: Database, router: express.Router) {
   router.post(
     '/unpublish/:quest',
     limitCors,
-    devACAO,
+    betaACAO,
     requireAuth,
     (req, res) => {
       Handlers.unpublish(db, req, res);
     },
   );
-  router.post('/quest/feedback/:type', limitCors, devACAO, (req, res) => {
+  router.post('/quest/feedback/:type', limitCors, betaACAO, (req, res) => {
     Handlers.feedback(db, Mail, req, res);
   });
-  router.post('/user/subscribe', limitCors, devACAO, (req, res) => {
+  router.post('/user/subscribe', limitCors, betaACAO, (req, res) => {
     Handlers.subscribe(
       mailchimp,
       Config.get('MAILCHIMP_PLAYERS_LIST_ID'),
@@ -132,19 +132,25 @@ export function installRoutes(db: Database, router: express.Router) {
       res,
     );
   });
-  router.get('/user/quests', limitCors, devACAO, requireAuth, (req, res) => {
+  router.get('/user/quests', limitCors, betaACAO, requireAuth, (req, res) => {
     Handlers.userQuests(db, req, res);
   });
-  router.get('/user/feedbacks', limitCors, devACAO, requireAuth, (req, res) => {
-    Handlers.userFeedbacks(db, req, res);
-  });
-  router.get('/user/badges', limitCors, devACAO, requireAuth, (req, res) => {
+  router.get(
+    '/user/feedbacks',
+    limitCors,
+    betaACAO,
+    requireAuth,
+    (req, res) => {
+      Handlers.userFeedbacks(db, req, res);
+    },
+  );
+  router.get('/user/badges', limitCors, betaACAO, requireAuth, (req, res) => {
     Handlers.userBadges(db, req, res);
   });
   router.get(
     '/multiplayer/v1/user',
     limitCors,
-    devACAO,
+    betaACAO,
     requireAuth,
     (req, res) => {
       MultiplayerHandlers.user(db, req, res);
@@ -154,7 +160,7 @@ export function installRoutes(db: Database, router: express.Router) {
     '/multiplayer/v1/new_session',
     sessionLimiter,
     limitCors,
-    devACAO,
+    betaACAO,
     requireAuth,
     (req, res) => {
       MultiplayerHandlers.newSession(db, req, res);
@@ -163,13 +169,13 @@ export function installRoutes(db: Database, router: express.Router) {
   router.post(
     '/multiplayer/v1/connect',
     limitCors,
-    devACAO,
+    betaACAO,
     requireAuth,
     (req, res) => {
       MultiplayerHandlers.connect(db, req, res);
     },
   );
-  router.post('/stripe/checkout', limitCors, devACAO, (req, res) => {
+  router.post('/stripe/checkout', limitCors, betaACAO, (req, res) => {
     Stripe.checkout(req, res);
   });
 

--- a/shared/webpack.shared.js
+++ b/shared/webpack.shared.js
@@ -4,9 +4,23 @@ const Webpack = require('webpack');
 const port = process.env.DOCKER_PORT || 8080;
 
 const options = {
-  mode: 'development',
-  devtool: 'source-map',
   cache: true,
+  devServer: {
+    contentBase: 'src',
+    disableHostCheck: true,
+    historyApiFallback: true,
+    host: '0.0.0.0',
+    hot: true,
+    noInfo: false,
+    port: port,
+    publicPath: '/',
+    quiet: false,
+    watchContentBase: true,
+    watchOptions: process.env.WATCH_POLL
+      ? { aggregateTimeout: 300, poll: 1000 }
+      : {},
+  },
+  devtool: 'source-map',
   entry: [
     'babel-polyfill',
     'whatwg-fetch',
@@ -14,64 +28,74 @@ const options = {
     'webpack-dev-server/client?http://localhost:' + port,
     'webpack/hot/only-dev-server',
   ],
-  output: {
-    publicPath: 'http://localhost:' + port + '/',
-    filename: '[name].js',
-  },
-  resolve: {
-    extensions: ['.js', '.ts', '.tsx', '.json', '.txt'],
-  },
-  stats: {
-    colors: true,
-    reasons: true,
-  },
+  mode: 'development',
   module: {
     rules: [
-      { test: /\.tsx$/, enforce: 'pre', loader: 'tslint-loader',
+      {
+        enforce: 'pre',
+        loader: 'tslint-loader',
         options: {
           fix: true,
-          typeCheck: false, // Explicitly disable extended type checking for dev workflow due to performance
           tsConfigFile: Path.resolve(__dirname, '../tsconfig.json'),
+          // Explicitly disable extended type checking for dev workflow due to performance
+          typeCheck: false,
         },
+        test: /\.tsx$/,
       },
-      { test: /\.(svg|png|gif|jpe?g)(\?[a-z0-9=&.]+)?$/, loader: 'file-loader',
-        options: { name: 'images/[name].[ext]' }, // disable filename hashing for infrequently changed static assets to enable preloading
+      {
+        loader: 'file-loader',
+        // disable filename hashing for infrequently changed static assets to enable preloading
+        options: { name: 'images/[name].[ext]' },
+        test: /\.(svg|png|gif|jpe?g)(\?[a-z0-9=&.]+)?$/,
       },
-      { test: /\.(ttf|eot|woff(2)?)(\?[a-z0-9=&.]+)?$/, loader: 'file-loader',
-        options: { name: 'fonts/[name].[ext]' }, // disable filename hashing for infrequently changed static assets to enable preloading
+      {
+        loader: 'file-loader',
+        // disable filename hashing for infrequently changed static assets to enable preloading
+        options: { name: 'fonts/[name].[ext]' },
+        test: /\.(ttf|eot|woff(2)?)(\?[a-z0-9=&.]+)?$/,
       },
-      { test: /\.scss$/, loaders: ['style-loader', 'css-loader', 'sass-loader'] },
-      { test: /\.tsx$/, loaders: ['awesome-typescript-loader'], exclude: /node_modules/ },
-    ]
+      {
+        loaders: ['style-loader', 'css-loader', 'sass-loader'],
+        test: /\.scss$/,
+      },
+      {
+        exclude: /node_modules/,
+        loaders: ['awesome-typescript-loader'],
+        test: /\.tsx$/,
+      },
+    ],
   },
-  plugins: [
-    new Webpack.DefinePlugin({
-      // Default to beta for safety
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
-      'process.env.API_HOST': JSON.stringify(process.env.API_HOST || 'http://betaapi.expeditiongame.com'),
-      'process.env.OAUTH2_CLIENT_ID': JSON.stringify(process.env.OAUTH2_CLIENT_ID || '545484140970-jq9jp7gdqdugil9qoapuualmkupigpdl.apps.googleusercontent.com'),
-    }),
-    new Webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), // Don't import bloated Moment locales
-    new Webpack.HotModuleReplacementPlugin(),
-  ],
   node: {
     console: true,
     fs: 'empty',
     net: 'empty',
     tls: 'empty',
   },
-  devServer: {
-    host: '0.0.0.0',
-    contentBase: 'src',
-    disableHostCheck: true,
-    publicPath: '/',
-    port: port,
-    hot: true,
-    quiet: false,
-    noInfo: false,
-    historyApiFallback: true,
-    watchContentBase: true,
-    watchOptions: ((process.env.WATCH_POLL) ? {aggregateTimeout: 300, poll: 1000} : {}),
+  output: {
+    filename: '[name].js',
+    publicPath: 'http://localhost:' + port + '/',
+  },
+  plugins: [
+    new Webpack.DefinePlugin({
+      // Default to beta for safety
+      'process.env.API_HOST': JSON.stringify(
+        process.env.API_HOST || 'https://betaapi.expeditiongame.com',
+      ),
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
+      'process.env.OAUTH2_CLIENT_ID': JSON.stringify(
+        process.env.OAUTH2_CLIENT_ID ||
+          '201136733984-q6bbbi2p01qfmknl97k0o2ag7utobm88.apps.googleusercontent.com',
+      ),
+    }),
+    new Webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), // Don't import bloated Moment locales
+    new Webpack.HotModuleReplacementPlugin(),
+  ],
+  resolve: {
+    extensions: ['.js', '.ts', '.tsx', '.json', '.txt'],
+  },
+  stats: {
+    colors: true,
+    reasons: true,
   },
 };
 


### PR DESCRIPTION
This adds access-control-allow-origin set to the origin for all requests in the dev API. This is necessary when developing on a domain other than the `betaapi` domain (E.g. with cloud shell)