### PR TITLE
fix ios logo positioning

### DIFF
--- a/services/app/src/Style.scss
+++ b/services/app/src/Style.scss
@@ -1139,6 +1139,7 @@ body.android .dialog .textfield:focus-within {
       position: absolute;
       top: size(small);
       // iPhone X padding fix
+      top: env(safe-area-inset-top);
       top: calc(size(small) + constant(safe-area-inset-top));
       top: calc(size(small) + env(safe-area-inset-top));
       left: size(small);


### PR DESCRIPTION
<img width="465" alt="Screen Shot 2020-03-08 at 14 36 20" src="https://user-images.githubusercontent.com/775657/76168941-40bfb080-614a-11ea-8b3b-f96072a2fac7.png">

Closes #803 