### PR TITLE
Remove buggy ids from cards in card creator

### DIFF
--- a/services/cards/package.json
+++ b/services/cards/package.json
@@ -6,5 +6,6 @@
   "scripts": {
     "build": "webpack --config ./webpack.dist.config.js --display-error-details --verbose --progress",
     "start": "webpack-dev-server --progress"
-  }
+  },
+  "dependencies": {}
 }

--- a/services/cards/src/helpers.test.tsx
+++ b/services/cards/src/helpers.test.tsx
@@ -1,14 +1,8 @@
 import * as React from 'react';
-import {camelCase, horizontalCounter, romanize} from './helpers';
+import {horizontalCounter, romanize} from './helpers';
 
 describe('icon', () => {
   test.skip('Returns JSX element', () => { /* TODO */ });
-});
-
-describe('camelCase', () => {
-  test('Skeleton Swordsman -> skeletonSwordsman', () => {
-    expect(camelCase('Skeleton Swordsman')).toEqual('skeletonSwordsman');
-  });
 });
 
 describe('romanize', () => {

--- a/services/cards/src/helpers.tsx
+++ b/services/cards/src/helpers.tsx
@@ -8,12 +8,6 @@ export function icon(name: string, theme?: string, key?: number): JSX.Element {
   return <img key={(key === null) ? name : key} className={'inline_icon svg ' + name} src={themeSrc || globalSrc}/>;
 }
 
-export function camelCase(str: string): string {
-  return str.replace(/(?:^\w|[A-Z]|\b\w)/g, (letter: string, index: number) => {
-    return index === 0 ? letter.toLowerCase() : letter.toUpperCase();
-  }).replace(/\s+/g, '').replace(/'/, '');
-}
-
 export function romanize(num: number): string { // http://blog.stevenlevithan.com/archives/javascript-roman-numeral-converter
   if (+num === 0) { return '0'; }
   if (!+num) { return ''; }

--- a/services/cards/src/themes/BlackAndWhite/CardFront.tsx
+++ b/services/cards/src/themes/BlackAndWhite/CardFront.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {MAX_ADVENTURER_HEALTH} from '../../Constants';
-import {camelCase, healthCounter, horizontalCounter, icon, lootCounter, translate, translateTier} from '../../helpers';
+import {healthCounter, horizontalCounter, icon, lootCounter, translate, translateTier} from '../../helpers';
 import {CardType} from '../../reducers/StateTypes';
 
 export default class CardFront extends React.Component<CardType, {}> {
@@ -10,7 +10,7 @@ export default class CardFront extends React.Component<CardType, {}> {
     switch (card.sheet) {
       case 'Ability':
         return (
-          <div className={`card front vertical ${card.sheet} ${card.classicon || card.class}`} id={camelCase(name)}>
+          <div className={`card front vertical ${card.sheet} ${card.classicon || card.class}`}>
             <div className="contents">
               <header>
                 <div className="typeicon">{card.typeicon}</div>
@@ -70,7 +70,7 @@ export default class CardFront extends React.Component<CardType, {}> {
         );
       case 'Adventurer':
         return (
-          <div className={`card front horizontal ${card.sheet} bottomBar level${card.level}`} id={camelCase(card.name)}>
+          <div className={`card front horizontal ${card.sheet} bottomBar level${card.level}`}>
             <div className="contents">
               <header>
                 <div className="name">{card.name}</div>
@@ -158,7 +158,7 @@ export default class CardFront extends React.Component<CardType, {}> {
         );
       case 'Loot':
         return (
-          <div className={`card front vertical ${card.sheet} tier${card.tier} ${card.tracker && 'tracker'} ${card.tracker > 14 && 'bottomBar'}`} id={camelCase(name)}>
+          <div className={`card front vertical ${card.sheet} tier${card.tier} ${card.tracker && 'tracker'} ${card.tracker > 14 && 'bottomBar'}`}>
             <div className="contents">
               <header>
                 <div className="name">{card.name}</div>
@@ -202,7 +202,7 @@ export default class CardFront extends React.Component<CardType, {}> {
         );
       case 'Skill':
         return (
-          <div className={`card front horizontal ${card.sheet} bottomBar`} id={camelCase(card.name)}>
+          <div className={`card front horizontal ${card.sheet} bottomBar`}>
             <div className="contents">
               <header>
                 {card.typeicon && <div className="typeIcon">{icon((card.typeicon).toLowerCase() + '_small')}</div>}

--- a/services/cards/src/themes/Color/CardFront.tsx
+++ b/services/cards/src/themes/Color/CardFront.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {MAX_ADVENTURER_HEALTH} from '../../Constants';
-import {camelCase, healthCounter, horizontalCounter, icon, lootCounter, translate, translateTier} from '../../helpers';
+import {healthCounter, horizontalCounter, icon, lootCounter, translate, translateTier} from '../../helpers';
 import {CardType} from '../../reducers/StateTypes';
 
 export default class CardFront extends React.Component<CardType, {}> {
@@ -20,7 +20,7 @@ export default class CardFront extends React.Component<CardType, {}> {
         );
       case 'Ability':
         return (
-          <div className={`card front vertical ${card.sheet} ${card.class}`} id={camelCase(name)}>
+          <div className={`card front vertical ${card.sheet} ${card.class}`}>
             <div className="contents">
               <header>
                 <div className="typeicon">{card.typeicon}</div>
@@ -80,7 +80,7 @@ export default class CardFront extends React.Component<CardType, {}> {
         );
       case 'Adventurer':
         return (
-          <div className={`card front horizontal ${card.sheet} bottomBar`} id={camelCase(card.name)}>
+          <div className={`card front horizontal ${card.sheet} bottomBar`}>
             <div className="contents">
               <header>
                 <div className="name">{card.name}</div>
@@ -157,7 +157,7 @@ export default class CardFront extends React.Component<CardType, {}> {
         );
       case 'Loot':
         return (
-          <div className={`card front vertical ${card.sheet} tier${card.tier} ${card.tracker && 'tracker'} ${card.tracker > 14 && 'bottomBar'}`} id="{{camelCase name }}">
+          <div className={`card front vertical ${card.sheet} tier${card.tier} ${card.tracker && 'tracker'} ${card.tracker > 14 && 'bottomBar'}`}>
             <div className="contents">
               <header>
                 <div className="name">{card.name}</div>
@@ -201,7 +201,7 @@ export default class CardFront extends React.Component<CardType, {}> {
         );
       case 'Skill':
         return (
-          <div className={`card front horizontal ${card.sheet} bottomBar`} id={camelCase(card.name)}>
+          <div className={`card front horizontal ${card.sheet} bottomBar`}>
             <div className="contents">
               <header>
                 {card.typeicon && <div className="typeIcon">{icon((card.typeicon).toLowerCase() + '_small')}</div>}


### PR DESCRIPTION
Turns out, we don't need no stinkin' ID's. They're not referenced anywhere, sometimes they aren't even added, and the 2 of 3 different ways they're implemented are broken:

` id={camelCase(card.name)}` - this is fine, but not referenced anywhere.

` id={camelCase(name)}` - I don't think `name` is even declared, and I'm not sure how this doesn't cause errors normally (it does break the site on some card sets though, like Future).

`  id="{{camelCase name }}"` - what.

So I removed them, and everything still works. Also ripped out `camelCase` from `helpers.tsx` and explicitly set zero dependencies in the package.json file.

Fixes bug uncovered by work on #871.
