### PR TITLE
Bug 7 players

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Run the tests to make sure everything's working: `yarn test`
 
 To build the Cordova app, you may need to install other global dependencies: `npm install -g cordova webpack@4 webpack-cli@3 webpack-dev-server@3`
 
-Chrome is used for headless browser testing. [How to install Chrome on WSL/Ubunutu cli](https://askubuntu.com/a/510186)
+Chrome is used for headless browser testing. [How to install Chrome on WSL/Ubuntu cli](https://askubuntu.com/a/510186)
 
 ### Running the code
 

--- a/services/app/src/Init.tsx
+++ b/services/app/src/Init.tsx
@@ -95,7 +95,7 @@ function setupDevice() {
     // https://stackoverflow.com/a/43502958/1332186
     if (/Android/.test(navigator.appVersion)) {
       window.addEventListener('resize', () => {
-        if (document.activeElement !== null) {
+        if (document.activeElement) {
           if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA') {
             document.activeElement.scrollIntoView();
           }

--- a/services/app/src/Init.tsx
+++ b/services/app/src/Init.tsx
@@ -95,8 +95,10 @@ function setupDevice() {
     // https://stackoverflow.com/a/43502958/1332186
     if (/Android/.test(navigator.appVersion)) {
       window.addEventListener('resize', () => {
-        if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA') {
-          document.activeElement.scrollIntoView();
+        if (document.activeElement !== null) {
+          if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA') {
+            document.activeElement.scrollIntoView();
+          }
         }
       });
     }

--- a/services/app/src/components/base/Card.tsx
+++ b/services/app/src/components/base/Card.tsx
@@ -97,7 +97,7 @@ class Card extends React.Component<Props, IState> {
             err = Error('Cannot rate web app');
             break;
           default:
-            err = Error('Uknown platform encountered');
+            err = Error('Unknown platform encountered');
         }
         if (err) {
           throw err;

--- a/services/app/src/components/base/Dialogs.test.tsx
+++ b/services/app/src/components/base/Dialogs.test.tsx
@@ -3,7 +3,6 @@ import {
   TextAreaDialog,
   BaseDialogProps,
   ConfirmationDialog,
-  BaseDialogProps
   MultiplayerStatusDialogProps,
   MultiplayerStatusDialog,
   ExpansionSelectDialogProps,
@@ -11,7 +10,8 @@ import {
   SetPlayerCountDialogProps,
   SetPlayerCountDialog,
   MultiplayerPeersDialogProps,
-  MultiplayerPeersDialog
+  MultiplayerPeersDialog,
+  TooManyPlayersDialog
 } from './Dialogs';
 import {loggedOutUser} from 'shared/auth/UserState';
 import {initialSettings} from 'app/reducers/Settings';
@@ -243,6 +243,29 @@ describe('Dialogs', () => {
       const {props, e} = setup({quest: new Quest({...TUTORIAL_QUESTS[0], expansionhorror: true})});
       expect(e.find('DialogContent').render().text()).toContain('expansion is required');
       expect(e.find('#play').length).toEqual(0);
+    });
+  });
+
+  describe('TooManyPlayersDialog', () => {
+    function setup(overrides?: Partial<BaseDialogProps>) {
+      const props: Props = {
+        open: true,
+        onClose: jasmine.createSpy('onClose'),
+        ...overrides,
+      };
+      return {props, e: mount(<TooManyPlayersDialog {...(props as any as BaseDialogProps)} />)};
+    }
+
+    test('renders title & content', () => {
+      const {e} = setup();
+      expect(e.find('DialogTitle').render().text()).toContain('Too many players!');
+      expect(e.find('DialogContent').render().text()).toContain('Expedition can only be played by a maximum of 6 players!');
+    });
+
+    test('calls onClose on Cancel tap', () => {
+      const {props, e} = setup();
+      e.find('#cancelButton').hostNodes().prop('onClick')();
+      expect(props.onClose).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/services/app/src/components/base/Dialogs.test.tsx
+++ b/services/app/src/components/base/Dialogs.test.tsx
@@ -259,7 +259,7 @@ describe('Dialogs', () => {
     test('renders title & content', () => {
       const {e} = setup();
       expect(e.find('DialogTitle').render().text()).toContain('Too many players!');
-      expect(e.find('DialogContent').render().text()).toContain('Expedition can only be played by a maximum of 6 players!');
+      expect(e.find('DialogContent').render().text()).toContain('Expedition can only be played by a maximum of 6 players.');
     });
 
     test('calls onClose on Cancel tap', () => {

--- a/services/app/src/components/base/Dialogs.tsx
+++ b/services/app/src/components/base/Dialogs.tsx
@@ -208,6 +208,35 @@ export class ExpansionSelectDialog extends React.Component<ExpansionSelectDialog
   }
 }
 
+export class TooManyPlayersDialog<T extends BaseDialogProps> extends React.Component<T, {}> {
+  protected title: string;
+  protected content: JSX.Element;
+
+  constructor(props: T) {
+    super(props);
+    this.title = 'Too many players!';
+    this.content = <p>Expedition can only be played by a maximum of 6 players!</p>;
+  }
+
+  public shouldComponentUpdate(nextProps: BaseDialogProps) {
+    return nextProps.open !== this.props.open;
+  }
+
+  public render(): JSX.Element {
+    return (
+      <Dialog classes={{paperWidthSm: 'dialog'}} open={Boolean(this.props.open)}>
+        <DialogTitle>{this.title}</DialogTitle>
+        <DialogContent className="dialog">
+          {this.content}
+        </DialogContent>
+        <DialogActions>
+          <Button id="cancelButton" onClick={() => this.props.onClose()}>Cancel</Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+}
+
 export class TextAreaDialog<T extends BaseDialogProps> extends React.Component<T, {}> {
   protected title: string;
   protected content: JSX.Element;
@@ -501,6 +530,10 @@ const Dialogs = (props: Props): JSX.Element => {
         quest={props.quest.details}
         settings={props.settings}
         multiplayer={props.multiplayer}
+      />
+      <TooManyPlayersDialog
+        open={props.dialog && props.dialog.open === 'TOO_MANY_PLAYERS'}
+        onClose={props.onClose}
       />
     </span>
   );

--- a/services/app/src/components/base/Dialogs.tsx
+++ b/services/app/src/components/base/Dialogs.tsx
@@ -215,7 +215,7 @@ export class TooManyPlayersDialog<T extends BaseDialogProps> extends React.Compo
   constructor(props: T) {
     super(props);
     this.title = 'Too many players!';
-    this.content = <p>Expedition can only be played by a maximum of 6 players!</p>;
+    this.content = <p>Expedition can only be played by a maximum of 6 players.</p>;
   }
 
   public shouldComponentUpdate(nextProps: BaseDialogProps) {

--- a/services/app/src/components/base/TouchIndicator.tsx
+++ b/services/app/src/components/base/TouchIndicator.tsx
@@ -85,7 +85,7 @@ export default class TouchIndicator extends React.Component<Props, {}> {
 
   public render() {
     return (
-       <canvas className="base_multi_touch_trigger touch_indicator" ref={(ref: Element|null) => {this.setupCanvas(ref); }} />
+      <canvas className="base_multi_touch_trigger touch_indicator" ref={(ref: Element|null) => {this.setupCanvas(ref); }} />
     );
   }
 }

--- a/services/app/src/components/views/SplashScreen.tsx
+++ b/services/app/src/components/views/SplashScreen.tsx
@@ -22,17 +22,19 @@ class PlayerCounter extends React.Component<PlayerCounterProps, {}> {
     animFrameReq: number|null;
   };
 
+  protected initialState = {
+    lastTouchTime: 0,
+    maxTouches: 0,
+    tip: SPLASH_SCREEN_TIPS[Math.floor(Math.random() * SPLASH_SCREEN_TIPS.length)],
+    touchCount: 0,
+    transitionTimeout: null,
+    progress: 0,
+    animFrameReq: null,
+  };
+
   constructor(props: PlayerCounterProps) {
     super(props);
-    this.state = {
-      lastTouchTime: 0,
-      maxTouches: 0,
-      tip: SPLASH_SCREEN_TIPS[Math.floor(Math.random() * SPLASH_SCREEN_TIPS.length)],
-      touchCount: 0,
-      transitionTimeout: null,
-      progress: 0,
-      animFrameReq: null,
-    };
+    this.state = this.initialState;
   }
 
   // NOTE: transitionMillis is also defined in scss for the timer spinner
@@ -57,6 +59,9 @@ class PlayerCounter extends React.Component<PlayerCounterProps, {}> {
       } else if (numFingers > 0) {
         this.setState({transitionTimeout: setTimeout(() => {
           this.props.onPlayerCountSelect(numFingers);
+          if (numFingers > 6) {
+            this.setState(this.initialState);
+          }
         }, this.props.transitionMillis)});
         this.animate();
       }

--- a/services/app/src/components/views/SplashScreenContainer.tsx
+++ b/services/app/src/components/views/SplashScreenContainer.tsx
@@ -1,3 +1,4 @@
+import { setDialog } from 'app/actions/Dialog';
 import {connect} from 'react-redux';
 import Redux from 'redux';
 import {toCard, toNavCard} from '../../actions/Card';
@@ -26,8 +27,12 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
       }
     },
     onPlayerCountSelect: (numLocalPlayers: number) => {
-      dispatch(changeSettings({numLocalPlayers, multitouch: true}));
-      dispatch(toNavCard({}));
+      if (numLocalPlayers > 6) {
+          dispatch(setDialog('TOO_MANY_PLAYERS'));
+      } else {
+        dispatch(changeSettings({numLocalPlayers, multitouch: true}));
+        dispatch(toNavCard({}));
+      }
     },
     onPlayerManualSelect: () => {
       dispatch(toCard({name: 'PLAYER_COUNT_SETTING'}));

--- a/services/app/src/components/views/SplashScreenContainer.tsx
+++ b/services/app/src/components/views/SplashScreenContainer.tsx
@@ -28,7 +28,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
     },
     onPlayerCountSelect: (numLocalPlayers: number) => {
       if (numLocalPlayers > 6) {
-          dispatch(setDialog('TOO_MANY_PLAYERS'));
+        dispatch(setDialog('TOO_MANY_PLAYERS'));
       } else {
         dispatch(changeSettings({numLocalPlayers, multitouch: true}));
         dispatch(toNavCard({}));

--- a/services/app/src/reducers/StateTypes.tsx
+++ b/services/app/src/reducers/StateTypes.tsx
@@ -52,7 +52,8 @@ export type DialogIDType = null
   | 'MULTIPLAYER_STATUS'
   | 'MULTIPLAYER_PEERS'
   | 'SET_PLAYER_COUNT'
-  | 'DELETE_SAVED_QUEST';
+  | 'DELETE_SAVED_QUEST'
+  | 'TOO_MANY_PLAYERS';
 export interface DialogState {
   open: DialogIDType;
   message?: string;


### PR DESCRIPTION
In the case of more than 6 players, a dialog saying "Too many players" open up.
![Peek 2020-01-29 17-05](https://user-images.githubusercontent.com/12206365/73353592-af8f2b80-42b9-11ea-9448-239ec2dc4f8b.gif)

Issue: Once the dialog is canceled, the splash screen sticks to the last state and requires an additional touch to reset. I need help there.

Fixes #811 