### PR TITLE
Migrate to google sheets CSV since sheets API changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@material-ui/core": "^1.2.1",
     "@material-ui/icons": "^1.1.0",
+    "@types/papaparse": "^5.3.1",
     "@types/raven-for-redux": "^1.1.1",
     "ace": "^1.3.0",
     "async": "~3.2.0",
@@ -75,6 +76,7 @@
     "node-sass": "^4.9.0",
     "nodemailer": "^4.6.4",
     "numeral": "^2.0.6",
+    "papaparse": "^5.3.1",
     "passport": "^0.4.0",
     "passport-google-id-token": "^0.4.5",
     "path": "^0.12.7",
@@ -111,7 +113,6 @@
     "stripe": "^6.0.0",
     "style-loader": "^0.23.0",
     "svg-injector": "^1.1.3",
-    "tabletop": "^1.5.1",
     "ts-jest": "^22.4.4",
     "tslint": "^5.8.0",
     "typescript": "2.8.3",

--- a/services/cards/CARD-CREATION.md
+++ b/services/cards/CARD-CREATION.md
@@ -3,9 +3,10 @@
 Making your own cards is easy! The card creator uses Google Sheets as its data source. Here's how to get started:
 
 1. Create a Google Sheet with the card information you'd like. Here's an [example card data sheet](https://docs.google.com/spreadsheets/d/1MVZ2hqihag6QvbRgBGafOi_NbNhZ1TL2a1DH_ojG__o/edit#gid=987926921), we recommend copying it to your Google account and working from there.
-2. Publish your sheet to the web in Sheets. File -> Publish to the Web. Make sure it's set to "Link", "Entire Document" and "Web Page", then hit publish.
+2. Publish your sheet to the web in Sheets. File -> Share -> Publish to the Web. Make sure it's set to "Link", one of your sheets in particular (e.g. "Ability") and "Comma-separated Values (.csv)", then hit publish.
+   * NOTE: As of Nov 2021 Google's Sheets API was restricted, making it unfortunately difficult to import the whole sheet at once. To work around this, we'll be importing an individual sheet containing one type of cards (e.g. Abilities) at a time.
 3. Copy the web page's URL in your browser's URL bar.
-4. Open the [card creator website](http://cards.expeditiongame.com), select Source -> Custom, and paste your publish link.
+4. Open the [card creator website](http://cards.expeditiongame.com), select Source -> Custom, then type the name of your sheet (e.g. "Ability") and paste your publish link.
 5. Refresh the page.
 6. Voila! Your cards should now be imported; you can select whichever theme you'd like, review the cards for appearance and accuracy, then print with `Ctrl + P` / `Command + P`
 7. If you have any issues, create an issue here: [https://github.com/ExpeditionRPG/expedition-cards/issues/new](https://github.com/ExpeditionRPG/expedition-cards/issues/new)

--- a/services/cards/src/Constants.tsx
+++ b/services/cards/src/Constants.tsx
@@ -16,7 +16,7 @@ export const SHEETS: CardSource[] = [
       Translations: '2111992856',
       Helper: '987926921',
       Adventurer: '558719643',
-      Ability: '0',
+      Ability: '0', // actually the sheet ID, not a placeholder
       Encounter: '1555320979',
       Loot: '1510752952',
     },
@@ -37,7 +37,7 @@ export const SHEETS: CardSource[] = [
     key: '2PACX-1vQcPWt9MO7ZDtLaR1teWcuNxoRHH4Q1Yf4xLpyv3xSEqSOLbpPVj_aB5Emh7sOnZ3hMIwvA9LJn76pZ',
     sheets: {
       Adventurer: '558719643',
-      Ability: '0',
+      Ability: '0', // actually the sheet ID, not a placeholder
       Encounter: '1555320979',
       Loot: '1510752952',
       Skill: '1013479922',
@@ -55,7 +55,7 @@ export const SHEETS: CardSource[] = [
     key: '2PACX-1vQ-jU0FGl9PGXm0m-jYJazhxYjLhpSwdPFNCVAGXTM6XrdcZ65MXRBtWdIJvWLglC4tFmUB_y324UMb',
     sheets: {
       Adventurer: '558719643',
-      Ability: '0',
+      Ability: '0', // actually the sheet ID, not a placeholder
       Encounter: '1555320979',
       Loot: '1510752952',
     },

--- a/services/cards/src/Constants.tsx
+++ b/services/cards/src/Constants.tsx
@@ -1,3 +1,63 @@
 export const MAX_COUNTER_HEALTH = 30;
 export const MAX_ADVENTURER_HEALTH = 12;
 export const POKER_CARDS_PER_LETTER_PAGE = 9;
+
+export interface CardSource {
+  name: string;
+  key: string;
+  sheets: {[key: string]: string};
+}
+
+export const SHEETS: CardSource[] = [
+  {
+    name: 'Expedition',
+    key: '2PACX-1vQ0Hx1RcDqkc3pn7ZyKEiqdDXm4miEgDeozJ9amJrxz2QzAH8AOaf6rqaLJL4G3fcqCDIYDKdDqsuax',
+    sheets: {
+      Translations: '2111992856',
+      Helper: '987926921',
+      Adventurer: '558719643',
+      Ability: '0',
+      Encounter: '1555320979',
+      Loot: '1510752952',
+    },
+  },
+  {
+    name: 'The Horror',
+    key: '2PACX-1vTYzRwsE32Dh6U_3Xn56-SEfF6SadUjU6rTdEroX6GgrdAAt7Ptzn1RyB-2H0UIR0pOoTbySxrqSnSu',
+    sheets: {
+      Ability: '2087688178',
+      Adventurer: '2140283349',
+      Encounter: '1555320979',
+      Loot: '756185894',
+      Persona: '1235118672',
+    },
+  },
+  {
+    name: 'The Future',
+    key: '2PACX-1vQcPWt9MO7ZDtLaR1teWcuNxoRHH4Q1Yf4xLpyv3xSEqSOLbpPVj_aB5Emh7sOnZ3hMIwvA9LJn76pZ',
+    sheets: {
+      Adventurer: '558719643',
+      Ability: '0',
+      Encounter: '1555320979',
+      Loot: '1510752952',
+      Skill: '1013479922',
+    },
+  },
+  {
+    name: 'Of Wyrms And Giants',
+    key: '2PACX-1vTpLs-jQwdK-WaOWFFqAOqrTYeMFk3j116-mLso3tmrq5PKD6jJNyIxAvs28FQiJ8VD0fk5e9ZN-7FN',
+    sheets: {
+      Encounter: '1555320979',
+    },
+  },
+  {
+    name: 'Scarred Lands',
+    key: '2PACX-1vQ-jU0FGl9PGXm0m-jYJazhxYjLhpSwdPFNCVAGXTM6XrdcZ65MXRBtWdIJvWLglC4tFmUB_y324UMb',
+    sheets: {
+      Adventurer: '558719643',
+      Ability: '0',
+      Encounter: '1555320979',
+      Loot: '1510752952',
+    },
+  },
+];

--- a/services/cards/src/actions/Filters.tsx
+++ b/services/cards/src/actions/Filters.tsx
@@ -12,13 +12,11 @@ const qs = require('qs');
 // Filter changes trigger several things, including the actual FiltersChange action
 export function filterChange(name: string, value: string | number): ((dispatch: Redux.Dispatch<any>) => void) {
   return (dispatch: Redux.Dispatch<any>) => {
-    if (name === 'source' && value === 'Custom') {
+    let cardstype = null;
+    if (name === 'source' && value === 'custom') {
       // TODO validate URL or ID, otherwise notify user + abort
-      value = window.prompt('Please enter your card sheet publish URL (see "?" in the top right for help)', '') as string;
-      if (value.indexOf('/e/') !== -1) {
-        return alert('Please use the URL of the Google Doc, not the publish link');
-      }
-      value = 'Custom:' + value.replace('https://docs.google.com/spreadsheets/d/', '').split('/')[0];
+      cardstype = window.prompt('Please enter a sheet type (Ability, Adventurer, Encounter, Helper, Loot, Persona, Skill)');
+      value = window.prompt('Please enter your card sheet publish CSV URL (see "?" in the top right for help)', '') as string;
     }
     // tslint:disable-next-line
     dispatch({type: 'FILTER_CHANGE', name, value}) as FilterChangeAction;
@@ -34,7 +32,7 @@ export function filterChange(name: string, value: string | number): ((dispatch: 
 
     const store = getStore();
     if (name === 'source') {
-      dispatch(downloadCards(store.getState().filters.source.current));
+      dispatch(downloadCards(store.getState().filters.source.current, cardstype));
     } else {
       dispatch(cardsFilter(store.getState().cards.data, store.getState().filters));
       dispatch(filtersCalculate(store.getState().cards.filtered));

--- a/services/cards/src/components/TopBar.tsx
+++ b/services/cards/src/components/TopBar.tsx
@@ -43,12 +43,12 @@ class TopBar extends React.Component<Props, {}> {
         // For "all" default values, nicen up their text presentation to users
         if (typeof option === 'string' && option.toLowerCase() === 'all') {
           text = 'All ' + name + ((['s', 'x'].indexOf(name[name.length - 1]) !== -1) ? 'es' : 's');
-        // For sources, remove the ":LONGIDSTRING" and just show the user the name of the source
-        } else if (name === 'source') {
-          text = text.split(':')[0];
         }
         return <MenuItem key={j} value={option}>{text}</MenuItem>;
       });
+      if (name === 'source') {
+        options.push(<MenuItem key="custom" value="custom">Custom</MenuItem>);
+      }
       return (
         <FormControl key={index}>
           <InputLabel htmlFor={name}>{name}</InputLabel>

--- a/services/cards/src/reducers/Filters.tsx
+++ b/services/cards/src/reducers/Filters.tsx
@@ -1,5 +1,6 @@
 import Redux from 'redux';
 import {FilterChangeAction, FiltersCalculateAction} from '../actions/ActionTypes';
+import {SHEETS} from '../Constants';
 import {CardType, FiltersState} from './StateTypes';
 
 // In UI order
@@ -30,15 +31,10 @@ export let initialState: FiltersState = {
     options: ['PrintAndPlay', 'WebView', 'DriveThruCards', 'AdMagicFronts', 'AdMagicBacks', 'FrontsOnly'],
   },
   source: {
-    current: 'Expedition:11Y8eS_cyIQ7wlGj5mo7VEHf355ycEHePrdysPzTnVJw',
-    default: 'Expedition:11Y8eS_cyIQ7wlGj5mo7VEHf355ycEHePrdysPzTnVJw',
-    options: ['Expedition:11Y8eS_cyIQ7wlGj5mo7VEHf355ycEHePrdysPzTnVJw',
-      'The Horror:1K08sXHXyW7TAMXJnHOv9V3QtjxwjAf2-cvbaO-S2fDQ',
-      'The Future:1LD4SP5YMFs49yn1sdgIrRnMGB3tz2jvGuCt2aKcCsyM',
-      'Expedition+Horror+Future:1LD4SP5YMFs49yn1sdgIrRnMGB3tz2jvGuCt2aKcCsyM,1K08sXHXyW7TAMXJnHOv9V3QtjxwjAf2-cvbaO-S2fDQ,11Y8eS_cyIQ7wlGj5mo7VEHf355ycEHePrdysPzTnVJw',
-      'Of Wyrms & Giants:1S5xcFPUejtgC4Mosh8uuiRE-YwdaJ6mlCX3bQcbBT-4',
-      'Scarred Lands:1JHYSbQwRAKojMY5L9ViVe-M0toH__tZFSzuoahOgKws',
-      'Custom',
+    current: SHEETS[0].name,
+    default: SHEETS[0].name,
+    options: [
+      ...SHEETS.map((s) => s.name),
     ],
   },
 };

--- a/services/cards/src/reducers/StateTypes.tsx
+++ b/services/cards/src/reducers/StateTypes.tsx
@@ -1,5 +1,5 @@
 export interface CardType {
-  // all cards have sheet: string as the tabletop sheet they originated from
+  // all cards have sheet: string as the sheet they originated from
   [key: string]: any;
 }
 

--- a/shared/Dockerfile
+++ b/shared/Dockerfile
@@ -1,17 +1,4 @@
-FROM ubuntu:18.04@sha256:72f832c6184b55569be1cd9043e4a80055d55873417ea792d989441f207dd2c7
-MAINTAINER Scott Martin <smartin015@gmail.com>
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-RUN apt-get update
-RUN apt-get install -y wget gnupg2
+FROM node:8
 
-# Install Google Chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update && apt-get install -y google-chrome-stable
-
-RUN apt-get install -y git nodejs tmux npm bash build-essential curl libfontconfig1
-RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.25.0/install.sh | bash
-RUN /bin/bash -l -c 'source ~/.nvm/nvm.sh && nvm install v8.11.3 && nvm alias default v8.11.3'
-RUN npm install -g webpack yarn
-RUN echo "#!/bin/bash\ncd /volume\ntmux new-session -s dev '/bin/bash'" > /run.sh && chmod a+x /run.sh
-ENTRYPOINT /run.sh
+RUN npm install -g yarn
+RUN bash -c "cd /volume && yarn install"

--- a/yarn.lock
+++ b/yarn.lock
@@ -346,6 +346,13 @@
   version "8.10.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.21.tgz#12b3f2359b27aa05a45d886c8ba1eb8d1a77e285"
 
+"@types/papaparse@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@types/papaparse/-/papaparse-5.3.1.tgz#fb5c613a64473c33b08fb9bc2a5ddbf25e54784e"
+  integrity sha512-1lbngk9wty2kCyQB42LjqSa12SEop3t9wcEC7/xYr3ujTSTmv7HWKjKYXly0GkMfQ42PRb2lFPFEibDOiMXS0g==
+  dependencies:
+    "@types/node" "*"
+
 "@types/passport@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/passport/-/passport-1.0.1.tgz#bf082e29497d09410e13c260903571a489bf9c2a"
@@ -2996,12 +3003,6 @@ cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-table@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
-  dependencies:
-    colors "1.0.3"
-
 cli-truncate@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
@@ -3016,10 +3017,6 @@ cli-width@^1.1.0:
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
-
-cliclopts@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/cliclopts/-/cliclopts-1.1.1.tgz#69431c7cb5af723774b0d3911b4c37512431910f"
 
 cliui@^3.0.3:
   version "3.2.0"
@@ -3151,7 +3148,7 @@ colors@0.5.x:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
-colors@1.0.3, colors@1.0.x:
+colors@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
@@ -3687,10 +3684,6 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-cvss@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cvss/-/cvss-1.0.3.tgz#70df9c4a4e07fdb9341f27a2847a21df25c3a83a"
-
 cwd@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/cwd/-/cwd-0.10.0.tgz#172400694057c22a13b0cf16162c7e4b7a7fe567"
@@ -3764,7 +3757,7 @@ debounce@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.1.0.tgz#6a1a4ee2a9dc4b7c24bb012558dbcdb05b37f408"
 
-debug@2, debug@2.6.9, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.4.1, debug@^2.6.0, debug@^2.6.2, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
+debug@2, debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.4.1, debug@^2.6.0, debug@^2.6.2, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -6007,7 +6000,7 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
-https-proxy-agent@1.0.0, https-proxy-agent@^1.0.0:
+https-proxy-agent@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz#35f7da6c48ce4ddbfa264891ac593ee5ff8671e6"
   dependencies:
@@ -6720,10 +6713,6 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isemail@1.x.x:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-1.2.0.tgz#be03df8cc3e29de4d2c5df6501263f1fa4595e9a"
-
 isemail@3.x.x:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.1.2.tgz#937cf919002077999a73ea8b1951d590e84e01dd"
@@ -7332,15 +7321,6 @@ joi@^13.2.0:
     hoek "5.x.x"
     isemail "3.x.x"
     topo "3.x.x"
-
-joi@^6.9.1:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-6.10.1.tgz#4d50c318079122000fe5f16af1ff8e1917b77e06"
-  dependencies:
-    hoek "2.x.x"
-    isemail "1.x.x"
-    moment "2.x.x"
-    topo "1.x.x"
 
 js-base64@^2.1.8:
   version "2.6.4"
@@ -8715,7 +8695,7 @@ moment-timezone@^0.5.21:
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.x.x, "moment@>= 2.9.0", moment@^2.22.1:
+"moment@>= 2.9.0", moment@^2.22.1:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
@@ -9019,10 +8999,6 @@ nodemailer@^4.6.4:
   version "4.6.7"
   resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-4.6.7.tgz#b68de7f36d65618bdeeeb76234e3547d51266373"
 
-nodesecurity-npm-utils@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/nodesecurity-npm-utils/-/nodesecurity-npm-utils-5.0.0.tgz#05aa30de30ca8c845c4048e94fd78e5e08b55ed9"
-
 nomnom@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
@@ -9174,22 +9150,6 @@ npm-which@^3.0.1:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
-
-nsp@^2.6.2:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/nsp/-/nsp-2.8.1.tgz#436e3f13869e0610d3a38f59d55f9b353cc32817"
-  dependencies:
-    chalk "^1.1.1"
-    cli-table "^0.3.1"
-    cvss "^1.0.0"
-    https-proxy-agent "^1.0.0"
-    joi "^6.9.1"
-    nodesecurity-npm-utils "^5.0.0"
-    path-is-absolute "^1.0.0"
-    rc "^1.1.2"
-    semver "^5.0.3"
-    subcommand "^2.0.3"
-    wreck "^6.3.0"
 
 nth-check@~1.0.1:
   version "1.0.1"
@@ -9557,6 +9517,11 @@ pako@~0.2.0:
 pako@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
+
+papaparse@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.1.tgz#770b7a9124d821d4b2132132b7bd7dce7194b5b1"
+  integrity sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==
 
 parallel-transform@^1.1.0:
   version "1.1.0"
@@ -10386,7 +10351,7 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.1.2, rc@^1.2.7:
+rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   dependencies:
@@ -10913,7 +10878,7 @@ request@2.81.x:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.51.0, request@^2.67.0, request@^2.81.0, request@^2.83.0:
+request@^2.67.0, request@^2.81.0, request@^2.83.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -11362,7 +11327,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-"semver@2.x || 3.x || 4 || 5", "semver@4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0:
+"semver@2.x || 3.x || 4 || 5", "semver@4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -12175,15 +12140,6 @@ subarg@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
-subcommand@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/subcommand/-/subcommand-2.1.0.tgz#5e4ceca5a3779e3365b1511e05f866877302f760"
-  dependencies:
-    cliclopts "^1.1.0"
-    debug "^2.1.3"
-    minimist "^1.2.0"
-    xtend "^4.0.0"
-
 success-symbol@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/success-symbol/-/success-symbol-0.1.0.tgz#24022e486f3bf1cdca094283b769c472d3b72897"
@@ -12245,13 +12201,6 @@ tableize-object@^0.1.0:
   resolved "https://registry.yarnpkg.com/tableize-object/-/tableize-object-0.1.0.tgz#7c29e0133b27d48b56b9e76d3a28d241df1b3a24"
   dependencies:
     isobject "^2.0.0"
-
-tabletop@^1.5.1:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/tabletop/-/tabletop-1.5.2.tgz#654d484cae4e0e65a1f2077a7bec60da7b7464f3"
-  dependencies:
-    nsp "^2.6.2"
-    request "^2.51.0"
 
 tail@^0.4.0:
   version "0.4.0"
@@ -12542,12 +12491,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
-
-topo@1.x.x:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
-  dependencies:
-    hoek "2.x.x"
 
 topo@3.x.x:
   version "3.0.0"
@@ -13399,13 +13342,6 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
-
-wreck@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/wreck/-/wreck-6.3.0.tgz#a1369769f07bbb62d6a378336a7871fc773c740b"
-  dependencies:
-    boom "2.x.x"
-    hoek "2.x.x"
 
 write-file-atomic@^2.1.0:
   version "2.3.0"


### PR DESCRIPTION
With the advent of Sheets API V4, the easiest way to fetch the card sheets is to fetch the sheet as a (public) CSV link. This PR fixes #871 by replacing Tabletop.JS (now deprecated) with PapaParse for CSV parsing. 

Additionally:

* Moved sheet keys/uids into `Constants.tsx` (previously in `services/cards/src/reducers/Filters.tsx`). Declared a new interface type so the structure is regular.
* Custom flow now shows two prompts: one for selecting the type of card and the second for linking to the specific sheet the cards are in. This is a worse user experience, but a necessary one as there is no easy way to fetch all tabs of the same google sheet at once any more :(